### PR TITLE
Cleanup IoBuf and add source/sink for it

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(base hash.cc histogram.cc init.cc logging.cc proc_util.cc
-            pthread_utils.cc varz_node.cc cuckoo_map.cc)
+            pthread_utils.cc varz_node.cc cuckoo_map.cc io_buf.cc)
 
 cxx_link(base glog::glog absl::flags_parse atomic rt # rt for timer_create etc.
          absl::strings absl::symbolize absl::time absl::failure_signal_handler TRDP::xxhash)

--- a/base/io_buf.cc
+++ b/base/io_buf.cc
@@ -26,7 +26,7 @@ void IoBuf::ReadAndConsume(size_t sz, void* dest) {
   ConsumeInput(sz);
 }
 
-void IoBuf::WriteAndCommit(size_t num_write, const void* source) {
+void IoBuf::WriteAndCommit(const void* source, size_t num_write) {
   EnsureCapacity(num_write);
   memcpy(AppendBuffer().data(), source, num_write);
   CommitWrite(num_write);

--- a/base/io_buf.cc
+++ b/base/io_buf.cc
@@ -1,0 +1,64 @@
+// Copyright 2022, Beeri 15.  All rights reserved.
+// Author: Roman Gershman (romange@gmail.com)
+//
+#include "base/io_buf.h"
+
+namespace base {
+
+void IoBuf::ConsumeInput(size_t sz) {
+  if (offs_ + sz >= size_) {
+    size_ = 0;
+    offs_ = 0;
+  } else {
+    offs_ += sz;
+    if (2 * offs_ > size_ && size_ - offs_ < 512) {
+      memcpy(buf_, buf_ + offs_, size_ - offs_);
+      size_ -= offs_;
+      offs_ = 0;
+    }
+  }
+}
+
+void IoBuf::ReadAndConsume(size_t sz, void* dest) {
+  ConstBytes b = InputBuffer();
+  assert(b.size() >= sz);
+  memcpy(dest, b.data(), sz);
+  ConsumeInput(sz);
+}
+
+void IoBuf::WriteAndCommit(size_t num_write, const void* source) {
+  EnsureCapacity(num_write);
+  memcpy(AppendBuffer().data(), source, num_write);
+  CommitWrite(num_write);
+}
+
+void IoBuf::Reserve(size_t sz) {
+  if (sz < capacity_)
+    return;
+
+  sz = absl::bit_ceil(sz);
+  uint8_t* nb = new (std::align_val_t{alignment_}) uint8_t[sz];
+  if (buf_) {
+    if (size_ > offs_) {
+      memcpy(nb, buf_ + offs_, size_ - offs_);
+      size_ -= offs_;
+      offs_ = 0;
+    } else {
+      size_ = offs_ = 0;
+    }
+    delete[] buf_;
+  }
+
+  buf_ = nb;
+  capacity_ = sz;
+}
+
+void IoBuf::Swap(IoBuf& other) {
+  std::swap(buf_, other.buf_);
+  std::swap(offs_, other.offs_);
+  std::swap(size_, other.size_);
+  std::swap(alignment_, other.alignment_);
+  std::swap(capacity_, other.capacity_);
+}
+
+};  // namespace base

--- a/base/io_buf.h
+++ b/base/io_buf.h
@@ -79,7 +79,7 @@ class IoBuf {
 
   // Copy num_copy bytes from source to append buffer and mark them as written.
   // Ensures append buffer is large enough.
-  void WriteAndCommit(size_t num_copy, const void* source);
+  void WriteAndCommit(const void* source, size_t num_copy);
 
   // Ensure required append buffer size.
   void EnsureCapacity(size_t sz) {

--- a/base/io_buf.h
+++ b/base/io_buf.h
@@ -10,17 +10,16 @@
 
 namespace base {
 
+// Generic buffer for reads and writes.
+// Write directly to AppendBuffer() and mark bytes as written with CommitWrite.
+// Read from InputBuffer() and mark bytes as read with ConsumeInput.
 class IoBuf {
  public:
-  IoBuf(const IoBuf&) = delete;
-  IoBuf& operator=(const IoBuf&) = delete;
-
   using Bytes = absl::Span<uint8_t>;
   using ConstBytes = absl::Span<const uint8_t>;
 
   explicit IoBuf(size_t capacity = 256) {
     assert(capacity > 0);
-
     Reserve(capacity);
   }
 
@@ -28,12 +27,25 @@ class IoBuf {
     Reserve(capacity);
   }
 
+  IoBuf(const IoBuf&) = delete;
+  IoBuf& operator=(const IoBuf&) = delete;
+
+  IoBuf(IoBuf&& other) {
+    Swap(other);
+  }
+  IoBuf& operator=(IoBuf&& other) {
+    Swap(other);
+    return *this;
+  }
+
   ~IoBuf() {
     delete[] buf_;
   }
 
-  size_t Capacity() const {
-    return capacity();
+  // ============== INPUT =======================
+
+  size_t InputLen() const {
+    return size_ - offs_;
   }
 
   ConstBytes InputBuffer() const {
@@ -44,65 +56,55 @@ class IoBuf {
     return Bytes{buf_ + offs_, InputLen()};
   }
 
-  size_t InputLen() const {
-    return size_ - offs_;
-  }
+  // Mark num_read bytes from the input as read.
+  void ConsumeInput(size_t num_read);
 
-  void ConsumeInput(size_t offs);
+  // Write num_write bytes to dest and mark them as read.
+  void ReadAndConsume(size_t num_write, void* dest);
 
-  void ReadAndConsume(size_t sz, void* dest) {
-    ConstBytes b = InputBuffer();
-    assert(b.size() >= sz);
-    memcpy(dest, b.data(), sz);
-    ConsumeInput(sz);
+  // ============== OUTPUT ============
+
+  size_t AppendLen() {
+    return capacity_ - size_;
   }
 
   Bytes AppendBuffer() {
-    return Bytes{buf_ + size_, Available()};
+    return Bytes{buf_ + size_, AppendLen()};
   }
 
-  void CommitWrite(size_t sz) {
-    size_ += sz;
+  // Mark num_written bytes as written and transform them to input.
+  void CommitWrite(size_t num_written) {
+    size_ += num_written;
   }
 
+  // Copy num_copy bytes from source to append buffer and mark them as written.
+  // Ensures append buffer is large enough.
+  void WriteAndCommit(size_t num_copy, const void* source);
+
+  // Ensure required append buffer size.
+  void EnsureCapacity(size_t sz) {
+    Reserve(size_ + sz);
+  }
+
+  // Reserve by whole buffer size.
+  // Use EnsureCapacity instead for resizing only by desired append buffer size.
+  void Reserve(size_t full_size);
+
+  // ============== GENERIC ===========
+
+  // Clear all input.
   void Clear() {
     size_ = 0;
     offs_ = 0;
   }
 
-  void EnsureCapacity(size_t sz) {
-    Reserve(InputLen() + sz);
-  }
-
-  void Reserve(size_t sz) {
-    if (sz < capacity_)
-      return;
-
-    sz = absl::bit_ceil(sz);
-    uint8_t* nb = new (std::align_val_t{alignment_}) uint8_t[sz];
-    if (buf_) {
-      if (size_ > offs_) {
-        memcpy(nb, buf_ + offs_, size_ - offs_);
-        size_ -= offs_;
-        offs_ = 0;
-      } else {
-        size_ = offs_ = 0;
-      }
-      delete[] buf_;
-    }
-
-    buf_ = nb;
-    capacity_ = sz;
+  // Return capacity of whole buffer.
+  size_t Capacity() const {
+    return capacity_;
   }
 
  private:
-  size_t Available() const {
-    return capacity() - size_;
-  }
-
-  uint32_t capacity() const {
-    return capacity_;
-  }
+  void Swap(IoBuf& other);
 
   uint8_t* buf_ = nullptr;
   uint32_t offs_ = 0;
@@ -110,19 +112,5 @@ class IoBuf {
   uint32_t alignment_ = 8;
   uint32_t capacity_ = 0;
 };
-
-inline void IoBuf::ConsumeInput(size_t sz) {
-  if (offs_ + sz >= size_) {
-    size_ = 0;
-    offs_ = 0;
-  } else {
-    offs_ += sz;
-    if (2 * offs_ > size_ && size_ - offs_ < 512) {
-      memcpy(buf_, buf_ + offs_, size_ - offs_);
-      size_ -= offs_;
-      offs_ = 0;
-    }
-  }
-}
 
 }  // namespace base

--- a/io/io.cc
+++ b/io/io.cc
@@ -73,16 +73,16 @@ void AsyncWriteState::OnCb(Result<size_t> res) {
   owner->AsyncWriteSome(cur, arr.end() - cur, [this](Result<size_t> res) { this->OnCb(res); });
 }
 
-// Read some bytes from buf starting at given offset offs and update it.
-Result<size_t> ReadSomeBytes(const iovec* v, uint32_t len, Bytes buf, off_t* offs) {
+// Read some bytes from source starting at given offset offs and update it.
+Result<size_t> ReadSomeBytes(const iovec* dest, uint32_t len, Bytes source, off_t* offs) {
   ssize_t read_total = 0;
-  while (size_t(*offs) < buf.size() && len > 0) {
-    size_t read_sz = min(buf.size() - *offs, v->iov_len);
-    memcpy(v->iov_base, buf.data() + *offs, read_sz);
+  while (size_t(*offs) < source.size() && len > 0) {
+    size_t read_sz = min(source.size() - *offs, dest->iov_len);
+    memcpy(dest->iov_base, source.data() + *offs, read_sz);
     read_total += read_sz;
     *offs += read_sz;
 
-    ++v;
+    ++dest;
     --len;
   }
 
@@ -152,7 +152,7 @@ Result<size_t> NullSink::WriteSome(const iovec* v, uint32_t len) {
 Result<size_t> BufSink::WriteSome(const iovec* ptr, uint32_t len) {
   size_t res = 0;
   for (size_t i = 0; i < len; ++i) {
-    buf_->WriteAndCommit(ptr[i].iov_len, ptr[i].iov_base);
+    buf_->WriteAndCommit(ptr[i].iov_base, ptr[i].iov_len);
     res += ptr[i].iov_len;
   }
   return res;


### PR DESCRIPTION
Some things that I desperately missed in DF:
- IoBuf is not movable (And is wrapped often into unique_ptr to account for this 🤯 )
- IoBuf WriteAndCommit akin to ReadAndConsume
- IoBuf cannot be used as a sink or as a source
- There is no way to convert Bytes into string_view easily