### PR TITLE
fix: fix accept server test with epoll

### DIFF
--- a/util/accept_server_test.cc
+++ b/util/accept_server_test.cc
@@ -61,7 +61,7 @@ class AcceptServerTest : public testing::Test {
   void SetUp() override;
 
   void TearDown() override {
-    client_sock_->Close();
+    client_sock_->proactor()->Await([&] { client_sock_->Close(); });
     as_->Stop(true);
     pp_->Stop();
   }

--- a/util/fibers/epoll_socket.cc
+++ b/util/fibers/epoll_socket.cc
@@ -118,6 +118,8 @@ EpollSocket::~EpollSocket() {
 auto EpollSocket::Close() -> error_code {
   error_code ec;
   if (fd_ >= 0) {
+    DCHECK_EQ(GetProactor()->thread_id(), pthread_self());
+
     int fd = native_handle();
     DVSOCK(1) << "Closing socket";
     GetProactor()->Disarm(fd, arm_index_);

--- a/util/uring/uring_socket.cc
+++ b/util/uring/uring_socket.cc
@@ -51,6 +51,8 @@ UringSocket::~UringSocket() {
 auto UringSocket::Close() -> error_code {
   error_code ec;
   if (fd_ >= 0) {
+    DCHECK_EQ(GetProactor()->thread_id(), pthread_self());
+
     DVSOCK(1) << "Closing socket";
 
     int fd = native_handle();


### PR DESCRIPTION
Fixes running the accept server tests with `epoll` (setting `USE_URING` to false). Before the socket was being closed by the wrong thread so hitting the `EpollProactor::Disarm` assertion (https://github.com/romange/helio/blob/0ec06cf8277ebb2e976afdda4f7304fc64010884/util/fibers/epoll_proactor.cc#L372)

Or is epoll meant to support closing from a different thread?

(Note `kqueue` still blocks on tear down due to the `shutdown` not waking the accept fiber issue)