### PR TITLE
feat(TlsSocket): add ownership semantics to TlsSocket

### DIFF
--- a/examples/echo_server.cc
+++ b/examples/echo_server.cc
@@ -173,16 +173,15 @@ void EchoConnection::HandleRequests() {
   uint8_t buf[8];
 
   int yes = 1;
-  LinuxSocketBase* sock = (LinuxSocketBase*)socket_.get();
   if (GetFlag(FLAGS_tcp_nodelay)) {
-    CHECK_EQ(0, setsockopt(sock->native_handle(), IPPROTO_TCP, TCP_NODELAY, &yes, sizeof(yes)));
+    CHECK_EQ(0, setsockopt(socket_->native_handle(), IPPROTO_TCP, TCP_NODELAY, &yes, sizeof(yes)));
   }
 
   connections.IncBy(1);
   vec[0].iov_base = buf;
   vec[0].iov_len = 8;
 
-  auto ep = sock->RemoteEndpoint();
+  auto ep = socket_->RemoteEndpoint();
 
   VLOG(1) << "New connection from " << ep;
 
@@ -320,7 +319,7 @@ void RunServer(ProactorPool* pp) {
 }
 
 class Driver {
-  std::unique_ptr<LinuxSocketBase> socket_;
+  std::unique_ptr<FiberSocketBase> socket_;
 
   Driver(const Driver&) = delete;
 

--- a/util/accept_server.h
+++ b/util/accept_server.h
@@ -6,6 +6,7 @@
 
 #include <functional>
 #include <vector>
+#include <memory>
 
 #include "util/connection.h"
 #include "util/fibers/synchronization.h"

--- a/util/connection.h
+++ b/util/connection.h
@@ -5,6 +5,7 @@
 
 #include <boost/intrusive/slist.hpp>
 #include <functional>
+#include <memory>
 
 #include "util/fiber_socket_base.h"
 

--- a/util/fiber_socket_base.h
+++ b/util/fiber_socket_base.h
@@ -92,7 +92,7 @@ class FiberSocketBase : public io::Sink, public io::AsyncSink, public io::Source
   //! in process of completing.
   virtual uint32_t CancelPoll(uint32_t id) = 0;
 
-  virtual  bool IsUDS() const = 0;
+  virtual bool IsUDS() const = 0;
   virtual bool IsDirect() const = 0;
 
   using native_handle_type = int;
@@ -101,7 +101,8 @@ class FiberSocketBase : public io::Sink, public io::AsyncSink, public io::Source
   /// Creates a socket. By default with AF_INET family (2).
   virtual error_code Create(unsigned short protocol_family = 2) = 0;
 
-  virtual ABSL_MUST_USE_RESULT error_code Bind(const struct sockaddr* bind_addr, unsigned addr_len) = 0;
+  virtual ABSL_MUST_USE_RESULT error_code Bind(const struct sockaddr* bind_addr,
+                                               unsigned addr_len) = 0;
   virtual ABSL_MUST_USE_RESULT error_code Listen(unsigned backlog) = 0;
 
   // Listens on all interfaces. If port is 0 then a random available port is chosen
@@ -109,7 +110,8 @@ class FiberSocketBase : public io::Sink, public io::AsyncSink, public io::Source
   virtual ABSL_MUST_USE_RESULT error_code Listen(uint16_t port, unsigned backlog) = 0;
 
   // Listen on UDS socket. Must be created with Create(AF_UNIX) first.
-  virtual ABSL_MUST_USE_RESULT error_code ListenUDS(const char* path, mode_t permissions, unsigned backlog)= 0;
+  virtual ABSL_MUST_USE_RESULT error_code ListenUDS(const char* path, mode_t permissions,
+                                                    unsigned backlog) = 0;
 
  protected:
   virtual void OnSetProactor() {
@@ -141,7 +143,8 @@ class LinuxSocketBase : public FiberSocketBase {
   /// Creates a socket. By default with AF_INET family (2).
   error_code Create(unsigned short protocol_family = 2) override;
 
-  ABSL_MUST_USE_RESULT error_code Bind(const struct sockaddr* bind_addr, unsigned addr_len) override;
+  ABSL_MUST_USE_RESULT error_code Bind(const struct sockaddr* bind_addr,
+                                       unsigned addr_len) override;
   ABSL_MUST_USE_RESULT error_code Listen(unsigned backlog) override;
 
   // Listens on all interfaces. If port is 0 then a random available port is chosen
@@ -149,7 +152,8 @@ class LinuxSocketBase : public FiberSocketBase {
   ABSL_MUST_USE_RESULT error_code Listen(uint16_t port, unsigned backlog) override;
 
   // Listen on UDS socket. Must be created with Create(AF_UNIX) first.
-  ABSL_MUST_USE_RESULT error_code ListenUDS(const char* path, mode_t permissions, unsigned backlog)override;
+  ABSL_MUST_USE_RESULT error_code ListenUDS(const char* path, mode_t permissions,
+                                            unsigned backlog) override;
 
   error_code Shutdown(int how) override;
 

--- a/util/fibers/accept_server.cc
+++ b/util/fibers/accept_server.cc
@@ -103,7 +103,7 @@ error_code AcceptServer::AddListener(const char* bind_addr, uint16_t port,
 
   ProactorBase* next = pool_->GetNextProactor();
 
-  unique_ptr<LinuxSocketBase> fs{next->CreateSocket()};
+  unique_ptr<FiberSocketBase> fs{next->CreateSocket()};
   DCHECK(fs);
 
   error_code ec;
@@ -154,7 +154,7 @@ error_code AcceptServer::AddUDSListener(const char* path, mode_t permissions,
   CHECK(listener && !listener->socket());
 
   ProactorBase* next = pool_->GetNextProactor();
-  unique_ptr<LinuxSocketBase> fs{next->CreateSocket()};
+  unique_ptr<FiberSocketBase> fs{next->CreateSocket()};
 
   error_code ec = next->Await([&] {
     error_code ec = fs->Create(AF_UNIX);

--- a/util/fibers/listener_interface.cc
+++ b/util/fibers/listener_interface.cc
@@ -30,13 +30,12 @@ using fibers_ext::Await;
 
 namespace {
 
-auto native_handle(const LinuxSocketBase& sock) {
+auto native_handle(const FiberSocketBase& sock) {
   return sock.native_handle();
 }
 
 auto native_handle(const Connection& conn) {
-  const LinuxSocketBase* ls = static_cast<const LinuxSocketBase*>(conn.socket());
-  return ls->native_handle();
+  return conn.socket()->native_handle();
 }
 
 using ListType =
@@ -114,7 +113,7 @@ void ListenerInterface::RunAcceptLoop() {
       break;
     }
 
-    unique_ptr<LinuxSocketBase> peer{static_cast<LinuxSocketBase*>(res.value())};
+    unique_ptr<FiberSocketBase> peer{res.value()};
 
     VSOCK(2, *peer) << "Accepted " << peer->RemoteEndpoint();
 
@@ -222,7 +221,7 @@ error_code ListenerInterface::ConfigureServerSocket(int fd) {
   return ec;
 }
 
-fb2::ProactorBase* ListenerInterface::PickConnectionProactor(LinuxSocketBase* sock) {
+fb2::ProactorBase* ListenerInterface::PickConnectionProactor(FiberSocketBase* sock) {
   return pool_->GetNextProactor();
 }
 

--- a/util/fibers/proactor_base.h
+++ b/util/fibers/proactor_base.h
@@ -19,6 +19,7 @@
 #include "util/fibers/detail/result_mover.h"
 #include "util/fibers/synchronization.h"
 #include "util/fibers/fibers.h"
+#include "util/fiber_socket_base.h"
 
 namespace util {
 class LinuxSocketBase;
@@ -57,7 +58,7 @@ class ProactorBase  {
   void Stop();
 
   //! Creates a socket that can be used with this proactor.
-  virtual LinuxSocketBase* CreateSocket(int fd = -1) = 0;
+  virtual FiberSocketBase* CreateSocket(int fd = -1) = 0;
 
   /**
    * @brief Returns true if the called is running in this Proactor thread.

--- a/util/http/http_client.cc
+++ b/util/http/http_client.cc
@@ -14,13 +14,11 @@
 #include <boost/beast/http/write.hpp>
 
 #include "base/logging.h"
-
 #include "util/fiber_socket_base.h"
+#include "util/fibers/dns_resolve.h"
+#include "util/fibers/proactor_base.h"
 #include "util/tls/tls_engine.h"
 #include "util/tls/tls_socket.h"
-
-#include "util/fibers/proactor_base.h"
-#include "util/fibers/dns_resolve.h"
 
 namespace util {
 namespace http {
@@ -164,8 +162,7 @@ std::error_code TlsClient::Connect(string_view host, string_view service, SSL_CT
 
   std::error_code ec = Client::Connect(host, service);
   if (!ec) {
-    tcp_socket_.reset(socket_.release());
-    std::unique_ptr<TlsSocket> tls_socket(new TlsSocket(std::move(tcp_socket_)));
+    std::unique_ptr<TlsSocket> tls_socket(std::make_unique<TlsSocket>(socket_.release()));
     tls_socket->InitSSL(context);
 
     const std::string& hn = Client::host();

--- a/util/http/http_client.h
+++ b/util/http/http_client.h
@@ -180,11 +180,6 @@ class TlsClient : public Client {
    *  @param context a valid SSL context that was created with the function CreateSslContext
    */
   std::error_code Connect(std::string_view host, std::string_view service, SSL_CTX* context);
-
- private:
-  // holds the socket that was generated with the base class, it should live as long as we're
-  // connected.
-  std::unique_ptr<FiberSocketBase> tcp_socket_;
 };
 
 }  // namespace http

--- a/util/listener_interface.h
+++ b/util/listener_interface.h
@@ -49,7 +49,7 @@ class ListenerInterface {
   // bind is called.
   virtual std::error_code ConfigureServerSocket(int fd);
 
-  virtual fb2::ProactorBase* PickConnectionProactor(LinuxSocketBase* sock);
+  virtual fb2::ProactorBase* PickConnectionProactor(FiberSocketBase* sock);
 
   // This callback should not preempt because we traverse the list of connections
   // without locking it.
@@ -66,7 +66,7 @@ class ListenerInterface {
   // Updates socket_ and listener interface bookeepings.
   void Migrate(Connection* conn, fb2::ProactorBase* dest);
 
-  LinuxSocketBase* socket() {
+  FiberSocketBase* socket() {
     return sock_.get();
   }
 
@@ -90,7 +90,7 @@ class ListenerInterface {
 
   static thread_local std::unordered_map<ListenerInterface*, TLConnList*> conn_list;
 
-  std::unique_ptr<LinuxSocketBase> sock_;
+  std::unique_ptr<FiberSocketBase> sock_;
 
   ProactorPool* pool_ = nullptr;
   friend class AcceptServer;

--- a/util/tls/tls_engine_test.cc
+++ b/util/tls/tls_engine_test.cc
@@ -333,11 +333,6 @@ TEST_F(SslStreamTest, Write) {
   }
 }
 
-
-TEST_F(SslStreamTest, Socket) {
-  TlsSocket socket;
-}
-
 void BM_TlsWrite(benchmark::State& state) {
   unique_ptr<Engine> client_engine, server_engine;
   SslStreamTest::Options sopts{"srv"}, copts{"client"};

--- a/util/tls/tls_socket.cc
+++ b/util/tls/tls_socket.cc
@@ -62,6 +62,9 @@ TlsSocket::TlsSocket(std::unique_ptr<FiberSocketBase> next)
     : FiberSocketBase(next ? next->proactor() : nullptr), next_sock_(std::move(next)) {
 }
 
+TlsSocket::TlsSocket(FiberSocketBase* next) : TlsSocket(std::unique_ptr<FiberSocketBase>(next)) {
+}
+
 TlsSocket::~TlsSocket() {
 }
 

--- a/util/tls/tls_socket.cc
+++ b/util/tls/tls_socket.cc
@@ -6,6 +6,8 @@
 
 #include <openssl/err.h>
 
+#include <algorithm>
+
 #include "base/logging.h"
 #include "util/tls/tls_engine.h"
 
@@ -56,8 +58,8 @@ inline error_code SSL2Error(unsigned long err) {
 
 }  // namespace
 
-TlsSocket::TlsSocket(FiberSocketBase* next)
-    : FiberSocketBase(next ? next->proactor() : nullptr), next_sock_(next) {
+TlsSocket::TlsSocket(std::unique_ptr<FiberSocketBase> next)
+    : FiberSocketBase(next ? next->proactor() : nullptr), next_sock_(std::move(next)) {
 }
 
 TlsSocket::~TlsSocket() {
@@ -70,8 +72,7 @@ void TlsSocket::InitSSL(SSL_CTX* context) {
 
 auto TlsSocket::Shutdown(int how) -> error_code {
   DCHECK(engine_);
-
-  return error_code{};
+  return next_sock_->Shutdown(how);
 }
 
 auto TlsSocket::Accept() -> AcceptResult {
@@ -106,20 +107,19 @@ auto TlsSocket::Accept() -> AcceptResult {
   return nullptr;
 }
 
-auto TlsSocket::Connect(const endpoint_type&) -> error_code {
+auto TlsSocket::Connect(const endpoint_type& endpoint) -> error_code {
   DCHECK(engine_);
   auto io_result = engine_->Handshake(Engine::HandshakeType::CLIENT);
-  if (io_result.has_value()) {
-    return std::error_code{};
-  } else {
+  if (!io_result.has_value()) {
     return std::error_code(io_result.error(), std::system_category());
   }
 
-  return error_code{};
+  return next_sock_->Connect(endpoint);
 }
 
 auto TlsSocket::Close() -> error_code {
   DCHECK(engine_);
+  next_sock_->Close();
 
   return error_code{};
 }
@@ -312,6 +312,59 @@ TlsSocket::Buffer TlsSocket::GetCachedBuffer() const {
 void TlsSocket::PlaceBufferInCache(Buffer buffer, size_t n_bytes) {
   cached_bytes_ = buffer;
   n_bytes_ = n_bytes;
+}
+
+TlsSocket::endpoint_type TlsSocket::LocalEndpoint() const {
+  return next_sock_->LocalEndpoint();
+}
+
+TlsSocket::endpoint_type TlsSocket::RemoteEndpoint() const {
+  return next_sock_->RemoteEndpoint();
+}
+
+uint32_t TlsSocket::PollEvent(uint32_t event_mask, std::function<void(uint32_t)> cb) {
+  return next_sock_->PollEvent(event_mask, cb);
+}
+
+uint32_t TlsSocket::CancelPoll(uint32_t id) {
+  return next_sock_->CancelPoll(id);
+}
+
+bool TlsSocket::IsUDS() const {
+  return next_sock_->IsUDS();
+}
+
+TlsSocket::native_handle_type TlsSocket::native_handle() const {
+  return next_sock_->native_handle();
+}
+
+bool TlsSocket::IsDirect() const {
+  return next_sock_->IsDirect();
+}
+
+error_code TlsSocket::Create(unsigned short protocol_family) {
+  return next_sock_->Create(protocol_family);
+}
+
+error_code TlsSocket::Bind(const struct sockaddr* bind_addr, unsigned addr_len) {
+  return next_sock_->Bind(bind_addr, addr_len);
+}
+
+error_code TlsSocket::Listen(unsigned backlog) {
+  return next_sock_->Listen(backlog);
+}
+
+error_code TlsSocket::Listen(uint16_t port, unsigned backlog) {
+  return next_sock_->Listen(port, backlog);
+}
+
+error_code TlsSocket::ListenUDS(const char* path, mode_t permissions, unsigned backlog) {
+  return next_sock_->ListenUDS(path, permissions, backlog);
+}
+
+void TlsSocket::SetProactor(ProactorBase* p) {
+  next_sock_->SetProactor(p);
+  FiberSocketBase::SetProactor(p);
 }
 
 }  // namespace tls

--- a/util/tls/tls_socket.h
+++ b/util/tls/tls_socket.h
@@ -18,7 +18,10 @@ class Engine;
 
 class TlsSocket : public FiberSocketBase {
  public:
-  TlsSocket(std::unique_ptr<FiberSocketBase>);
+  TlsSocket(std::unique_ptr<FiberSocketBase> next);
+
+  // Takes ownership of next
+  TlsSocket(FiberSocketBase* next);
 
   ~TlsSocket();
 

--- a/util/tls/tls_socket.h
+++ b/util/tls/tls_socket.h
@@ -6,6 +6,8 @@
 
 #include <openssl/ssl.h>
 
+#include <memory>
+
 #include "util/fiber_socket_base.h"
 #include "util/tls/tls_engine.h"
 
@@ -16,9 +18,7 @@ class Engine;
 
 class TlsSocket : public FiberSocketBase {
  public:
-  //! Does not take ownership over next. 'next' must be live as long as we use
-  //! TlsSocket instance.
-  TlsSocket(FiberSocketBase* next = nullptr);
+  TlsSocket(std::unique_ptr<FiberSocketBase>);
 
   ~TlsSocket();
 
@@ -56,12 +56,38 @@ class TlsSocket : public FiberSocketBase {
   Buffer GetCachedBuffer() const;
 
   void PlaceBufferInCache(Buffer buffer, size_t n_bytes);
+  using FiberSocketBase::endpoint_type;
+  endpoint_type LocalEndpoint() const override;
+  endpoint_type RemoteEndpoint() const override;
+
+  uint32_t PollEvent(uint32_t event_mask, std::function<void(uint32_t)> cb) override;
+
+  uint32_t CancelPoll(uint32_t id) override;
+
+  bool IsUDS() const override;
+  bool IsDirect() const override;
+
+  using FiberSocketBase::native_handle_type;
+  native_handle_type native_handle() const override;
+
+  error_code Create(unsigned short protocol_family = 2) override;
+
+  ABSL_MUST_USE_RESULT error_code Bind(const struct sockaddr* bind_addr,
+                                       unsigned addr_len) override;
+  ABSL_MUST_USE_RESULT error_code Listen(unsigned backlog) override;
+
+  ABSL_MUST_USE_RESULT error_code Listen(uint16_t port, unsigned backlog) override;
+
+  ABSL_MUST_USE_RESULT error_code ListenUDS(const char* path, mode_t permissions,
+                                            unsigned backlog) override;
+
+  virtual void SetProactor(ProactorBase* p) override;
 
  private:
   error_code MaybeSendOutput();
   error_code HandleRead();
 
-  FiberSocketBase* next_sock_;
+  std::unique_ptr<FiberSocketBase> next_sock_;
   std::unique_ptr<Engine> engine_;
 
   // Used to signal HandleRead() to cache the first n_bytes


### PR DESCRIPTION
TlsSocket is constructed by a pointer to the next socket, effectively acting as a decorator/proxy object of the underline socket. This however is problematic, because once a connection upgrades to tls, you now need to keep alive two different objects with whose lifetime semantics are bound. Therefore, we make TlsSocket own the underline socket, to avoid decoupling the lifetime of the two sockets.