### PR TITLE
Fix deadlock bug in epoll proactor.

### DIFF
--- a/util/fiber_sched_algo.cc
+++ b/util/fiber_sched_algo.cc
@@ -144,7 +144,7 @@ bool FiberSchedAlgo::has_ready_fibers() const noexcept {
 // In our case, "sleeping" means - might stuck the wait function waiting for completion events.
 // wait_for_cqe is the only place where the thread can be stalled.
 void FiberSchedAlgo::notify() noexcept {
-  DVLOG(2) << "notify from " << syscall(SYS_gettid);
+  DVLOG(2) << "notify from thread";  // thread id is in the log.
 
   // We signal so that
   // 1. Main context should awake if it is not
@@ -194,7 +194,7 @@ bool FiberSchedAlgo::SuspendIoLoop(uint64_t now) {
   flags_.ioloop_yielded = 0;
   flags_.ioloop_woke = 0;
 
-  DVLOG(2) << "WaitTillFibersSuspend:End";
+  DVLOG(2) << "WaitTillFibersSuspend:End " << int(flags_.suspenduntil_called);
 
   return flags_.suspenduntil_called;
 }

--- a/util/uring/proactor.cc
+++ b/util/uring/proactor.cc
@@ -212,11 +212,11 @@ void Proactor::Run() {
     if (tq_seq & 1) {
       // We allow dispatch fiber to run.
 
-      // We must reset LSB for both tq_seq and tq_seq_  so that if notify() was called after
-      // yield(), tq_seq_ would be invalidated.
       unsigned read_cnt = scheduler_->ready_cnt();
 
-      tq_seq_.fetch_and(~1, memory_order_relaxed);
+      // We must reset LSB for both tq_seq and tq_seq_  so that if notify() was called after
+      // yield(), tq_seq_ would be invalidated.
+      tq_seq_.fetch_and(~1, memory_order_acq_rel);
       tq_seq &= ~1;
       this_fiber::yield();
       VPRO(2) << "this_fiber::yield_end " << loop_cnt << " " << read_cnt << " "


### PR DESCRIPTION
The issue is about main io loop blocking on epoll_wait when in fact there are active fibers that could be running. It's either dispatch fiber that has not run yet or user fibers that were activated but the state machine has not took it into the account. Now I wrote enough comments that hopefully further refactorings won't introduce this bug again. In addition, I added the test to epoll_proactor_test that reproduced the bug with some probability.

Signed-off-by: Roman Gershman <romange@gmail.com>