### PR TITLE
feat(tls-socket): allow tls socket to cache the first bytes received

### DIFF
--- a/util/tls/tls_socket.cc
+++ b/util/tls/tls_socket.cc
@@ -290,9 +290,28 @@ auto TlsSocket::HandleRead() -> error_code {
   if (!esz) {
     return esz.error();
   }
+
+  if(cache_) {
+    PlaceBufferInCache(mut_buf, *esz);
+    cache_ = false;
+  }
+
   engine_->CommitInput(*esz);
 
   return error_code{};
+}
+
+void TlsSocket::CacheOnce() {
+  cache_ = true;
+}
+
+TlsSocket::Buffer TlsSocket::GetCachedBuffer() const {
+  return {cached_bytes_.data(), n_bytes_};
+}
+
+void TlsSocket::PlaceBufferInCache(Buffer buffer, size_t n_bytes) {
+  cached_bytes_ = buffer;
+  n_bytes_ = n_bytes;
 }
 
 }  // namespace tls

--- a/util/tls/tls_socket.cc
+++ b/util/tls/tls_socket.cc
@@ -291,7 +291,7 @@ auto TlsSocket::HandleRead() -> error_code {
     return esz.error();
   }
 
-  if(cache_) {
+  if (cache_) {
     PlaceBufferInCache(mut_buf, *esz);
     cache_ = false;
   }

--- a/util/tls/tls_socket.h
+++ b/util/tls/tls_socket.h
@@ -7,6 +7,7 @@
 #include <openssl/ssl.h>
 
 #include "util/fiber_socket_base.h"
+#include "util/tls/tls_engine.h"
 
 namespace util {
 namespace tls {
@@ -45,12 +46,28 @@ class TlsSocket : public FiberSocketBase {
 
   SSL* ssl_handle();
 
+  // Enables caching the first n_bytes received in HandleRead()
+  // such that it can be used later to downgrade tls to non-tls 
+  // connections
+  void CacheOnce();
+  
+  using Buffer = Engine::Buffer;  
+
+  Buffer GetCachedBuffer() const;
+  
+  void PlaceBufferInCache(Buffer buffer, size_t n_bytes); 
+
  private:
   error_code MaybeSendOutput();
   error_code HandleRead();
 
   FiberSocketBase* next_sock_;
   std::unique_ptr<Engine> engine_;
+
+  // Used to signal HandleRead() to cache the first n_bytes
+  bool cache_{false};
+  size_t n_bytes_{0};
+  Buffer cached_bytes_;
 };
 
 }  // namespace tls

--- a/util/tls/tls_socket.h
+++ b/util/tls/tls_socket.h
@@ -47,15 +47,15 @@ class TlsSocket : public FiberSocketBase {
   SSL* ssl_handle();
 
   // Enables caching the first n_bytes received in HandleRead()
-  // such that it can be used later to downgrade tls to non-tls 
+  // such that it can be used later to downgrade tls to non-tls
   // connections
   void CacheOnce();
-  
-  using Buffer = Engine::Buffer;  
+
+  using Buffer = Engine::Buffer;
 
   Buffer GetCachedBuffer() const;
-  
-  void PlaceBufferInCache(Buffer buffer, size_t n_bytes); 
+
+  void PlaceBufferInCache(Buffer buffer, size_t n_bytes);
 
  private:
   error_code MaybeSendOutput();


### PR DESCRIPTION
This is used such that connections can be downgraded from tls to non-tls