### PR TITLE
chore: disable dchecks in socket d-tors

### DIFF
--- a/util/fibers/epoll_socket.cc
+++ b/util/fibers/epoll_socket.cc
@@ -109,7 +109,7 @@ EpollSocket::EpollSocket(int fd) : LinuxSocketBase(fd, nullptr) {
 }
 
 EpollSocket::~EpollSocket() {
-  DCHECK_LT(fd_, 0) << "Socket must have been closed explicitly.";
+  // DCHECK_LT(fd_, 0) << "Socket must have been closed explicitly.";
   error_code ec = Close();  // Quietly close.
 
   LOG_IF(WARNING, ec) << "Error closing socket " << ec << "/" << ec.message();

--- a/util/uring/uring_socket.cc
+++ b/util/uring/uring_socket.cc
@@ -42,7 +42,7 @@ auto Unexpected(std::errc e) {
 }  // namespace
 
 UringSocket::~UringSocket() {
-  DCHECK_LT(fd_, 0) << "Socket must have been closed explicitly.";
+  // DCHECK_LT(fd_, 0) << "Socket must have been closed explicitly.";
   error_code ec = Close();  // Quietly close.
 
   LOG_IF(WARNING, ec) << "Error closing socket " << ec << "/" << ec.message();


### PR DESCRIPTION
We will reenable them once Dragonfly is kosher
for this change.