### PR TITLE
mimalloc patching for memory defrag

### DIFF
--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -124,7 +124,7 @@ function(add_third_party name)
   endif()
 endfunction()
 
-# gflags
+#gflags
 # FetchContent_Declare(
 #   gflags
 #   URL https://github.com/gflags/gflags/archive/v2.2.2.zip
@@ -265,9 +265,12 @@ else()
   set(MI_OVERRIDE OFF)
 endif()
 
-add_third_party(mimalloc
-  URL https://github.com/microsoft/mimalloc/archive/refs/tags/v2.0.5.tar.gz
+set (MIMALLOC_PATCH_COMMAND patch -p1 -d ${THIRD_PARTY_DIR}/mimalloc/ -i ${CMAKE_CURRENT_LIST_DIR}/../patches/mimalloc-v2.0.5.patch)
 
+ add_third_party(mimalloc
+   URL https://github.com/microsoft/mimalloc/archive/refs/tags/v2.0.5.tar.gz
+   PATCH_COMMAND "${MIMALLOC_PATCH_COMMAND}"
+   # -DCMAKE_BUILD_TYPE=Release
   # Add -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=-O0 to debug
   CMAKE_PASS_FLAGS "-DCMAKE_BUILD_TYPE=Release -DMI_BUILD_SHARED=OFF -DMI_BUILD_TESTS=OFF \
                     -DMI_INSTALL_TOPLEVEL=ON -DMI_OVERRIDE=${MI_OVERRIDE} -DCMAKE_C_FLAGS=-g"
@@ -276,7 +279,7 @@ add_third_party(mimalloc
   INSTALL_COMMAND make install
   COMMAND cp <SOURCE_DIR>/include/mimalloc-types.h <SOURCE_DIR>/include/mimalloc-atomic.h
           ${MIMALLOC_INCLUDE_DIR}/
-  # LIB libmimalloc-debug.a
+  #LIB libmimalloc-debug.a
 )
 
 add_third_party(jemalloc

--- a/patches/mimalloc-v2.0.5.patch
+++ b/patches/mimalloc-v2.0.5.patch
@@ -1,0 +1,73 @@
+From 41d8a6b4995a87b2c5e41c8a59bb9a326bca2755 Mon Sep 17 00:00:00 2001
+From: Boaz Sade <boaz@dragonflydb.io>
+Date: Tue, 22 Nov 2022 16:35:47 +0200
+Subject: [PATCH] code chagnes for the df
+
+---
+ include/mimalloc-types.h |  6 +++---
+ include/mimalloc.h       |  2 ++
+ src/alloc.c              | 21 +++++++++++++++++++++
+ 3 files changed, 26 insertions(+), 3 deletions(-)
+
+diff --git a/include/mimalloc-types.h b/include/mimalloc-types.h
+index 310fb92..d0b5073 100644
+--- a/include/mimalloc-types.h
++++ b/include/mimalloc-types.h
+@@ -63,9 +63,9 @@ terms of the MIT license. A copy of the license can be found in the file
+ 
+ // Encoded free lists allow detection of corrupted free lists
+ // and can detect buffer overflows, modify after free, and double `free`s.
+-#if (MI_SECURE>=3 || MI_DEBUG>=1 || MI_PADDING > 0)
+-#define MI_ENCODE_FREELIST  1
+-#endif
++//#if (MI_SECURE>=3 || MI_DEBUG>=1 || MI_PADDING > 0)
++//#define MI_ENCODE_FREELIST  1
++//#endif
+ 
+ 
+ // ------------------------------------------------------
+diff --git a/include/mimalloc.h b/include/mimalloc.h
+index 83debd2..90d6ae2 100644
+--- a/include/mimalloc.h
++++ b/include/mimalloc.h
+@@ -274,6 +274,8 @@ mi_decl_export bool mi_manage_os_memory(void* start, size_t size, bool is_commit
+ 
+ mi_decl_export void mi_debug_show_arenas(void) mi_attr_noexcept;
+ 
++mi_decl_export bool mi_heap_page_is_underutilized(mi_heap_t* heap, void* p, float ratio) mi_attr_noexcept;
++
+ // deprecated
+ mi_decl_export int  mi_reserve_huge_os_pages(size_t pages, double max_secs, size_t* pages_reserved) mi_attr_noexcept;
+ 
+diff --git a/src/alloc.c b/src/alloc.c
+index 8cf7242..c2e8d0c 100644
+--- a/src/alloc.c
++++ b/src/alloc.c
+@@ -912,3 +912,24 @@ void* mi_new_reallocn(void* p, size_t newcount, size_t size) {
+     return mi_new_realloc(p, total);
+   }
+ }
++
++bool mi_heap_page_is_underutilized(mi_heap_t* heap, void* p, float ratio) mi_attr_noexcept {
++  mi_page_t* page = _mi_ptr_page(p);	// get the page that this belongs to
++
++  mi_heap_t* page_heap = (mi_heap_t*)(mi_atomic_load_relaxed(&(page)->xheap));
++
++  // the heap id matches and it is not a full page
++  if (mi_likely(page_heap == heap && page->flags.x.in_full == 0)) {
++    // mi_page_queue_t* pq = mi_heap_page_queue_of(heap, page);
++
++    // first in the list, meaning it's the head of page queue, thus being used for malloc
++    if (page->prev == NULL)
++      return false;
++
++    // this page belong to this heap and is not first in the page queue. Lets check its
++    // utilization.
++    return page->used <= (unsigned)(page->capacity * ratio);
++  }
++  return false;
++}
++
+-- 
+2.34.1
+


### PR DESCRIPTION
This PR is for enabling memory defragmentation using mimalloc
There are two issue that this should solve:
1. We are building mimalloc as release version, but DF can then build as debug, this create different structs sizes between mimallc and DF (because of different flags that the header files and source files "see").
2. Adding a function that checks whether a given page is underutilised.
3. the third party cmake will apply the patch as part of the build.
Signed-off-by: Boaz Sade <boaz@dragonflydb.io>