### PR TITLE
Remove spurious wakeup notifications

### DIFF
--- a/util/fibers/CMakeLists.txt
+++ b/util/fibers/CMakeLists.txt
@@ -5,7 +5,7 @@ endif()
 
 add_library(fibers2 fibers.cc proactor_base.cc synchronization.cc
             fiber_file.cc epoll_proactor.cc epoll_socket.cc pool.cc
-            detail/scheduler.cc detail/fiber_interface.cc accept_server.cc
+            detail/scheduler.cc detail/fiber_interface.cc detail/wait_queue.cc accept_server.cc
             fiber_socket_base.cc listener_interface.cc
             prebuilt_asio.cc proactor_pool.cc
             sliding_counter.cc varz.cc fiberqueue_threadpool.cc dns_resolve.cc

--- a/util/fibers/detail/fiber_interface.h
+++ b/util/fibers/detail/fiber_interface.h
@@ -73,7 +73,7 @@ class FiberInterface {
   void Yield();
 
   // inline
-  void WaitUntil(std::chrono::steady_clock::time_point tp);
+  bool WaitUntil(std::chrono::steady_clock::time_point tp);
 
   // Schedules another fiber without switching to it.
   // other can belong to another thread.
@@ -272,6 +272,9 @@ FiberInterface* FiberActive() noexcept;
 void EnterFiberAtomicSection() noexcept;
 void LeaveFiberAtomicSection() noexcept;
 bool IsFiberAtomicSection() noexcept;
+
+constexpr uint64_t kRemoteFree = 1;
+
 
 }  // namespace detail
 }  // namespace fb2

--- a/util/fibers/detail/fiber_interface_impl.h
+++ b/util/fibers/detail/fiber_interface_impl.h
@@ -14,8 +14,8 @@ inline void FiberInterface::Yield() {
   scheduler_->Preempt();
 }
 
