### PR TITLE
Save SWAP information from `/proc/meminfo`

### DIFF
--- a/io/proc_reader.cc
+++ b/io/proc_reader.cc
@@ -118,6 +118,12 @@ Result<MemInfoData> ReadMemInfo() {
       ParseKb(num, &mdata.mem_cached);
     } else if (key == "SReclaimable") {
       ParseKb(num, &mdata.mem_SReclaimable);
+    } else if (key == "SwapCached") {
+      ParseKb(num, &mdata.swap_cached)
+    } else if (key == "SwapTotal") {
+      ParseKb(num, &mdata.swap_total);
+    } else if (key == "SwapFree") {
+      ParseKb(num, &mdata.swap_free);
     }
   };
 

--- a/io/proc_reader.h
+++ b/io/proc_reader.h
@@ -23,6 +23,9 @@ struct MemInfoData {
   size_t mem_buffers = 0;
   size_t mem_cached = 0;
   size_t mem_SReclaimable = 0;
+  size_t swap_cached = 0;
+  size_t swap_total = 0;
+  size_t swap_free = 0;
 
   // in meminfo.c of free program - mem used
   // equals to: total - (free + buffers + cached + SReclaimable).


### PR DESCRIPTION
Save SWAP information from `/proc/meminfo`, can also be used in determining whether the SWAP file is enabled or not.