### PR TITLE
Cleanup the <memory_resource> include mess.

### DIFF
--- a/base/pmr/arena.h
+++ b/base/pmr/arena.h
@@ -7,15 +7,16 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <memory_resource>
 #include <vector>
+
+#include "memory_resource.h"
 
 namespace base {
 
 // Used to allocate small blobs with size upto 4GB.
 class PmrArena {
  public:
-  PmrArena(std::pmr::memory_resource* mr = std::pmr::get_default_resource());
+  PmrArena(PMR_NS::memory_resource* mr = PMR_NS::get_default_resource());
   ~PmrArena();
 
   // Return a pointer to a newly allocated memory block of "bytes" bytes.
@@ -37,7 +38,7 @@ class PmrArena {
   char* AllocateFallback(size_t bytes);
   char* AllocateNewBlock(uint32_t block_bytes);
 
-  std::pmr::memory_resource* mr_;
+  PMR_NS::memory_resource* mr_;
 
   // Allocation state
   char* alloc_ptr_ = nullptr;
@@ -54,7 +55,7 @@ class PmrArena {
   static_assert(sizeof(Block) == 12);
 
   // Array of the allocated memory blocks
-  std::pmr::vector<Block> blocks_;
+  PMR_NS::vector<Block> blocks_;
 
   // No copying allowed
   PmrArena(const PmrArena&) = delete;

--- a/base/pmr/memory_resource.h
+++ b/base/pmr/memory_resource.h
@@ -1,0 +1,12 @@
+#pragma once
+/// A workaround for libc++ versions with only experimental memory_resource support.
+
+#include <version>
+
+#if defined(__clang__) && !defined(__cpp_lib_memory_resource)
+#include <experimental/memory_resource>
+namespace PMR_NS = std::experimental::pmr;
+#else
+#include <memory_resource>
+namespace PMR_NS = std::pmr;
+#endif

--- a/base/pmr/pod_array.h
+++ b/base/pmr/pod_array.h
@@ -5,22 +5,15 @@
 //
 #pragma once
 
+#include <absl/base/macros.h>
+#include <absl/numeric/bits.h>
 #include <string.h>
 
 #include <algorithm>
 #include <cstddef>
 #include <memory>
 
-#if defined(__clang__) && defined(__APPLE__)
-#include <experimental/memory_resource>
-#define PMR_NS std::experimental::pmr
-#else
-#include <memory_resource>
-#define PMR_NS std::pmr
-#endif
-
-#include <absl/base/macros.h>
-#include <absl/numeric/bits.h>
+#include "base/pmr/memory_resource.h"
 
 namespace base {
 
@@ -388,5 +381,3 @@ void swap(PODArray<T, pad_right_>& lhs, PODArray<T, pad_right_>& rhs) {
 }
 
 }  // namespace base
-
-#undef PMR_NS

--- a/util/http/http_main.cc
+++ b/util/http/http_main.cc
@@ -37,10 +37,10 @@ metrics::CounterFamily http_req("http_requests_total", "Number of served http re
 
 class MyListener : public HttpListener<> {
  public:
-  ProactorBase* PickConnectionProactor(LinuxSocketBase* sock);
+  ProactorBase* PickConnectionProactor(FiberSocketBase* sock);
 };
 
-ProactorBase* MyListener::PickConnectionProactor(LinuxSocketBase* sock) {
+ProactorBase* MyListener::PickConnectionProactor(FiberSocketBase* sock) {
   int fd = sock->native_handle();
 
   int cpu;

--- a/util/proactor_pool.h
+++ b/util/proactor_pool.h
@@ -6,12 +6,10 @@
 
 #include <absl/container/flat_hash_set.h>
 
-#if defined(__linux__)
-#include <memory_resource>
-#endif
 #include <string_view>
 
 #include "base/RWSpinLock.h"
+#include "base/pmr/memory_resource.h"
 #include "base/type_traits.h"
 #include "util/fibers/proactor_base.h"
 
@@ -230,7 +228,7 @@ class ProactorPool {
 
 #if defined(__linux__)
   // clang on my mac (13.0) does not have monotonic_buffer_resource yet.
-  std::pmr::monotonic_buffer_resource str_arena_;
+  PMR_NS::monotonic_buffer_resource str_arena_;
 #endif
 
   enum State { STOPPED, RUN } state_ = STOPPED;


### PR DESCRIPTION
We did some recent changes I think, so now we have errors - https://github.com/dragonflydb/dragonfly/actions/runs/5601507387/jobs/10245489679?pr=1525#step:7:1297.

I can compile dragonfly locally with Clang after this change.