### PR TITLE
support for https added as well as an example application

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
           cd ${{github.workspace}}/build
           cat /proc/cpuinfo
-          ninja -k 5 base/all io/all strings/all util/all echo_server ping_iouring_server
+          ninja -k 5 base/all io/all strings/all util/all echo_server ping_iouring_server https_client_cli
           GLOG_logtostderr=1 gdb -batch -ex "run" -ex "thread apply all bt" \
              ./accept_server_test || true
           GLOG_logtostderr=1 GLOG_vmodule=proactor=1 ctest -V -L CI

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,3 +16,6 @@ cxx_link(proactor_stress base uring_fiber_lib http_server_lib)
 
 add_executable(s3_demo s3_demo.cc)
 cxx_link(s3_demo uring_fiber_lib http_client_lib aws_lib)
+
+add_executable(https_client_cli https_client_cli.cc)
+cxx_link(https_client_cli base uring_fiber_lib http_client_lib tls_lib)

--- a/examples/https_client_cli.cc
+++ b/examples/https_client_cli.cc
@@ -1,0 +1,186 @@
+// Create an https client test program
+// Note this that example show how to run HTTPS client
+// which connect to the remote server, read a resource and print thi
+// the response to the LOG.
+// To see command line args run with --helpful command line flag
+// Since there is no reasonable default host name you must at minimum run
+// this with --host <domain name: https://en.wikipedia.org/wiki/Domain_name> such as www.google.com
+// (note that you should not add the service name at the start such as https).
+// To demo that this is not a blocking HTTPS client this would run 2 fibers for connection
+// and another task that basically does nothing.
+// output from this is either an error (in case we failed - try given illegal host or port) or a
+// the headers and the body from the host and resource you gave.
+// for example:
+// ./https_client --host redis.io --resource /commands/asking/ --vmodule=https_client=2
+// --logbuflevel=-1 --alsologtostderr
+// will print the content from https://redis.io/commands/asking command to the log as well as to the
+// terminal
+#include <openssl/err.h>
+
+#include <boost/beast/http.hpp>
+#include <chrono>
+#include <iostream>
+#include <memory>
+
+#include "base/flags.h"
+#include "base/init.h"
+#include "util/fibers/event_count.h"
+#include "util/http/http_client.h"
+#include "util/proactor_base.h"
+#include "util/proactor_pool.h"
+#include "util/tls/tls_engine.h"
+#include "util/tls/tls_socket.h"
+#include "util/uring/uring_pool.h"
+
+using util::ProactorBase;
+using util::ProactorPool;
+using util::http::Client;
+using util::http::TlsClient;
+namespace h2 = boost::beast::http;
+using ResponseType = h2::response<h2::string_body>;
+using absl::GetFlag;
+
+ABSL_FLAG(short, http_port, 443, "HTTPS remote server port.");
+ABSL_FLAG(std::string, host, "", "Remote host domain name");
+ABSL_FLAG(std::string, resource, "/", "resource path on the remote host");
+
+struct RequestResults {
+  unsigned int status = 400;
+  std::optional<ResponseType> result;
+
+  RequestResults() = default;
+
+  RequestResults(unsigned int s, ResponseType&& res) : status{s}, result{std::move(res)} {
+  }
+
+  bool good() const {
+    return status < 400;
+  }
+
+  bool has_result() const {
+    return result != std::nullopt;
+  }
+
+  const ResponseType& get() const {
+    assert(good() && has_result());
+    return result.value();
+  }
+};
+
+std::ostream& operator<<(std::ostream& os, const RequestResults& res) {
+  if (res.has_result()) {
+    if (res.good()) {
+      const auto& msg = res.get();
+      os << "headers: " << msg.base();
+      return os << "body: " << msg.body();
+    } else {
+      return os << "got errors results: " << res.result.value();
+    }
+  } else {
+    return os << "no result were successfully read from remote host";
+  }
+}
+
+using OpResult = io::Result<RequestResults, std::string>;
+
+OpResult ConnectAndRead(ProactorBase* proactor, std::string_view host, std::string_view service,
+                        const char* resource, SSL_CTX* ssl_ctx) {
+  TlsClient http_client{proactor};
+
+  http_client.set_connect_timeout_ms(2000);
+  auto list_res = proactor->Await([&] {
+    if (auto ec = http_client.Connect(host, service, ssl_ctx); !ec) {
+      h2::request<h2::string_body> req{h2::verb::get, resource, 11 /*http 1.1*/};
+      req.set(h2::field::host, std::string(host).c_str());
+      ResponseType res;
+      if (auto ec = http_client.Send(req, &res); !ec) {
+        return OpResult{RequestResults{res.result_int(), std::move(res)}};
+      } else {
+        return OpResult{
+            nonstd::unexpected<std::string>("Failed HTTPS GET Send(): " + ec.message())};
+      }
+    } else {
+      return OpResult{nonstd::unexpected<std::string>("Failed to connect: " + ec.message())};
+    }
+    return OpResult{RequestResults{}};
+  });
+
+  return list_res;
+};
+
+using namespace std::chrono_literals;
+
+util::fibers_ext::Fiber ReadFromRemoteHost(ProactorPool* pool, SSL_CTX* ssl_context,
+                                           std::string_view task_name,
+                                           util::fibers_ext::Done* done_condition) {
+  std::string service = std::to_string(GetFlag(FLAGS_http_port));
+  std::string host = GetFlag(FLAGS_host);
+  std::string resource = GetFlag(FLAGS_resource);
+
+  LOG(INFO) << task_name << ": host '" << host << "', port " << service << ", resource '"
+            << resource << "'";
+  return pool->GetNextProactor()->LaunchFiber([=]() {
+    while (true) {
+      if (done_condition->WaitFor(1s)) {
+        VLOG(1) << task_name << ": finish running HTTPS task";
+        return;
+      }
+      auto pb = pool->GetNextProactor();
+
+      auto results = ConnectAndRead(pb, host, service, resource.c_str(), ssl_context);
+      if (results.has_value()) {
+        LOG(INFO) << task_name << ": successfully read";
+        LOG(INFO) << task_name << ": " << results.value();
+      } else {
+        LOG(WARNING) << task_name << ": Failed for '" << host << "':" << service << "/" << resource
+                     << ", error: '" << results.error() << "'";
+      }
+    }
+  });
+}
+
+util::fibers_ext::Fiber IdleFiberRun(ProactorPool* pool, std::string_view task_name,
+                                     util::fibers_ext::Done* done_condition) {
+  return pool->GetNextProactor()->LaunchFiber([=]() {
+    while (true) {
+      LOG(INFO) << task_name << ": just burning CPU";
+      if (done_condition->WaitFor(100ms)) {
+        VLOG(1) << task_name << ": finish running with idle task";
+        return;
+      }
+    }
+  });
+}
+
+int main(int argc, char** argv) {
+  MainInitGuard guard(&argc, &argv);
+
+  std::string host = GetFlag(FLAGS_host);
+  if (host.empty()) {
+    LOG(ERROR) << "Host name is missing - please run with --host <host name>";
+    return -1;
+  }
+
+  SSL_library_init();
+  SSL_load_error_strings();
+  util::uring::UringPool pp;
+
+  pp.Run();
+  SSL_CTX* ssl_context = TlsClient::CreateSslContext();
+  CHECK(ssl_context) << " failed to create SSL context";
+  VLOG(1) << "starting the fibers that test the connection";
+  util::fibers_ext::Done done_condition;
+  auto fiber = ReadFromRemoteHost(&pp, ssl_context, "task 1", &done_condition);
+  auto fiber2 = ReadFromRemoteHost(&pp, ssl_context, "task 2", &done_condition);
+  auto idle_fiber = IdleFiberRun(&pp, "task 3", &done_condition);
+  // Let the background tasks run for a while
+  for (int i = 0; i < 3; i++) {
+    util::fibers_ext::SleepFor(1s);
+  }
+  done_condition.Notify();
+  fiber.Join();
+  fiber2.Join();
+  idle_fiber.Join();
+  LOG(INFO) << "finish running the test";
+  TlsClient::FreeContext(ssl_context);
+}

