### PR TITLE
Remove usage of pool_ for threads estimate as it can be uninitialized.

### DIFF
--- a/util/fibers/listener_interface.cc
+++ b/util/fibers/listener_interface.cc
@@ -278,9 +278,9 @@ void ListenerInterface::SetMaxClients(uint32_t max_clients) {
   max_clients_ = max_clients;
 
   // We usually have 2 open files per proactor and ~10 more open files
-  // for the rest. Taking 32 as a reasonable maximum bound.
-  const uint32_t kResidualOpenFiles = 32;
-  uint32_t wanted_limit = 2 * pool_->size() + max_clients + kResidualOpenFiles;
+  // for the rest. Taking 150 as a reasonable upper bound.
+  const uint32_t kResidualOpenFiles = 150;
+  uint32_t wanted_limit = max_clients + kResidualOpenFiles;
 
   struct rlimit lim;
   if (getrlimit(RLIMIT_NOFILE, &lim) == -1) {


### PR DESCRIPTION
I was trying to be clever by including the number of threads in the estimation, turns out this is annoying because `pool_` can be null.

This time at I also have the Dragonfly side already done with tests so we don't have to do any more ping-pong :)