-inline void FiberInterface::WaitUntil(std::chrono::steady_clock::time_point tp) {
-  scheduler_->WaitUntil(tp, this);
+inline bool FiberInterface::WaitUntil(std::chrono::steady_clock::time_point tp) {
+  return scheduler_->WaitUntil(tp, this);
 }
 
 inline void FiberInterface::Suspend() {

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -18,7 +18,6 @@ using namespace std;
 
 namespace {
 
-FiberInterface* const kRemoteFree = reinterpret_cast<FiberInterface*>((void*)1);
 
 #if PARKING_ENABLED
 template <typename T> void WriteOnce(T src, T* dest) {
@@ -511,14 +510,7 @@ void Scheduler::AddReady(FiberInterface* fibi) {
 }
 
 void Scheduler::ScheduleFromRemote(FiberInterface* cntx) {
-  // to make sure that the fiber is not destroyed before it's been pulled from the queue.
-  FiberInterface* free_cntx = kRemoteFree;
-
-  // we can push only the same fiber instance until it gets pulled. However MPSCIntrusiveQueue
-  // does not verify and expects already free items. We verify it here with kRemoteFree test.
-  if (!cntx->remote_next_.compare_exchange_strong(free_cntx, nullptr, memory_order_acquire,
-                                                  memory_order_relaxed))
-    return;
+  DCHECK(cntx->remote_next_.load(memory_order_relaxed) == (FiberInterface*)kRemoteFree);
 
   intrusive_ptr_add_ref(cntx);
   remote_ready_queue_.Push(cntx);
@@ -559,7 +551,7 @@ void Scheduler::DestroyTerminated() {
   }
 }
 
-void Scheduler::WaitUntil(chrono::steady_clock::time_point tp, FiberInterface* me) {
+bool Scheduler::WaitUntil(chrono::steady_clock::time_point tp, FiberInterface* me) {
   DCHECK(!me->sleep_hook.is_linked());
   DCHECK(!me->list_hook.is_linked());
 
@@ -567,6 +559,9 @@ void Scheduler::WaitUntil(chrono::steady_clock::time_point tp, FiberInterface* m
   sleep_queue_.insert(*me);
   auto fc = Preempt();
   DCHECK(!fc);
+  bool has_timed_out = (me->tp_ == chrono::steady_clock::time_point::max());
+
+  return has_timed_out;
 }
 
 void Scheduler::ProcessRemoteReady() {
@@ -574,6 +569,9 @@ void Scheduler::ProcessRemoteReady() {
     FiberInterface* fi = remote_ready_queue_.Pop();
     if (!fi)
       break;
+
+    // Marks as free.
+    fi->remote_next_.store((FiberInterface*)kRemoteFree, memory_order_relaxed);
 
     DVLOG(1) << "Pulled " << fi->name() << " " << fi->DEBUG_use_count();
 
@@ -585,9 +583,6 @@ void Scheduler::ProcessRemoteReady() {
       DVLOG(2) << "set ready " << fi->name();
       AddReady(fi);
     }
-
-    // Mark that this fiber is available to be pushed again into remote_ready_queue_.
-    fi->remote_next_.store(kRemoteFree, memory_order_release);
 
     // Each time we push fi to remote_ready_queue_ we increase the reference count.
     intrusive_ptr_release(fi);
@@ -609,6 +604,7 @@ void Scheduler::ProcessSleep() {
 
     DCHECK(!fi.list_hook.is_linked());
     DVLOG(2) << "timeout for " << fi.name();
+    fi.tp_ = chrono::steady_clock::time_point::max();  // meaning it has timed out.
     ready_queue_.push_back(fi);
   } while (!sleep_queue_.empty());
 }
@@ -640,75 +636,6 @@ void Scheduler::RunDeferred() {
   }
 #endif
 }
-
-#if PARKING_ENABLED
-void FiberInterface::NotifyParked(FiberInterface* other) {
-  DCHECK(other->scheduler_ && other->scheduler_ != scheduler_);
-
-  uintptr_t token = uintptr_t(other);
-
-  // to avoid the missed notification case, we reset the flag even if we had not find the fiber.
-  // this handles the scenario, where the parking fiber started async process, but has not been
-  // added to the parking lot yet and now this process tries to notify it.
-  FiberInterface* item = g_parking_ht->Remove(
-      token,
-      [](FiberInterface* fibi) {
-        fibi->flags_.fetch_and(~kParkingInProgress, memory_order_relaxed);
-      },
-      [other] { return other->flags_.fetch_and(~kParkingInProgress, memory_order_relaxed); });
-
-  if (item == nullptr) {  // The fiber has not parked yet.
-    // we reset the flag, so "other" will skip the suspension.
-    return;
-  }
-  CHECK(item == other);
-  other->scheduler_->ScheduleFromRemote(other);
-}
-
-FiberInterface* FiberInterface::NotifyParked(uint64_t token) {
-  FiberInterface* removed = g_parking_ht->Remove(
-      token, [](FiberInterface* fibi) {}, [] {});
-  if (removed) {
-    ActivateOther(removed);
-  }
-  return removed;
-}
-
-void FiberInterface::NotifyAllParked(uint64_t token) {
-  WaitQueue res;
-
-  g_parking_ht->RemoveAll(token, &res);
-  while (!res.empty()) {
-    auto& fibi = res.front();
-    res.pop_front();
-    ActivateOther(&fibi);
-  }
-}
-
-void FiberInterface::SuspendUntilWakeup() {
-  uintptr_t token = uintptr_t(this);
-  bool parked = g_parking_ht->Emplace(token, this, [this] {
-    // if parking process was stopped we should not park.
-    return (flags_.load(memory_order_relaxed) & kParkingInProgress) == 0;
-  });
-
-  if (parked) {
-    scheduler_->Preempt();
-  }
-}
-
-bool FiberInterface::SuspendConditionally(uint64_t token, absl::FunctionRef<bool()> validate) {
-  bool parked = g_parking_ht->Emplace(token, this, std::move(validate));
-
-  if (parked) {
-    scheduler_->Preempt();
-    return true;
-  }
-
-  return false;
-}
-
-#endif
 
 }  // namespace detail
 

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -405,7 +405,6 @@ ctx::fiber DispatcherImpl::Run(ctx::fiber&& c) {
 
 void DispatcherImpl::DefaultDispatch(Scheduler* sched) {
   DCHECK(FiberActive() == this);
-  DCHECK(!wait_hook.is_linked());
 
   while (true) {
     if (sched->IsShutdown()) {
@@ -464,7 +463,6 @@ Scheduler::~Scheduler() {
 
   while (HasReady()) {
     FiberInterface* fi = PopReady();
-    DCHECK(!fi->wait_hook.is_linked());
     DCHECK(!fi->sleep_hook.is_linked());
     fi->SwitchTo();
   }

--- a/util/fibers/detail/scheduler.h
+++ b/util/fibers/detail/scheduler.h
@@ -42,7 +42,8 @@ class Scheduler {
 
   ::boost::context::fiber_context Preempt();
 
-  void WaitUntil(std::chrono::steady_clock::time_point tp, FiberInterface* me);
+  // Returns true if the fiber timed out by reaching tp.
+  bool WaitUntil(std::chrono::steady_clock::time_point tp, FiberInterface* me);
 
   // Assumes HasReady() is true.
   FiberInterface* PopReady() {

--- a/util/fibers/detail/wait_queue.cc
+++ b/util/fibers/detail/wait_queue.cc
@@ -30,7 +30,5 @@ void WaitQueue::NotifyImpl(uint32_t epoch, FiberInterface* suspended, FiberInter
 }
 
 }  // namespace detail
-
 }  // namespace fb2
-
 }  // namespace util

--- a/util/fibers/detail/wait_queue.cc
+++ b/util/fibers/detail/wait_queue.cc
@@ -1,0 +1,36 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "util/fibers/detail/wait_queue.h"
+
+#include "base/logging.h"
+#include "util/fibers/detail/fiber_interface.h"
+
+namespace util {
+namespace fb2 {
+namespace detail {
+
+[[maybe_unused]] constexpr size_t WakeOtherkSizeOfWaitQ = sizeof(WaitQueue);
+
+void WaitQueue::NotifyAll(FiberInterface* active) {
+  while (!wait_list_.empty()) {
+    Waiter* waiter = &wait_list_.front();
+    wait_list_.pop_front();
+
+    FiberInterface* cntx = waiter->cntx();
+    DVLOG(2) << "Scheduling " << cntx->name() << " from " << active->name();
+
+    active->WakeOther(waiter->epoch(),  cntx);
+  }
+}
+
+void WaitQueue::NotifyImpl(uint32_t epoch, FiberInterface* suspended, FiberInterface* active) {
+  active->WakeOther(epoch, suspended);
+}
+
+}  // namespace detail
+
+}  // namespace fb2
+
+}  // namespace util

--- a/util/fibers/detail/wait_queue.h
+++ b/util/fibers/detail/wait_queue.h
@@ -1,0 +1,86 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <boost/intrusive/slist.hpp>
+
+namespace util {
+namespace fb2 {
+namespace detail {
+
+class FiberInterface;
+
+class Waiter {
+  friend class FiberInterface;
+
+  explicit Waiter(FiberInterface* cntx, uint32_t epoch) : cntx_(cntx), epoch_(epoch) {
+  }
+
+ public:
+  using ListHookType =
+      boost::intrusive::slist_member_hook<boost::intrusive::link_mode<boost::intrusive::safe_link>>;
+
+
+  FiberInterface* cntx() const {
+    return cntx_;
+  }
+
+  uint32_t epoch() const {
+    return epoch_;
+  }
+
+  bool IsLinked() const {
+    return wait_hook.is_linked();
+  }
+
+  ListHookType wait_hook;
+
+ private:
+  FiberInterface* cntx_;
+  uint32_t epoch_;
+};
+
+class WaitQueue {
+ public:
+  bool empty() const {
+    return wait_list_.empty();
+  }
+
+  void Register(Waiter* waiter) {
+    wait_list_.push_back(*waiter);
+  }
+
+  void Unregister(Waiter* waiter) {
+    auto it = WaitList::s_iterator_to(*waiter);
+    wait_list_.erase(it);
+  }
+
+  bool NotifyOne(FiberInterface* active) {
+    if (wait_list_.empty())
+      return false;
+
+    Waiter* waiter = &wait_list_.front();
+    wait_list_.pop_front();
+    NotifyImpl(waiter->epoch(), waiter->cntx(), active);
+
+    return true;
+  }
+
+  void NotifyAll(FiberInterface* active);
+
+
+ private:
+  using WaitList = boost::intrusive::slist<
+      Waiter, boost::intrusive::member_hook<Waiter, Waiter::ListHookType, &Waiter::wait_hook>,
+      boost::intrusive::constant_time_size<false>, boost::intrusive::cache_last<true>>;
+
+  void NotifyImpl(uint32_t epoch, FiberInterface* suspended, FiberInterface* active);
+
+  WaitList wait_list_;
+};
+
+}  // namespace detail
+}  // namespace fb2
+}  // namespace util

--- a/util/fibers/detail/wait_queue.h
+++ b/util/fibers/detail/wait_queue.h
@@ -48,11 +48,11 @@ class WaitQueue {
     return wait_list_.empty();
   }
 
-  void Register(Waiter* waiter) {
+  void Link(Waiter* waiter) {
     wait_list_.push_back(*waiter);
   }
 
-  void Unregister(Waiter* waiter) {
+  void Unlink(Waiter* waiter) {
     auto it = WaitList::s_iterator_to(*waiter);
     wait_list_.erase(it);
   }

--- a/util/fibers/epoll_proactor.cc
+++ b/util/fibers/epoll_proactor.cc
@@ -303,7 +303,6 @@ void EpollProactor::MainLoop(detail::Scheduler* scheduler) {
 
       DVLOG(2) << "Switching to " << fi->name();
       fi->SwitchTo();
-      DCHECK(!dispatcher->wait_hook.is_linked());
       cqe_count = 1;
     }
 

--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -589,6 +589,28 @@ TEST_P(ProactorTest, Timeout) {
   producer_fb.Join();
 }
 
+TEST_P(ProactorTest, Mutex) {
+  unique_ptr<ProactorThread> ths[kNumThreads];
+  Fiber fbs[kNumThreads];
+
+  for (unsigned i = 0; i < kNumThreads; ++i) {
+    ths[i] = CreateProactorThread();
+  }
+
+  Mutex mu;
+
+  for (unsigned i = 0; i < kNumThreads; ++i) {
+    fbs[i] = ths[i]->get()->LaunchFiber([&] {
+      lock_guard lk(mu);
+    });
+  }
+
+  for (auto& fb : fbs)
+    fb.Join();
+
+  for (auto& th : ths)
+    th.reset();
+}
 
 }  // namespace fb2
 }  // namespace util

--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -266,7 +266,6 @@ TEST_F(FiberTest, EventCount) {
   ec.notify();
   fb.Join();
 
-  ASSERT_FALSE(detail::FiberActive()->wait_hook.is_linked());
   EXPECT_EQ(std::cv_status::timeout,
             ec.await_until([] { return false; }, chrono::steady_clock::now() + 10ms));
 
@@ -292,6 +291,50 @@ TEST_F(FiberTest, EventCount) {
   EXPECT_EQ(std::cv_status::timeout, ec.await_until([&] { return signal; }, next));
   fb3.Join();
 }
+
+TEST_F(FiberTest, EventCountMT) {
+  EventCount ec1, ec2;
+  atomic_uint32_t cnt{0}, gate{0};
+  constexpr unsigned kNumIters = 1000;
+
+  array<thread, 5> threads;
+  for (auto& th : threads) {
+    th = thread([&] {
+      Fiber fb2("producer", [&] {
+        for (unsigned i = 0; i < kNumIters; ++i) {
+          ec2.await([&] {
+            return gate.load(memory_order_relaxed) == i;
+          });
+          ThisFiber::SleepFor(1us);
+          if (cnt.fetch_add(1, memory_order_relaxed) == threads.size() - 1)
+            ec1.notify();
+        }
+      });
+      fb2.Join();
+    });
+  }
+
+  unsigned preempts = 0;
+
+  Fiber fb(Launch::dispatch, "fb1", [&] {
+    for (unsigned i = 0; i < kNumIters; ++i) {
+      gate.store(i, memory_order_release);
+      ec2.notifyAll();
+
+      preempts += ec1.await([&] {
+        return cnt.load(memory_order_relaxed) == threads.size();
+      });
+      cnt.store(0, memory_order_relaxed);
+    }
+  });
+
+  fb.Join();
+  for (auto& th : threads) {
+    th.join();
+  }
+  LOG(INFO) << "Preempts: " << preempts;
+}
+
 
 TEST_F(FiberTest, Future) {
   Promise<int> p1;

--- a/util/fibers/synchronization.cc
+++ b/util/fibers/synchronization.cc
@@ -11,24 +11,67 @@ namespace fb2 {
 
 using namespace std;
 
+std::cv_status EventCount::wait_until(uint32_t epoch,
+                                      const std::chrono::steady_clock::time_point& tp) noexcept {
+  detail::FiberInterface* active = detail::FiberActive();
+
+  cv_status status = cv_status::no_timeout;
+
+  std::unique_lock lk(lock_);
+  if ((val_.load(std::memory_order_relaxed) >> kEpochShift) == epoch) {
+    detail::Waiter waiter(active->CreateWaiter());
+
+    wait_queue_.Link(&waiter);
+    lk.unlock();
+
+    bool timed_out = active->WaitUntil(tp);
+    bool clear_remote = true;
+
+    // We must protect wait_hook because we modify it in notification thread.
+    lk.lock();
+
+    if (waiter.IsLinked()) {
+      assert(!wait_queue_.empty());
+
+      // We were woken up by timeout, lets remove ourselves from the queue.
+      wait_queue_.Unlink(&waiter);
+      DCHECK(timed_out);
+      status = cv_status::timeout;
+      clear_remote = false;
+    } else if (timed_out) {
+      status = cv_status::timeout;
+    }
+    lk.unlock();
+
+    if (clear_remote &&
+        MPSC_intrusive_load_next(*active) != (detail::FiberInterface*)detail::kRemoteFree) {
+      // will eventually switch to the dispatcher loop, which will call ProcessRemoteReady, which
+      // will clear the remote_next pointer.
+      active->Yield();
+      CHECK_EQ(detail::kRemoteFree, (uintptr_t)MPSC_intrusive_load_next(*active));
+    }
+  }
+  return status;
+}
+
 void Mutex::lock() {
   detail::FiberInterface* active = detail::FiberActive();
-  detail::Waiter waiter(active->CreateWaiter());
+
 
   while (true) {
-    {
-      unique_lock lk(wait_queue_splk_);
+    detail::Waiter waiter(active->CreateWaiter());
+    wait_queue_splk_.lock();
+    if (nullptr == owner_) {
+      DCHECK(!waiter.IsLinked());
 
-      if (nullptr == owner_) {
-        DCHECK(!waiter.IsLinked());
-
-        owner_ = active;
-        return;
-      }
-
-      CHECK(active != owner_);
-      wait_queue_.Register(&waiter);
+      owner_ = active;
+      wait_queue_splk_.unlock();
+      return;
     }
+
+    CHECK(active != owner_);
+    wait_queue_.Link(&waiter);
+    wait_queue_splk_.unlock();
     active->Suspend();
   }
 }

--- a/util/fibers/synchronization.h
+++ b/util/fibers/synchronization.h
@@ -14,11 +14,12 @@ namespace fb2 {
 
 namespace detail {
 
-using WaitQueue = boost::intrusive::slist<
+/*using WaitQueue2 = boost::intrusive::slist<
     detail::FiberInterface,
     boost::intrusive::member_hook<detail::FiberInterface, detail::FI_ListHook,
                                   &detail::FiberInterface::wait_hook>,
     boost::intrusive::constant_time_size<false>, boost::intrusive::cache_last<true>>;
+*/
 
 }  // namespace detail
 
@@ -154,13 +155,15 @@ class CondVarAny {
 
   template <typename LockType> void wait(LockType& lt) {
     detail::FiberInterface* active = detail::FiberActive();
-    assert(!active->wait_hook.is_linked());
+
+    detail::Waiter waiter(active->CreateWaiter());
 
     // atomically call lt.unlock() and block on *this
     // store this fiber in waiting-queue
     wait_queue_splk_.lock();
     lt.unlock();
-    wait_queue_.push_back(*active);
+
+    wait_queue_.Register(&waiter);
     wait_queue_splk_.unlock();
     active->Suspend();
 
@@ -181,22 +184,23 @@ class CondVarAny {
   template <typename LockType>
   std::cv_status wait_until(LockType& lt, std::chrono::steady_clock::time_point tp) {
     detail::FiberInterface* active = detail::FiberActive();
-    assert(!active->wait_hook.is_linked());
 
     std::cv_status status = std::cv_status::no_timeout;
+    detail::Waiter waiter(active->CreateWaiter());
 
     // atomically call lt.unlock() and block on *this
     // store this fiber in waiting-queue
     wait_queue_splk_.lock();
     lt.unlock();
-    wait_queue_.push_back(*active);
+    wait_queue_.Register(&waiter);
     wait_queue_splk_.unlock();
+
     active->WaitUntil(tp);
 
     wait_queue_splk_.lock();
-    if (active->wait_hook.is_linked()) {
-      auto it = detail::WaitQueue::s_iterator_to(*active);
-      wait_queue_.erase(it);
+    if (waiter.IsLinked()) {
+      wait_queue_.Unregister(&waiter);
+
       status = std::cv_status::timeout;
     }
     wait_queue_splk_.unlock();
@@ -489,31 +493,12 @@ inline bool EventCount::notify() noexcept {
 
   if (prev & kWaiterMask) {
     detail::FiberInterface* active = detail::FiberActive();
-    assert(!active->wait_hook.is_linked());
 
-#if 1
     std::unique_lock lk(lock_);
 
-    if (!wait_queue_.empty()) {
-      detail::FiberInterface* fi = &wait_queue_.front();
-      wait_queue_.pop_front();
-      // At this point we know that fi exists still exists.
-      // but if fi is remote and we cross unlock, it can timeout and destroy itself.
-      // Therefore, we call ActivateOther under lock.
-      active->ActivateOther(fi);
-      lk.unlock();
-
-      return true;
-    }
-
-#else
-    detail::FiberInterface* dest = active->NotifyParked(uintptr_t(this));
-    if (dest) {
-      return true;
-    }
-
-#endif
+    return wait_queue_.NotifyOne(active);
   }
+
   return false;
 }
 
@@ -522,27 +507,12 @@ inline bool EventCount::notifyAll() noexcept {
 
   if (prev & kWaiterMask) {
     detail::FiberInterface* active = detail::FiberActive();
-    assert(!active->wait_hook.is_linked());
 
-#if 1
-    decltype(wait_queue_) tmp_queue;
-    {
-      std::unique_lock holder(lock_);
-      tmp_queue.swap(wait_queue_);
+    std::unique_lock lk(lock_);
 
-      // fi may be remote and when we cross unlock, it can timeout and destroy itself.
-      // therefore we call ActivateOther under lock.
-      while (!tmp_queue.empty()) {
-        detail::FiberInterface* fi = &tmp_queue.front();
-        tmp_queue.pop_front();
-        active->ActivateOther(fi);
-      }
-    }
+    wait_queue_.NotifyAll(active);
 
-#else
-    active->NotifyAllParked(uintptr_t(this));
     return true;
-#endif
   }
 
   return false;
@@ -551,47 +521,40 @@ inline bool EventCount::notifyAll() noexcept {
 // Atomically checks for epoch and waits on cond_var.
 inline bool EventCount::wait(uint32_t epoch) noexcept {
   detail::FiberInterface* active = detail::FiberActive();
-  assert(!active->wait_hook.is_linked());
 
-#if 1
   std::unique_lock lk(lock_);
   if ((val_.load(std::memory_order_relaxed) >> kEpochShift) == epoch) {
-
-    wait_queue_.push_back(*active);
+    detail::Waiter waiter(active->CreateWaiter());
+    wait_queue_.Register(&waiter);
     lk.unlock();
     active->Suspend();
     return true;
   }
   return false;
-#else
-  return active->SuspendConditionally(uintptr_t(this), [&] {
-    return (val_.load(std::memory_order_relaxed) >> kEpochShift) != epoch;
-  });
-#endif
 }
 
 inline std::cv_status EventCount::wait_until(
     uint32_t epoch, const std::chrono::steady_clock::time_point& tp) noexcept {
   detail::FiberInterface* active = detail::FiberActive();
-  assert(!active->wait_hook.is_linked());
 
   cv_status status = cv_status::no_timeout;
 
   std::unique_lock lk(lock_);
   if ((val_.load(std::memory_order_relaxed) >> kEpochShift) == epoch) {
-    wait_queue_.push_back(*active);
+    detail::Waiter waiter(active->CreateWaiter());
+
+    wait_queue_.Register(&waiter);
     lk.unlock();
 
     active->WaitUntil(tp);
 
     // We must protect wait_hook because we modify it in notification thread.
     lk.lock();
-    if (active->wait_hook.is_linked()) {
+    if (waiter.IsLinked()) {
       assert(!wait_queue_.empty());
 
       // We were woken up by timeout, lets remove ourselves from the queue.
-      auto it = detail::WaitQueue::s_iterator_to(*active);
-      wait_queue_.erase(it);
+      wait_queue_.Unregister(&waiter);
       status = cv_status::timeout;
     }
   }

--- a/util/fibers/uring_proactor.cc
+++ b/util/fibers/uring_proactor.cc
@@ -575,7 +575,6 @@ void UringProactor::MainLoop(detail::Scheduler* scheduler) {
       DVLOG(2) << "Switching to " << fi->name();
 
       fi->SwitchTo();
-      DCHECK(!dispatcher->wait_hook.is_linked());
     }
 
     if (cqe_count) {


### PR DESCRIPTION
The fix addresses #92 

Specifically, it introduces a dedicated WaitQueue and Waiter objects that allow registering into a wait list before suspending. 
Now, `FiberInterface::wait_link` was removed and fibers register via  intrusive `Waiter` object on stack. 

Moreover, the old approach of preventing the double booking int remote ready queue was removed and now we prevent double booking by unloading remote-ready queue in case the active fiber was added to it.

I also introduced an epoch-based notification mechanism, but I am not sure it's needed so I added `LOG(FATAL)` check to test it. We should notify exactly once based on the WaitQueue and we should not have dangling notifications, therefore I expect we won't have late notifications now. 