### PR TITLE
fix: Unfriendly output in blaze.sh for cmake versions below 3.4

### DIFF
--- a/blaze.sh
+++ b/blaze.sh
@@ -48,7 +48,17 @@ BUILD_DIR=${BUILD_PREF}-${BUILD_SUF}
 
 set -x
 
+result="$(cmake --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
+major="${result%%.*}"
+remainder="${result#*.}"
+minor="${remainder%.*}"
+
+if [ "$major" -lt 3 ] ||
+    ( [ "$major" -eq 3 ] &&
+        ( [ "$minor" -lt 4 ] )) ; then
+    echo "you are using an older version of cmake, need cmake >= 3.4"
+    exit 1
+fi
+
 cmake -L -B $BUILD_DIR -DCMAKE_BUILD_TYPE=$TARGET_BUILD_TYPE -DCMAKE_CXX_COMPILER=$COMPILER \
     "$GENERATOR" $LAUNCHER $@
-
-


### PR DESCRIPTION
Signed-off-by: Super-long <0x4f4f4f4f@gmail.com>

When compiling I encountered the following problem：
<img width="865" alt="截屏2022-10-25 21 06 14" src="https://user-images.githubusercontent.com/46051144/197781038-8991b5ce-57b7-4b84-bf73-6e8ec38da13c.png">
It is because the lower version of cmake does not support -B. So add a version determination for cmake in blaze.sh. Now when a low version of cmake is encountered there is the following output：

<img width="489" alt="截屏2022-10-25 21 09 11" src="https://user-images.githubusercontent.com/46051144/197781814-8d6e729a-52ad-4c22-acae-b005f2fd9ebd.png">


This is a very common situation, many people have both cmake and cmake3 on their machines.

