### PR TITLE
feat: Add proactor pool to fb2 namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.4)
 
-set(PACKAGE_NAME    "async")
+set(PACKAGE_NAME    "helio")
 set(PROJECT_CONTACT romange@gmail.com)
 
 project(${PACKAGE_NAME} C CXX)
@@ -18,6 +18,7 @@ Message(STATUS "PROJECT_SOURCE_DIR ${PROJECT_SOURCE_DIR} CMAKE_SOURCE_DIR ${CMAK
 option (BUILD_DOCS "Generate documentation " ON)
 option (BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option (USE_MOLD "whether to use mold linker" OFF)
+option (USE_FB2 "whether to use fibers2 library" OFF)
 
 if (PARENT_PROJ_NAME)
   Message(STATUS "PARENT_PROJ_NAME ${PARENT_PROJ_NAME}")
@@ -29,6 +30,9 @@ else()
   include(internal)
 endif()
 
+if (USE_FB2)
+  add_definitions(-DUSE_FB2)
+endif()
 
 add_subdirectory(base)
 add_subdirectory(io)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,7 +5,12 @@ add_executable(raw_echo_server raw_echo_server.cc)
 cxx_link(raw_echo_server base fibers2 TRDP::uring TRDP::gperf)
 
 add_executable(echo_server echo_server.cc)
-cxx_link(echo_server base uring_fiber_lib epoll_fiber_lib http_server_lib)
+if (USE_FB2)
+    cxx_link(echo_server base fibers2 http_server_lib TRDP::gperf)
+else()
+    cxx_link(echo_server base uring_fiber_lib epoll_fiber_lib http_server_lib)
+endif()
+
 
 # add_executable(proactor_stress proactor_stress.cc)
 # cxx_link(proactor_stress base uring_fiber_lib http_server_lib)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -10,7 +10,12 @@ if (NOT ANL_LIB)  # for some distributions it does not exist.
 endif()
 
 cxx_link(proactor_lib base absl::flat_hash_map Boost::fiber Boost::headers ${ANL_LIB})
-cxx_test(accept_server_test uring_fiber_lib epoll_fiber_lib http_beast_prebuilt LABELS CI)
+
+if (USE_FB2)
+  cxx_test(accept_server_test fibers2 http_beast_prebuilt LABELS CI)
+else()
+  cxx_test(accept_server_test uring_fiber_lib epoll_fiber_lib http_beast_prebuilt LABELS CI)
+endif()
 
 set(OPENSSL_ROOT_DIR "/opt/openssl/")
 find_package(OpenSSL)

--- a/util/accept_server.cc
+++ b/util/accept_server.cc
@@ -103,6 +103,7 @@ error_code AcceptServer::AddListener(const char* bind_addr, uint16_t port,
   ProactorBase* next = pool_->GetNextProactor();
 
   unique_ptr<LinuxSocketBase> fs{next->CreateSocket()};
+  DCHECK(fs);
 
   error_code ec;
   bool success = false;

--- a/util/accept_server.h
+++ b/util/accept_server.h
@@ -60,7 +60,7 @@ class AcceptServer {
   std::function<void()> on_break_hook_;
 
   std::vector<std::unique_ptr<ListenerInterface>> list_interface_;
-  fibers_ext::BlockingCounter ref_bc_;  // to synchronize listener threads during the shutdown.
+  BlockingCounter ref_bc_;  // to synchronize listener threads during the shutdown.
 
   bool was_run_ = false;
 

--- a/util/accept_server_test.cc
+++ b/util/accept_server_test.cc
@@ -11,14 +11,23 @@
 #include "base/logging.h"
 #include "util/asio_stream_adapter.h"
 #include "util/listener_interface.h"
+
+#ifdef USE_FB2
+#include "util/fibers/uring_pool.h"
+#else
 #include "util/uring/uring_pool.h"
+#endif
 
 namespace util {
-namespace uring {
 
 using namespace std;
 namespace h2 = boost::beast::http;
-using fibers_ext::BlockingCounter;
+
+#ifdef USE_FB2
+using fb2::UringPool;
+#else
+using uring::UringPool;
+#endif
 
 #define USE_URING 1
 
@@ -122,5 +131,4 @@ TEST_F(AcceptServerTest, Break) {
   as_->Stop(true);
 }
 
-}  // namespace uring
 }  // namespace util

--- a/util/fiber_socket_base.h
+++ b/util/fiber_socket_base.h
@@ -13,7 +13,16 @@
 
 namespace util {
 
+#ifdef USE_FB2
+namespace fb2 {
 class ProactorBase;
+}  // namespace fb2
+
+using fb2::ProactorBase;
+
+#else
+class ProactorBase;
+#endif
 
 class FiberSocketBase : public io::Sink, io::AsyncSink {
   FiberSocketBase(const FiberSocketBase&) = delete;

--- a/util/fibers/CMakeLists.txt
+++ b/util/fibers/CMakeLists.txt
@@ -1,6 +1,9 @@
-add_library(fibers2 fiber2.cc proactor_base.cc synchronization.cc uring_proactor.cc
-             detail/scheduler.cc)
-cxx_link(fibers2 base TRDP::uring Boost::context)
+add_library(fibers2 fiber2.cc proactor_base.cc synchronization.cc uring_proactor.cc uring_pool.cc
+            detail/scheduler.cc ../accept_server.cc ../fiber_socket_base.cc ../listener_interface.cc
+            ../prebuilt_asio.cc ../proactor_pool.cc ../uring/uring_socket.cc
+            ../sliding_counter.cc ../varz.cc)
+target_compile_definitions(fibers2 PRIVATE USE_FB2)
+cxx_link(fibers2 base io TRDP::uring Boost::context Boost::headers)
 
 
 add_library(fibers_ext fibers_ext.cc fiber_file.cc fiberqueue_threadpool.cc)

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -648,6 +648,14 @@ FiberInterface::~FiberInterface() {
   DCHECK(!list_hook.is_linked());
 }
 
+void FiberInterface::SetName(std::string_view nm) {
+  if (nm.empty())
+    return;
+  size_t len = std::min(nm.size(), sizeof(name_) - 1);
+  memcpy(name_, nm.data(), len);
+  name_[len] = 0;
+}
+
 // We can not destroy this instance within the context of the fiber it's been running in.
 // The reason: the instance is hosted within the stack region of the fiber itself, and it
 // implicitly destroys the stack when destroying its 'entry_' member variable.

--- a/util/fibers/event_count.h
+++ b/util/fibers/event_count.h
@@ -6,6 +6,10 @@
 // https://software.intel.com/en-us/forums/intel-threading-building-blocks/topic/299245
 #pragma once
 
+#ifdef USE_FB2
+#error "This file is not compatible with fb2"
+#endif
+
 #include <absl/base/macros.h>
 #include <boost/fiber/context.hpp>
 #include <boost/version.hpp>

--- a/util/fibers/fiber.h
+++ b/util/fibers/fiber.h
@@ -68,4 +68,9 @@ inline void Yield() noexcept {
 }
 
 }  // namespace fibers_ext
+
+template <typename Fn, typename... Arg> fibers_ext::Fiber MakeFiber(Fn&& fn, Arg&&... arg) {
+  return fibers_ext::Fiber(std::forward<Fn>(fn), std::forward<Arg>(arg)...);
+}
+
 }  // namespace util

--- a/util/fibers/fiber2_test.cc
+++ b/util/fibers/fiber2_test.cc
@@ -73,6 +73,9 @@ TEST_F(FiberTest, Basic) {
   fb2.Join();
 
   EXPECT_EQ(2, run);
+
+  Fiber fb3("test3", [](int i) {}, 1);
+  fb3.Join();
 }
 
 TEST_F(FiberTest, Remote) {
@@ -170,7 +173,7 @@ TEST_F(ProactorTest, AsyncEvent) {
   };
 
   proactor_th_->proactor->DispatchBrief([&] {
-    uring::SubmitEntry se = proactor_th_->proactor->GetSubmitEntry(std::move(cb), 1);
+    SubmitEntry se = proactor_th_->proactor->GetSubmitEntry(std::move(cb), 1);
     se.sqe()->opcode = IORING_OP_NOP;
     LOG(INFO) << "submit";
   });

--- a/util/fibers/fibers_ext.h
+++ b/util/fibers/fibers_ext.h
@@ -1,7 +1,13 @@
-// Copyright 2018, Beeri 15.  All rights reserved.
-// Author: Roman Gershman (romange@gmail.com)
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
 //
+
 #pragma once
+
+#ifdef USE_FB2
+#include "util/fibers/synchronization.h"
+using util::fb2::SharedMutex;
+#else
 
 #include <boost/fiber/barrier.hpp>
 #include <boost/fiber/channel_op_status.hpp>
@@ -341,4 +347,10 @@ class Barrier {
 };
 
 }  // namespace fibers_ext
+
+using fibers_ext::BlockingCounter;
+using fibers_ext::SharedMutex;
+
 }  // namespace util
+
+#endif  // USE_FB2

--- a/util/fibers/proactor_base.h
+++ b/util/fibers/proactor_base.h
@@ -21,14 +21,13 @@
 #include "util/fibers/fiber2.h"
 
 namespace util {
-namespace fb2 {
-
 class LinuxSocketBase;
+
+namespace fb2 {
 
 class ProactorBase {
   ProactorBase(const ProactorBase&) = delete;
   void operator=(const ProactorBase&) = delete;
-  friend class FiberSchedAlgo;
 
  public:
   enum { kTaskQueueLen = 256 };
@@ -127,7 +126,7 @@ class ProactorBase {
     // So I just copy them into capture.
     // We forward captured variables so we need lambda to be mutable.
     DispatchBrief([f = std::forward<Func>(f), args...]() mutable {
-      Fiber(std::forward<Func>(f), std::forward<Args>(args)...).Detach();
+      Fiber("Dispatched", std::forward<Func>(f), std::forward<Args>(args)...).Detach();
     });
   }
 

--- a/util/fibers/uring_pool.cc
+++ b/util/fibers/uring_pool.cc
@@ -2,27 +2,27 @@
 // See LICENSE for licensing terms.
 //
 
-#include "util/uring/uring_pool.h"
+#include "util/fibers/uring_pool.h"
 
 #include "base/logging.h"
-#include "util/uring/proactor.h"
+#include "util/fibers/uring_proactor.h"
 
 using namespace std;
 
 namespace util {
-namespace uring {
+namespace fb2 {
 
 UringPool::~UringPool() {
 }
 
 ProactorBase* UringPool::CreateProactor() {
-  return new Proactor;
+  return new UringProactor;
 }
 
 void UringPool::InitInThread(unsigned index) {
-  Proactor* p = static_cast<Proactor*>(proactor_[index]);
+  UringProactor* p = static_cast<UringProactor*>(proactor_[index]);
   p->Init(ring_depth_);
 }
 
-}  // namespace uring
+}  // namespace fb2
 }  // namespace util

--- a/util/fibers/uring_pool.h
+++ b/util/fibers/uring_pool.h
@@ -1,5 +1,5 @@
-// Copyright 2021, Beeri 15.  All rights reserved.
-// Author: Roman Gershman (romange@gmail.com)
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
 //
 
 #pragma once
@@ -7,7 +7,7 @@
 #include "util/proactor_pool.h"
 
 namespace util {
-namespace uring {
+namespace fb2 {
 
 class UringPool : public ProactorPool {
  public:
@@ -28,5 +28,5 @@ class UringPool : public ProactorPool {
   unsigned ring_depth_;
 };
 
-}  // namespace uring
+}  // namespace fb2
 }  // namespace util

--- a/util/fibers/uring_proactor.h
+++ b/util/fibers/uring_proactor.h
@@ -13,6 +13,10 @@
 namespace util {
 namespace fb2 {
 
+#ifndef USE_FB2
+using uring::SubmitEntry;
+#endif
+
 namespace detail {
   class Scheduler;
 }
@@ -60,7 +64,7 @@ class UringProactor : public ProactorBase {
    *       In that case we will need RegisterCallback function that takes an unregistered SQE
    *       and assigns a callback to it. GetSubmitEntry will be implemented using those functions.
    */
-  uring::SubmitEntry GetSubmitEntry(CbType cb, int64_t payload);
+  SubmitEntry GetSubmitEntry(CbType cb, int64_t payload);
 
   // Returns number of entries available for submitting to io_uring.
   uint32_t GetSubmitRingAvailability() const {
@@ -170,7 +174,7 @@ class FiberCall {
 
   ~FiberCall();
 
-  uring::SubmitEntry* operator->() {
+  SubmitEntry* operator->() {
     return &se_;
   }
 
@@ -186,8 +190,8 @@ class FiberCall {
   }
 
  private:
-  uring::SubmitEntry se_;
-  uring::SubmitEntry tm_;
+  SubmitEntry se_;
+  SubmitEntry tm_;
 
   detail::FiberInterface* me_;
   UringProactor::IoResult io_res_ = 0;

--- a/util/listener_interface.cc
+++ b/util/listener_interface.cc
@@ -6,11 +6,14 @@
 
 #include <signal.h>
 
-#include <boost/fiber/operations.hpp>
+// #include <boost/fiber/operations.hpp>
 
 #include "base/logging.h"
 #include "util/accept_server.h"
+#ifndef USE_FB2
 #include "util/fiber_sched_algo.h"
+#endif
+
 #include "util/proactor_pool.h"
 
 #define VSOCK(verbosity, sock) VLOG(verbosity) << "sock[" << native_handle(sock) << "] "
@@ -20,6 +23,10 @@ namespace util {
 
 using namespace boost;
 using namespace std;
+
+#ifndef USE_FB2
+using fibers_ext::Await;
+#endif
 
 namespace {
 
@@ -40,7 +47,11 @@ using ListType =
 
 struct ListenerInterface::TLConnList {
   ListType list;
+#ifdef USE_FB2
+  fb2::CondVarAny empty_cv;
+#else
   fibers::condition_variable_any empty_cv;
+#endif
 
   void Link(Connection* c) {
     DCHECK(!c->hook_.is_linked());
@@ -67,7 +78,7 @@ struct ListenerInterface::TLConnList {
 
     DVLOG(1) << "AwaitEmpty: List size: " << list.size();
 
-    fibers_ext::Await(empty_cv, [this] { return this->list.empty(); });
+    Await(empty_cv, [this] { return this->list.empty(); });
     DVLOG(1) << "AwaitEmpty finished ";
   }
 };
@@ -78,7 +89,6 @@ thread_local unordered_map<ListenerInterface*, ListenerInterface::TLConnList*>
 // Runs in a dedicated fiber for each listener.
 void ListenerInterface::RunAcceptLoop() {
   FiberProps::SetName("AcceptLoop");
-
   FiberSocketBase::endpoint_type ep;
 
   if (!sock_->IsUDS() && !sock_->IsDirect()) {
@@ -88,7 +98,10 @@ void ListenerInterface::RunAcceptLoop() {
 
   PreAcceptLoop(sock_->proactor());
 
-  pool_->Await([this](auto*) { conn_list.emplace(this, new TLConnList{}); });
+  pool_->Await([this](auto*) {
+    DVLOG(1) << "Emplacing " << this;
+    conn_list.emplace(this, new TLConnList{});
+  });
 
   while (true) {
     FiberSocketBase::AcceptResult res = sock_->Accept();
@@ -118,15 +131,20 @@ void ListenerInterface::RunAcceptLoop() {
 
   PreShutdown();
 
+#ifdef USE_FB2
+#else
   // I am not a fan of "almost works" solutions. Here, I wait for Dispatch() calls
   // to start running and decrease the probability we continue without the up to date conn_list.
   // Since we are during the shutdown phase, waiting for 10ms is "probably" enough to let all the
   // callback to unwind and run.
   fibers_ext::SleepFor(10ms);
+#endif
   atomic_uint32_t cur_conn_cnt{0};
 
   pool_->AwaitFiberOnAll([&](auto* pb) {
-    auto* clist = conn_list.find(this)->second;
+    auto it = conn_list.find(this);
+    DCHECK(it != conn_list.end());
+    auto* clist = it->second;
 
     cur_conn_cnt.fetch_add(clist->list.size(), memory_order_relaxed);
 

--- a/util/metrics/CMakeLists.txt
+++ b/util/metrics/CMakeLists.txt
@@ -1,3 +1,6 @@
 add_library(metrics family.cc metrics.cc)
+if (USE_FB2)
+cxx_link(metrics fibers2)
+else()
 cxx_link(metrics proactor_lib)
-
+endif()

--- a/util/metrics/family.cc
+++ b/util/metrics/family.cc
@@ -12,6 +12,12 @@ namespace util {
 namespace metrics {
 using namespace std;
 
+#ifdef USE_FB2
+using fb2::Mutex;
+#else
+using Mutex = ::boost::fibers::mutex;
+#endif
+
 namespace {
 
 shared_mutex list_mu;
@@ -149,7 +155,7 @@ void Iterate(MetricRowCb cb) {
     ++index;
   }
 
-  boost::fibers::mutex mu;
+  Mutex mu;
   vector<double> result(total_metrics, 0.0);
   auto per_thread_cb = [&](unsigned tindex, auto*) {
     uint32_t offset = 0;

--- a/util/metrics/family.h
+++ b/util/metrics/family.h
@@ -1,6 +1,7 @@
-// Copyright 2021, Beeri 15.  All rights reserved.
-// Author: Roman Gershman (romange@gmail.com)
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
 //
+
 #pragma once
 
 #include <absl/container/flat_hash_map.h>
@@ -129,7 +130,7 @@ class Family {
   std::vector<LabelValues> label_values_;  // Guarded by mu_
   LabelMap label_map_;                     // Guarded by mu_
 
-  fibers_ext::SharedMutex mu_;
+  SharedMutex mu_;
 
   ProactorPool* pp_;
   Family* next_ = nullptr;

--- a/util/metrics/metrics.h
+++ b/util/metrics/metrics.h
@@ -1,5 +1,5 @@
-// Copyright 2021, Beeri 15.  All rights reserved.
-// Author: Roman Gershman (romange@gmail.com)
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
 //
 
 #pragma once

--- a/util/proactor_base.h
+++ b/util/proactor_base.h
@@ -4,6 +4,10 @@
 
 #pragma once
 
+#ifdef USE_FB2
+#errror "Can not compile with USE_FB2"
+#endif
+
 #include <pthread.h>
 
 #pragma GCC diagnostic push

--- a/util/proactor_pool.h
+++ b/util/proactor_pool.h
@@ -11,9 +11,18 @@
 
 #include "base/RWSpinLock.h"
 #include "base/type_traits.h"
+
+#ifdef USE_FB2
+#include "util/fibers/proactor_base.h"
+#else
 #include "util/proactor_base.h"
+#endif
 
 namespace util {
+
+#ifdef USE_FB2
+using fb2::ProactorBase;
+#endif
 
 class ProactorPool {
   template <typename Func, typename... Args>
@@ -97,7 +106,7 @@ class ProactorPool {
    * Func must accept "ProactorBase&" and it should not block.
    */
   template <typename Func, AcceptArgsCheck<Func, ProactorBase*> = 0> void Await(Func&& func) {
-    fibers_ext::BlockingCounter bc(size());
+    BlockingCounter bc(size());
     auto cb = [func = std::forward<Func>(func), bc](ProactorBase* context) mutable {
       func(context);
       bc.Dec();
@@ -113,7 +122,7 @@ class ProactorPool {
    */
   template <typename Func, AcceptArgsCheck<Func, unsigned, ProactorBase*> = 0>
   void Await(Func&& func) {
-    fibers_ext::BlockingCounter bc(size());
+    BlockingCounter bc(size());
     auto cb = [func = std::forward<Func>(func), bc](unsigned index, ProactorBase* p) mutable {
       func(index, p);
       bc.Dec();
@@ -133,7 +142,7 @@ class ProactorPool {
   template <typename Func, AcceptArgsCheck<Func, unsigned, ProactorBase*> = 0>
   void DispatchOnAll(Func&& func) {
     DispatchBrief([func = std::forward<Func>(func)](unsigned i, ProactorBase* context) {
-      fibers_ext::Fiber(func, i, context).Detach();
+      MakeFiber(func, i, context).Detach();
     });
   }
 
@@ -148,7 +157,7 @@ class ProactorPool {
   template <typename Func, AcceptArgsCheck<Func, ProactorBase*> = 0>
   void DispatchOnAll(Func&& func) {
     DispatchBrief([func = std::forward<Func>(func)](ProactorBase* context) {
-      fibers_ext::Fiber(func, context).Detach();
+      MakeFiber(func, context).Detach();
     });
   }
 
@@ -162,7 +171,7 @@ class ProactorPool {
    */
   template <typename Func, AcceptArgsCheck<Func, unsigned, ProactorBase*> = 0>
   void AwaitFiberOnAll(Func&& func) {
-    fibers_ext::BlockingCounter bc(size());
+    BlockingCounter bc(size());
     auto cb = [func = std::forward<Func>(func), bc](unsigned i, ProactorBase* context) mutable {
       func(i, context);
       bc.Dec();
@@ -181,7 +190,7 @@ class ProactorPool {
    */
   template <typename Func, AcceptArgsCheck<Func, ProactorBase*> = 0>
   void AwaitFiberOnAll(Func&& func) {
-    fibers_ext::BlockingCounter bc(size());
+    BlockingCounter bc(size());
     auto cb = [func = std::forward<Func>(func), bc](ProactorBase* context) mutable {
       func(context);
       bc.Dec();
@@ -209,7 +218,7 @@ class ProactorPool {
  private:
   void SetupProactors();
 
-  void WrapLoop(size_t index, fibers_ext::BlockingCounter* bc);
+  void WrapLoop(size_t index, BlockingCounter* bc);
   void CheckRunningState();
 
   /// The next io_context to use for a connection.

--- a/util/sliding_counter.h
+++ b/util/sliding_counter.h
@@ -104,7 +104,7 @@ template <unsigned NUM> class SlidingCounterDist : protected detail::SlidingCoun
       res.fetch_add(sc_thread_map_[i].Sum(), std::memory_order_relaxed);
     });
 
-    return res.load(std::memory_order_release);
+    return res.load(std::memory_order_acquire);
   }
 
   uint32_t SumTail() const {
@@ -115,7 +115,7 @@ template <unsigned NUM> class SlidingCounterDist : protected detail::SlidingCoun
       res.fetch_add(sc_thread_map_[i].SumTail(), std::memory_order_relaxed);
     });
 
-    return res.load(std::memory_order_release);
+    return res.load(std::memory_order_acquire);
   }
 
  private:

--- a/util/uring/proactor.h
+++ b/util/uring/proactor.h
@@ -4,6 +4,10 @@
 
 #pragma once
 
+#ifdef USE_FB2
+#error "This file should not be included when using fb2"
+#else
+
 #include <liburing.h>
 #include <pthread.h>
 
@@ -192,3 +196,4 @@ class FiberCall {
 
 }  // namespace uring
 }  // namespace util
+#endif

--- a/util/uring/submit_entry.h
+++ b/util/uring/submit_entry.h
@@ -7,9 +7,14 @@
 #include <liburing/io_uring.h>
 
 namespace util {
+#ifdef USE_FB2
+namespace fb2 {
+class UringProactor;
+#else
 namespace uring {
-
 class Proactor;
+#endif
+
 
 /**
  * @brief Wraps and prepares SQE for submission.
@@ -188,7 +193,9 @@ class SubmitEntry {
     sqe_->fd = fd;
   }
 
+  #ifndef USE_FB2
   friend class Proactor;
+  #endif
 };
 
 }  // namespace uring

--- a/util/uring/uring_socket.cc
+++ b/util/uring/uring_socket.cc
@@ -1,5 +1,5 @@
-// Copyright 2021, Beeri 15.  All rights reserved.
-// Author: Roman Gershman (romange@gmail.com)
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
 //
 
 #include "util/uring/uring_socket.h"
@@ -7,17 +7,20 @@
 #include <netinet/in.h>
 #include <poll.h>
 
-#include <boost/fiber/context.hpp>
+// #include <boost/fiber/context.hpp>
 
 #include "base/logging.h"
 #include "base/stl_util.h"
-#include "util/uring/proactor.h"
 
 #define VSOCK(verbosity) VLOG(verbosity) << "sock[" << native_handle() << "] "
 #define DVSOCK(verbosity) DVLOG(verbosity) << "sock[" << native_handle() << "] "
 
 namespace util {
+#ifdef USE_FB2
+namespace fb2 {
+#else
 namespace uring {
+#endif
 
 using namespace std;
 using IoResult = Proactor::IoResult;

--- a/util/uring/uring_socket.h
+++ b/util/uring/uring_socket.h
@@ -1,5 +1,5 @@
-// Copyright 2022, Beeri 15.  All rights reserved.
-// Author: Roman Gershman (romange@gmail.com)
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
 //
 
 #pragma once
@@ -7,10 +7,20 @@
 #include <liburing/io_uring.h>
 
 #include "util/fiber_socket_base.h"
+#ifdef USE_FB2
+#include "util/fibers/uring_proactor.h"
+#else
 #include "util/uring/proactor.h"
+#endif
 
 namespace util {
+
+#ifdef USE_FB2
+namespace fb2 {
+using Proactor = UringProactor;
+#else
 namespace uring {
+#endif
 
 class UringSocket : public LinuxSocketBase {
  public:

--- a/util/varz.cc
+++ b/util/varz.cc
@@ -1,15 +1,20 @@
-// Copyright 2021, Beeri 15.  All rights reserved.
-// Author: Roman Gershman (romange@gmail.com)
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
 //
 
 #include "util/varz.h"
 #include "base/logging.h"
 
-using namespace boost;
-
 using base::VarzValue;
 using namespace std;
 
+#ifdef USE_FB2
+#include "util/fibers/synchronization.h"
+using util::fb2::Mutex;
+#else
+#include <boost/fiber/mutex.hpp>
+using Mutex = boost::fibers::mutex;
+#endif
 namespace util {
 
 VarzValue VarzQps::GetData() const {
@@ -55,7 +60,7 @@ VarzValue VarzMapAverage::GetData() const {
   CHECK(pp_);
 
   AnyValue::Map result;
-  fibers::mutex mu;
+  Mutex mu;
 
   auto cb = [&](unsigned index, auto*) {
     auto& map = avg_map_[index];


### PR DESCRIPTION
Now helio can be compiled with USE_FB2 switch in which its internal libraries will use fibers2 lib instead of Boost.Fibers