### PR TITLE
fix: move rt library dependency to fibers2 lib

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(base hash.cc histogram.cc init.cc logging.cc proc_util.cc
 
 # atomic is not present on Fedora. I suspect it's not needed on ubuntu as well
 # removing it for now.
-cxx_link(base glog::glog absl::flags_parse rt # rt for timer_create etc.
+cxx_link(base glog::glog absl::flags_parse
          absl::strings absl::symbolize absl::time absl::failure_signal_handler TRDP::xxhash)
 
 # Define default gtest_main for tests.

--- a/util/fibers/CMakeLists.txt
+++ b/util/fibers/CMakeLists.txt
@@ -1,5 +1,5 @@
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
-  set(FB_LINUX_LIBS TRDP::uring)
+  set(FB_LINUX_LIBS TRDP::uring rt) # rt is required for timerfd_create
   set(FB_LINUX_SRCS uring_proactor.cc ../uring/uring_socket.cc ../uring/uring_file.cc)
 endif()
 


### PR DESCRIPTION
Also, add it for Linux only.