### PR TITLE
allow to compile with an OpenSSL installation

### DIFF
--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -17,7 +17,6 @@ else()
   cxx_test(accept_server_test uring_fiber_lib epoll_fiber_lib http_beast_prebuilt LABELS CI)
 endif()
 
-set(OPENSSL_ROOT_DIR "/opt/openssl/")
 find_package(OpenSSL)
 
 add_subdirectory(fibers)

--- a/util/cloud/CMakeLists.txt
+++ b/util/cloud/CMakeLists.txt
@@ -3,7 +3,7 @@ find_package(LibXml2)
 add_library(aws_lib aws.cc cloud_utils.cc s3.cc s3_file.cc)
 
 if(TARGET LibXml2::LibXml2)
-  cxx_link(aws_lib base crypto LibXml2::LibXml2 TRDP::rapidjson http_utils io)
+  cxx_link(aws_lib base OpenSSL::Crypto LibXml2::LibXml2 TRDP::rapidjson http_utils io)
 else()
   Message(WARNING "LibXml2 not found, if you need aws_lib, install LibXml2 with 'sudo apt install libxml2-dev'")
 endif()


### PR DESCRIPTION
- remove the override of OPENSSL_ROOT_DIR
- allow to pass a custom OpenSSL folder from build command as -DOPENSSL_ROOT_DIR=/path/to/openssl/folder
- make sure crypto and ssl library using the same installation source