### PR TITLE
fix: __sigval_t causes compile error.

### DIFF
--- a/util/dns_resolve.cc
+++ b/util/dns_resolve.cc
@@ -25,7 +25,17 @@ struct NotifyStruct {
   fibers_ext::EventCount evc;
 };
 
-static void DnsResolveNotify(__sigval_t val) {
+// To ensure compatibility between different versions of Glibc,
+// we use sigval_t instead of __sigval_t. However, some older 
+// versions may still require __sigval_t, such as when __USE_POSIX199309
+// is defined. The following text is derived from the comments in Glibc 2.31:
+// To avoid sigval_t (not a standard type name) having C++ name
+// mangling depending on whether the selected standard includes union
+// sigval, it should not be defined at all when using a standard for
+// which the sigval name is not reserved; in that case, headers should
+// not include <bits/types/sigval_t.h> and should use only the
+// internal __sigval_t name.  
+static void DnsResolveNotify(sigval_t val) {
   NotifyStruct* ns = (NotifyStruct*)val.sival_ptr;
   ns->gate.store(true, memory_order_relaxed);
   ns->evc.notify();


### PR DESCRIPTION
Signed-off-by: Super-long <0x4f4f4f4f@gmail.com>

I encountered the following problem when compiling：
<img width="1188" alt="截屏2022-10-25 20 29 35" src="https://user-images.githubusercontent.com/46051144/197773162-32600bcd-3c93-4939-999a-b43b11804c03.png">


__sigval_t has limitations, to take two different examples：
Linux VM-9-54-centos 5.4.119-1-tlinux4-0008 #1 SMP Fri Nov 26 11:17:45 CST 2021 x86_64 x86_64 x86_64 GNU/Linux
<img width="440" alt="截屏2022-10-25 20 15 01" src="https://user-images.githubusercontent.com/46051144/197772630-d85b0a85-aee6-4fa4-b770-319d30938f6c.png">

Linux VM-16-16-ubuntu 5.4.0-126-generic #142-Ubuntu SMP Fri Aug 26 12:12:57 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
<img width="273" alt="截屏2022-10-25 20 27 28" src="https://user-images.githubusercontent.com/46051144/197772722-c6d503a9-b45d-44ba-8b5a-03416d5f87c7.png">

This change was made for better compatibility.
