### PR TITLE
fix: fix non-linux set nonblocking

### DIFF
--- a/util/fiber_socket_base.h
+++ b/util/fiber_socket_base.h
@@ -196,6 +196,10 @@ class LinuxSocketBase : public FiberSocketBase {
   int32_t fd_;
 };
 
+void SetNonBlocking(int fd);
+
+void SetCloexec(int fd);
+
 #if 0
 class SocketSource : public io::Source {
  public:

--- a/util/fibers/epoll_socket.cc
+++ b/util/fibers/epoll_socket.cc
@@ -73,8 +73,8 @@ int AcceptSock(int fd) {
   socklen_t addr_len = sizeof(client_addr);
   int res = accept(fd, (struct sockaddr*)&client_addr, &addr_len);
   if (res >= 0) {
-    int prev = fcntl(res, F_GETFL, 0);
-    fcntl(res, F_SETFL, prev | FD_CLOEXEC | O_NONBLOCK);
+    SetNonBlocking(fd);
+    SetCloexec(fd);
   }
 
   return res;
@@ -83,8 +83,8 @@ int AcceptSock(int fd) {
 int CreateSockFd() {
   int fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
   if (fd >= 0) {
-    int prev = fcntl(fd, F_GETFL, 0);
-    fcntl(fd, F_SETFL, prev | FD_CLOEXEC | O_NONBLOCK);
+    SetNonBlocking(fd);
+    SetCloexec(fd);
   }
   return fd;
 }

--- a/util/fibers/fiber_socket_base.cc
+++ b/util/fibers/fiber_socket_base.cc
@@ -82,8 +82,8 @@ error_code LinuxSocketBase::Create(unsigned short pfamily) {
     return ec;
 
 #ifndef __linux__
-  int prev = fcntl(fd, F_GETFL, 0);
-  CHECK_EQ(0, fcntl(fd, F_SETFL, prev | FD_CLOEXEC | O_NONBLOCK));
+  SetNonBlocking(fd);
+  SetCloexec(fd);
 #endif
   fd_ = fd << kFdShift;
   if (pfamily == AF_UNIX) {
@@ -220,6 +220,16 @@ auto LinuxSocketBase::RemoteEndpoint() const -> endpoint_type {
     endpoint.resize(addr_len);
 
   return endpoint;
+}
+
+void SetNonBlocking(int fd) {
+  int flags = fcntl(fd, F_GETFL, 0);
+  CHECK_EQ(0, fcntl(fd, F_SETFL, flags | O_NONBLOCK));
+}
+
+void SetCloexec(int fd) {
+  int flags = fcntl(fd, F_GETFD, 0);
+  CHECK_EQ(0, fcntl(fd, F_SETFD, flags | FD_CLOEXEC));
 }
 
 }  // namespace util


### PR DESCRIPTION
Running locally found `EpollSocket::Accept` was just blocking forever and never suspending the fiber - looks like `FD_CLOEXEC` is being set with `F_SETFL` instead of `F_SETFD` which is then breaking `O_NONBLOCK`

@romange this is part of the cause of the deadlock you mentioned (if `Accept` never releases the fiber the accept loop never finishes so `AcceptServer::Stop` blocks in the test tear down) - though theres then another issue where `shutdown` isn't waking up the `accept` fiber so it still blocks `Stop` (will look at that separately)