--- a/util/http/http_client.cc
+++ b/util/http/http_client.cc
@@ -26,7 +26,7 @@ using namespace std;
 namespace h2 = boost::beast::http;
 namespace ip = boost::asio::ip;
 using boost_error = boost::system::error_code;
-using TlsSocket = util::tls::TlsSocket;
+using util::tls::TlsSocket;
 
 namespace {
 // This can be used for debugging
@@ -115,7 +115,7 @@ bool Client::IsConnected() const {
 SSL_CTX* TlsClient::CreateSslContext() {
   SSL_CTX* ctx = SSL_CTX_new(TLS_client_method());
   if (ctx) {
-    // USe the default locations for certificates. This means that any trusted
+    // Use the default locations for certificates. This means that any trusted
     // remote host by this local host, will be trusted as well.
     // see https://www.openssl.org/docs/man3.0/man1/openssl-verification-options.html
     SSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION);
@@ -136,12 +136,12 @@ SSL_CTX* TlsClient::CreateSslContext() {
 }
 
 std::error_code TlsClient::Connect(StringPiece host, StringPiece service, SSL_CTX* context) {
-  DCHECK(context) << "invalid NULL SSL context";
+  DCHECK(context) << " NULL SSL context";
   // Four phases:
   // 1. TCP connection
   // 2. Setting SSL level verification for the remote host
   // 3. Using the connected TCP for SSL (handshake).
-  // 4. Setting the base class to use the "new" TLS socket for here on end
+  // 4. Setting the base class to use the "new" TLS socket from here on end
 
   std::error_code ec = Client::Connect(host, service);
   if (!ec) {

--- a/util/http/http_client.cc
+++ b/util/http/http_client.cc
@@ -12,9 +12,11 @@
 #include <boost/beast/http/write.hpp>
 
 #include "base/logging.h"
+#include "util/dns_resolve.h"
 #include "util/fiber_socket_base.h"
 #include "util/proactor_base.h"
-#include "util/dns_resolve.h"
+#include "util/tls/tls_engine.h"
+#include "util/tls/tls_socket.h"
 
 namespace util {
 namespace http {
@@ -24,10 +26,22 @@ using namespace std;
 namespace h2 = boost::beast::http;
 namespace ip = boost::asio::ip;
 using boost_error = boost::system::error_code;
+using TlsSocket = util::tls::TlsSocket;
 
-Client::Client(ProactorBase* proactor) : proactor_(proactor) {}
+namespace {
+// This can be used for debugging
+int VerifyCallback(int ok, X509_STORE_CTX* ctx) {
+  // since this is a client side, we don't do much here,
+  VLOG(1) << "verify_callback: " << std::boolalpha << bool(ok);
+  return ok;
+}
+}  // namespace
 
-Client::~Client() {}
+Client::Client(ProactorBase* proactor) : proactor_(proactor) {
+}
+
+Client::~Client() {
+}
 
 std::error_code Client::Connect(StringPiece host, StringPiece service) {
   uint32_t port;
@@ -53,8 +67,7 @@ std::error_code Client::Connect(StringPiece host, StringPiece service) {
   return socket_->Connect(ep);
 }
 
-std::error_code Client::Send(Verb verb, StringPiece url, StringPiece body,
-                                         Response* response) {
+std::error_code Client::Send(Verb verb, StringPiece url, StringPiece body, Response* response) {
   // Set the URL
   h2::request<h2::string_body> req{verb, boost::string_view(url.data(), url.size()), 11};
 
@@ -95,6 +108,66 @@ void Client::Shutdown() {
 
 bool Client::IsConnected() const {
   return socket_ && socket_->IsOpen();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+SSL_CTX* TlsClient::CreateSslContext() {
+  SSL_CTX* ctx = SSL_CTX_new(TLS_client_method());
+  if (ctx) {
+    // USe the default locations for certificates. This means that any trusted
+    // remote host by this local host, will be trusted as well.
+    // see https://www.openssl.org/docs/man3.0/man1/openssl-verification-options.html
+    SSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION);
+    if (SSL_CTX_set_default_verify_paths(ctx) != 1) {
+      LOG(WARNING) << "failed to set default verify path on client context for TLS connection";
+      FreeContext(ctx);
+      return nullptr;
+    }
+    SSL_CTX_set_options(ctx, SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS);
+    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, VerifyCallback);
+    SSL_CTX_set_verify_depth(ctx, 4);
+    // see https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_security_level.html
+    // this default is for Security level set to 112 bits of security
+    SSL_CTX_set_security_level(ctx, 2);
+    SSL_CTX_dane_enable(ctx);  // see https://www.internetsociety.org/resources/deploy360/dane/
+  }
+  return ctx;
+}
+
+std::error_code TlsClient::Connect(StringPiece host, StringPiece service, SSL_CTX* context) {
+  DCHECK(context) << "invalid NULL SSL context";
+  // Four phases:
+  // 1. TCP connection
+  // 2. Setting SSL level verification for the remote host
+  // 3. Using the connected TCP for SSL (handshake).
+  // 4. Setting the base class to use the "new" TLS socket for here on end
+
+  std::error_code ec = Client::Connect(host, service);
+  if (!ec) {
+    tcp_socket_.reset(socket_.release());
+    std::unique_ptr<TlsSocket> tls_socket(new TlsSocket(tcp_socket_.get()));
+    tls_socket->InitSSL(context);
+
+    const std::string& hn = Client::host();
+    const char* host = hn.c_str();
+    SSL* ssl_handle = tls_socket->ssl_handle();
+    // add SNI
+    SSL_set_tlsext_host_name(ssl_handle, host);
+    // verify server cert using server hostname
+    SSL_dane_enable(ssl_handle, host);
+    ec = tls_socket->Connect(FiberSocketBase::endpoint_type{});
+    if (!ec) {
+      socket_.reset(tls_socket.release());
+    }
+  }
+  return ec;
+}
+
+void TlsClient::FreeContext(SSL_CTX* ctx) {
+  if (ctx) {
+    SSL_CTX_free(ctx);
+  }
 }
 
 }  // namespace http

--- a/util/tls/tls_socket.cc
+++ b/util/tls/tls_socket.cc
@@ -106,8 +106,14 @@ auto TlsSocket::Accept() -> AcceptResult {
   return nullptr;
 }
 
-auto TlsSocket::Connect(const endpoint_type& ep) -> error_code {
+auto TlsSocket::Connect(const endpoint_type&) -> error_code {
   DCHECK(engine_);
+  auto io_result = engine_->Handshake(Engine::HandshakeType::CLIENT);
+  if (io_result.has_value()) {
+    return std::error_code{};
+  } else {
+    return std::error_code(io_result.error(), std::system_category());
+  }
 
   return error_code{};
 }

--- a/util/tls/tls_socket.h
+++ b/util/tls/tls_socket.h
@@ -8,7 +8,6 @@
 
 #include "util/fiber_socket_base.h"
 
-
 namespace util {
 namespace tls {
 
@@ -28,7 +27,9 @@ class TlsSocket : public FiberSocketBase {
 
   AcceptResult Accept() final;
 
-  error_code Connect(const endpoint_type& ep) final;
+  // The endpoint should not really pass here, it is to keep
+  // the interface with FiberSocketBase.
+  error_code Connect(const endpoint_type&) final;
 
   error_code Close() final;
 


### PR DESCRIPTION
This add support for HTTPS client.
The code is based on the existing HTTP client and the TLS socket. What it adds is:
* HTTPS client that uses the TLS socket under the hood.
* A demo application that can be use to demo this new client.
note that the application is very useful to ensure that the TLS is working successfully.
I tried to make sure that this will be as secure as possible without making the use of it to complicated (i.e. loading cert file for example).
Signed-off-by: Boaz Sade <boaz@dragonflydb.io>