### PR TITLE
Fix bug in EpollSocket::RecvMsg

### DIFF
--- a/util/fibers/detail/fiber_interface.cc
+++ b/util/fibers/detail/fiber_interface.cc
@@ -218,6 +218,7 @@ void FiberInterface::Join() {
 }
 
 void FiberInterface::ActivateOther(FiberInterface* other) {
+  DVLOG(1) << "Activating " << other->name() << " from " << this->name();
   DCHECK(other->scheduler_);
 
   // Check first if we the fiber belongs to the active thread.
@@ -232,6 +233,7 @@ void FiberInterface::ActivateOther(FiberInterface* other) {
 }
 
 void FiberInterface::WakeOther(uint32_t epoch, FiberInterface* other) {
+  DVLOG(1) << "Waking " << other->name() << " from " << this->name();
   DCHECK(other->scheduler_);
 
   uint32_t next = epoch + 1;

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -500,6 +500,8 @@ ctx::fiber_context Scheduler::Preempt() {
 
 void Scheduler::AddReady(FiberInterface* fibi) {
   DCHECK(!fibi->list_hook.is_linked());
+  DVLOG(1) << "Adding " << fibi->name() << " to ready_queue_";
+
   ready_queue_.push_back(*fibi);
 
   // Case of notifications coming to a sleeping fiber.

--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -615,9 +615,6 @@ TEST_P(ProactorTest, Mutex) {
 }
 
 TEST_P(ProactorTest, DragonflyBug1591) {
-  unique_ptr<ProactorThread> ths[kNumThreads];
-  Fiber fbs[kNumThreads];
-
   auto sock = std::unique_ptr<FiberSocketBase>(proactor()->CreateSocket());
   auto sock2 = std::unique_ptr<FiberSocketBase>(proactor()->CreateSocket());
 


### PR DESCRIPTION
Fixes [dragonflydb/dragonfly/1591](https://github.com/dragonflydb/dragonfly/issues/1591)

The problem is that a code path in `EpollSocket::RecvMsg` would not reset `read_context_` so fibers would resume at random suspend points outside.