### PR TITLE
Don't allow arbitrary paths in /filez endpoint

### DIFF
--- a/util/http/http_common.cc
+++ b/util/http/http_common.cc
@@ -43,7 +43,7 @@ const char kSvgMime[] = "image/svg+xml";
 const char kTextMime[] = "text/plain";
 const char kXmlMime[] = "application/xml";
 const char kBinMime[] = "application/octet-stream";
-;
+const char kProfilesFolder[] = "/tmp/profile/";
 
 QueryParam ParseQuery(std::string_view str) {
   std::pair<std::string_view, std::string_view> res;

--- a/util/http/http_common.h
+++ b/util/http/http_common.h
@@ -2,9 +2,8 @@
 // Author: Roman Gershman (romange@gmail.com)
 //
 #pragma once
-#include <boost/beast/http/string_body.hpp>
 #include <boost/beast/http/file_body.hpp>
-
+#include <boost/beast/http/string_body.hpp>
 #include <string_view>
 
 namespace util {
@@ -17,15 +16,14 @@ namespace http {
 using QueryParam = std::pair<std::string_view, std::string_view>;
 typedef std::vector<QueryParam> QueryArgs;
 
-typedef ::boost::beast::http::response<::boost::beast::http::string_body>
-    StringResponse;
+typedef ::boost::beast::http::response<::boost::beast::http::string_body> StringResponse;
 
 inline StringResponse MakeStringResponse(
     ::boost::beast::http::status st = ::boost::beast::http::status::ok) {
   return StringResponse(st, 11);
 }
 
-template<typename Fields> inline void SetMime(const char* mime, Fields* dest) {
+template <typename Fields> inline void SetMime(const char* mime, Fields* dest) {
   dest->set(::boost::beast::http::field::content_type, mime);
 }
 
@@ -39,6 +37,7 @@ extern const char kSvgMime[];
 extern const char kTextMime[];
 extern const char kXmlMime[];
 extern const char kBinMime[];
+extern const char kProfilesFolder[];
 
 QueryParam ParseQuery(std::string_view str);
 QueryArgs SplitQuery(std::string_view query);

--- a/util/http/profilez_handler.cc
+++ b/util/http/profilez_handler.cc
@@ -6,6 +6,7 @@
 #include <absl/time/time.h>
 #include <gperftools/profiler.h>
 
+#include <filesystem>
 #include <thread>
 #include <unordered_map>
 
@@ -34,7 +35,8 @@ namespace h2 = beast::http;
 typedef h2::response<h2::string_body> StringResponse;
 
 static void HandleCpuProfile(bool enable, StringResponse* response) {
-  string profile_name = "/tmp/" + base::ProgramBaseName();
+  std::filesystem::create_directory(kProfilesFolder);
+  string profile_name = kProfilesFolder + base::ProgramBaseName();
   response->set(h2::field::cache_control, "no-cache, no-store, must-revalidate");
   response->set(h2::field::pragma, "no-cache");
   response->set(field::content_type, kHtmlMime);


### PR DESCRIPTION
Allow only paths starting with `/tmp/profile`