### PR TITLE
fix: wake kqueue socket on shutdown

### DIFF
--- a/util/fibers/epoll_socket.h
+++ b/util/fibers/epoll_socket.h
@@ -32,6 +32,8 @@ class EpollSocket : public LinuxSocketBase {
   Result<size_t> RecvMsg(const msghdr& msg, int flags) override;
   Result<size_t> Recv(const io::MutableBytes& mb, int flags = 0) override;
 
+  error_code Shutdown(int how) override;
+
   //! Subsribes to one-shot poll. event_mask is a mask of POLLXXX values.
   //! When and an event occurs, the cb will be called with the mask of actual events
   //! that trigerred it.


### PR DESCRIPTION
As mentioned in https://github.com/romange/helio/pull/111, `shutdown` doesn't seem to wake up the socket accept fiber (can't find any reference to this but running locally getting the same behaviour, wheras `epoll` is woken)

With this the accept server tests pass ok as the accept fiber no longer blocks on tear down (theres some other failures on MacOS but they seem unrelatex)

This seemed simpler than using `EVFILT_USER` since AFAICT the trigger must include the `centries_` index, which the socket doesn't know, and it requires calling back to the proactor, which notifies the kqueue, which calls `Wakey`, so seemed easier just to call directly? It is still a bit hacky - the `#ifndef __linux__` is probably redundant but figured better to include to be safe