### PR TITLE
Introduce faber native parking-lot ability.

### DIFF
--- a/base/varz_node.cc
+++ b/base/varz_node.cc
@@ -3,7 +3,7 @@
 //
 
 #include "base/varz_node.h"
-#include "absl/strings/str_cat.h"
+#include <absl/strings/str_cat.h>
 
 namespace base {
 

--- a/util/fiber_socket_base.h
+++ b/util/fiber_socket_base.h
@@ -5,9 +5,10 @@
 #pragma once
 
 // for tcp::endpoint. Consider introducing our own.
+#include <absl/base/attributes.h>
+
 #include <boost/asio/ip/tcp.hpp>
 
-#include "absl/base/attributes.h"
 #include "io/io.h"
 
 namespace util {
@@ -136,16 +137,24 @@ class LinuxSocketBase : public FiberSocketBase {
   //! in process of completing.
   virtual uint32_t CancelPoll(uint32_t id) = 0;
 
-  bool IsUDS() const { return fd_ & IS_UDS; }
+  bool IsUDS() const {
+    return fd_ & IS_UDS;
+  }
 
   // Whether it was registered with io_uring engine.
-  bool IsDirect() const { return fd_ & REGISTER_FD; }
+  bool IsDirect() const {
+    return fd_ & REGISTER_FD;
+  }
 
  protected:
   LinuxSocketBase(int fd, ProactorBase* pb) : FiberSocketBase(pb), fd_(fd > 0 ? fd << 3 : fd) {
   }
 
-  enum { IS_SHUTDOWN = 0x1, IS_UDS = 0x2, REGISTER_FD = 0x4,};
+  enum {
+    IS_SHUTDOWN = 0x1,
+    IS_UDS = 0x2,
+    REGISTER_FD = 0x4,
+  };
 
   // 3 low bits are used for masking the state of fd.
   // gives me 512M descriptors.

--- a/util/fibers/fiberqueue_threadpool.cc
+++ b/util/fibers/fiberqueue_threadpool.cc
@@ -1,9 +1,9 @@
-// Copyright 2019, Beeri 15.  All rights reserved.
+// Copyright 2023, Beeri 15.  All rights reserved.
 // Author: Roman Gershman (romange@gmail.com)
 //
 #include "util/fibers/fiberqueue_threadpool.h"
 
-#include "absl/strings/str_cat.h"
+#include <absl/strings/str_cat.h>
 #include "base/pthread_utils.h"
 
 namespace util {

--- a/util/fibers/synchronization.h
+++ b/util/fibers/synchronization.h
@@ -6,7 +6,7 @@
 
 #include <condition_variable>  // for cv_status
 
-#include "absl/base/internal/spinlock.h"
+#include <absl/base/internal/spinlock.h>
 #include "util/fibers/detail/scheduler.h"
 
 namespace util {
@@ -321,6 +321,12 @@ inline bool EventCount::notify() noexcept {
 
   if (prev & kWaiterMask) {
     detail::FiberInterface* active = detail::FiberActive();
+    /*detail::FiberInterface* dest = active->UnparkOne(this);
+    if (dest) {
+      active->ActivateOther(dest);
+      return true;
+    }*/
+
     lock_.Lock();
 
     if (!wait_queue_.empty()) {

--- a/util/fibers/uring_proactor.cc
+++ b/util/fibers/uring_proactor.cc
@@ -4,12 +4,12 @@
 
 #include "util/fibers/uring_proactor.h"
 
+#include <absl/base/attributes.h>
 #include <liburing.h>
 #include <poll.h>
 #include <string.h>
 #include <sys/eventfd.h>
 
-#include "absl/base/attributes.h"
 #include "base/flags.h"
 #include "base/histogram.h"
 #include "base/logging.h"
@@ -458,7 +458,7 @@ void UringProactor::UnregisterFd(unsigned fixed_fd) {
   }
 }
 
-LinuxSocketBase* UringProactor::CreateSocket(int fd)  {
+LinuxSocketBase* UringProactor::CreateSocket(int fd) {
   return nullptr;
 }
 
@@ -582,6 +582,7 @@ void UringProactor::DispatchLoop(detail::Scheduler* scheduler) {
     }
 
     scheduler->DestroyTerminated();
+    scheduler->RunDeferred();
 
     bool should_spin = RunOnIdleTasks();
     if (should_spin) {

--- a/util/uring/proactor.cc
+++ b/util/uring/proactor.cc
@@ -4,6 +4,7 @@
 
 #include "util/uring/proactor.h"
 
+#include <absl/base/attributes.h>
 #include <liburing.h>
 #include <poll.h>
 #include <string.h>
@@ -12,7 +13,6 @@
 #include <boost/fiber/operations.hpp>
 #include <boost/fiber/scheduler.hpp>
 
-#include "absl/base/attributes.h"
 #include "base/flags.h"
 #include "base/histogram.h"
 #include "base/logging.h"

--- a/util/varz.h
+++ b/util/varz.h
@@ -6,7 +6,7 @@
 
 #include <string_view>
 
-#include "absl/container/flat_hash_map.h"
+#include <absl/container/flat_hash_map.h>
 #include "base/varz_node.h"
 #include "util/sliding_counter.h"
 


### PR DESCRIPTION
Parking lot is a global table that allows parking fibers without maintaining dedicated spinlocks and waiting queues. The parking-lot framework maintains a resizeable hashtable that uses spinlocks per bucket. When a hashtable needs resizing it's done in such way that fibers do not need to contend on bucket array pointer. bucket array replacement is performed using qsbr technique together with derred deletions.