### PR TITLE
ring_buffer: Add tests coverage and clean-up the interface a bit.

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_library(base hash.cc histogram.cc init.cc logging.cc proc_util.cc
-            pthread_utils.cc varz_node.cc cuckoo_map.cc io_buf.cc)
+    pthread_utils.cc varz_node.cc cuckoo_map.cc io_buf.cc)
 
 # atomic is not present on Fedora. I suspect it's not needed on ubuntu as well
 # removing it for now.
 cxx_link(base glog::glog absl::flags_parse
-         absl::strings absl::symbolize absl::time absl::failure_signal_handler TRDP::xxhash)
+    absl::strings absl::symbolize absl::time absl::failure_signal_handler TRDP::xxhash)
 
 # Define default gtest_main for tests.
 add_library(gtest_main_ext gtest_main.cc)
@@ -24,4 +24,5 @@ endif()
 
 cxx_test(flit_test base LABELS CI)
 cxx_test(cxx_test base absl::flat_hash_map LABELS CI)
-cxx_test(string_view_sso_test base base LABELS CI)
+cxx_test(string_view_sso_test base LABELS CI)
+cxx_test(ring_buffer_test base LABELS CI)

--- a/base/ring_buffer.h
+++ b/base/ring_buffer.h
@@ -3,69 +3,70 @@
 //
 #pragma once
 
+#include <cassert>
 #include <climits>
 #include <memory>
+#include <utility>
 
 namespace base {
 
 // Simple, single-threaded ring buffer.
+// T must be default constructible.
 template <typename T> class RingBuffer {
  public:
   using value_type = T;
 
-  // cap must be power of 2.
-  RingBuffer(unsigned cap) : capacity_(cap) {
+  explicit RingBuffer(unsigned cap) : capacity_(cap) {
     buf_.reset(new T[cap]);
     mask_ = cap - 1;
+    // cap must be power of 2.
+    assert((mask_ & capacity_) == 0);
   }
 
   unsigned size() const {
     return tail_ - head_;
   }
 
-  bool empty() const {
+  [[nodiscard]] bool empty() const {
     return tail_ == head_;
+  }
+
+  [[nodiscard]] bool Full() const {
+    return tail_ - head_ == capacity_;
   }
 
   // Try to inserts into tail of the buffer.
   template <typename U> bool TryEmplace(U&& u) {
-    // due to how 2s compliment work, this check works even in case of overflows.
-    // for example,
-    constexpr unsigned kHead = UINT_MAX;
-    constexpr unsigned kTail = kHead + 10;
-    static_assert(kTail == 9);
-    static_assert(kTail - kHead == 10);
-
-    if (tail_ - head_ < capacity_) {
-      buf_[tail_ & mask_] = std::forward<U>(u);
-      ++tail_;
-      return true;
+    T* slot = GetTail();
+    if (slot) {
+      *slot = std::forward<U>(u);
     }
-    return false;
+    return bool(slot);
   }
 
   // Inserts into tail. If buffer is full overrides the first inserted item at head
   // and keeps the ring at maximal capacity.
   // Returns true if an item was overriden and false otherwise.
   template <typename U> bool EmplaceOrOverride(U&& u) {
-    buf_[tail_ & mask_] = std::forward<U>(u);
-    ++tail_;
-    if (tail_ <= head_ + capacity_) {
-      return false;
-    }
-
-    ++head_;  // override.
-    return true;
+    bool is_full = Full();
+    *GetTail(/*override=*/true) = std::forward<U>(u);
+    return is_full;
   }
 
-  // Gets the pointer to the next tail entry, or null if buffer is full
-  // advances the tail to the next position.
-  T* GetTail() {
+  // Gets a pointer to the next tail entry, if `override` is set, override existing
+  // entries when needed.
+  // Advances the tail to the next position.
+  [[nodiscard]] T* GetTail(bool override = false) {
     T* res = nullptr;
-    if (tail_ - head_ < capacity_) {
-      res = buf_.get() + (tail_ & mask_);
-      ++tail_;
+    if (Full()) {
+      if (override)
+        head_++;
+      else
+        return res;
     }
+
+    res = buf_.get() + (tail_ & mask_);
+    ++tail_;
     return res;
   }
 
@@ -83,14 +84,19 @@ template <typename T> class RingBuffer {
     return capacity_;
   }
 
-  // Zero-copy deque interface.
-  // Returns pointer to array of length size().
-  T* GetItem(unsigned index) {
-    return buf_.get() + ((head_ + index) & mask_);
+  T& operator[](unsigned index) {
+    assert(index < size());
+    return buf_[(head_ + index) & mask_];
+  }
+
+  const T& operator[](unsigned index) const {
+    assert(index < size());
+    return buf_[(head_ + index) & mask_];
   }
 
   // Requires: n <= size()
   void ConsumeHead(unsigned n) {
+    assert(n <= size());
     head_ += n;
   }
 

--- a/base/ring_buffer_test.cc
+++ b/base/ring_buffer_test.cc
@@ -1,0 +1,67 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "base/ring_buffer.h"
+
+#include <gtest/gtest.h>
+
+#include "base/gtest.h"
+
+TEST(ring_buffer, simple) {
+  base::RingBuffer<int> buf(4);
+
+  EXPECT_EQ(buf.capacity(), 4);
+
+  for (size_t i = 0; i < 23; i++)
+    buf.EmplaceOrOverride(i);
+
+  EXPECT_EQ(buf.size(), 4);
+  EXPECT_FALSE(buf.empty());
+  EXPECT_TRUE(buf.Full());
+
+  EXPECT_EQ(buf[0], 19);
+  EXPECT_EQ(buf[1], 20);
+  EXPECT_EQ(buf[2], 21);
+  EXPECT_EQ(buf[3], 22);
+
+  buf.ConsumeHead(2);
+  EXPECT_EQ(buf.size(), 2);
+  EXPECT_FALSE(buf.empty());
+  EXPECT_FALSE(buf.Full());
+  EXPECT_EQ(buf[0], 21);
+  EXPECT_EQ(buf[1], 22);
+
+  int res;
+  EXPECT_TRUE(buf.TryDeque(res));
+  EXPECT_EQ(res, 21);
+  EXPECT_TRUE(buf.TryDeque(res));
+  EXPECT_EQ(res, 22);
+  EXPECT_FALSE(buf.TryDeque(res));
+
+  EXPECT_EQ(buf.size(), 0);
+  EXPECT_TRUE(buf.empty());
+  EXPECT_FALSE(buf.Full());
+}
+
+TEST(ring_buffer, TryEmplace) {
+  base::RingBuffer<int> buf(4);
+
+  EXPECT_TRUE(buf.TryEmplace(4));
+  for (size_t i = 0; i < 4; i++)
+    buf.EmplaceOrOverride(i);
+  EXPECT_FALSE(buf.TryEmplace(4));
+}
+
+TEST(ring_buffer, GetTail) {
+  base::RingBuffer<int> buf(4);
+
+  EXPECT_TRUE(buf.GetTail());
+  EXPECT_EQ(buf.size(), 1);
+
+  for (size_t i = 0; i < 4; i++)
+    buf.EmplaceOrOverride(i);
+
+  EXPECT_FALSE(buf.GetTail());
+  EXPECT_TRUE(buf.GetTail(/*override=*/true));
+}


### PR DESCRIPTION
1. Add testing coverage and a bunch of `[D]CHECK`s
2. Slightly improve (IMO) the exposed functions. In particular, the new `GetTail` allows optional overriding which will allow reusing resources without having to construct a new intermediate object.

Part of the road towards partial sync :)