### PR TITLE
feat(http): Add authentication support

### DIFF
--- a/util/http/http_handler.cc
+++ b/util/http/http_handler.cc
@@ -372,10 +372,10 @@ bool HttpConnection::CheckRequestAuthorization(const RequestType& req, HttpConte
 
   bool authenticated = false;
   if (const boost::string_view header = req[h2::field::authorization]; !header.empty()) {
-    if (header.substr(0, 6) == "Basic ") {
-      boost::string_view encoded_login = header.substr(6);
+    std::string_view header_stl{header.data(), header.size()};
+    if (absl::StartsWith(header_stl, "Basic ")) {
       std::string decoded;
-      absl::Base64Unescape({encoded_login.data(), encoded_login.size()}, &decoded);
+      absl::Base64Unescape(header_stl.substr(6), &decoded);
       auto split_pos = decoded.find(':');
       if (split_pos != std::string::npos) {
         std::string username = decoded.substr(0, split_pos);

--- a/util/http/http_handler.cc
+++ b/util/http/http_handler.cc
@@ -387,7 +387,7 @@ bool HttpConnection::CheckRequestAuthorization(const RequestType& req, HttpConte
     }
   }
 
-  if (!owner_->password_.empty() && !authenticated) {
+  if (!authenticated) {
     h2::response<h2::string_body> resp{h2::status::unauthorized, req.version()};
     resp.set(h2::field::content_type, "text/plain");
     resp.set(h2::field::www_authenticate, "Basic realm=\"Restricted Area\"");
@@ -402,7 +402,7 @@ bool HttpConnection::CheckRequestAuthorization(const RequestType& req, HttpConte
 void HttpConnection::HandleSingleRequest(const RequestType& req, HttpContext* cntx) {
   CHECK(owner_);
 
-  if (!CheckRequestAuthorization(req, cntx))
+  if (!owner_->password_.empty() && !CheckRequestAuthorization(req, cntx))
     return;
 
   if (owner_->HandleRoot(req, cntx)) {

--- a/util/http/http_main.cc
+++ b/util/http/http_main.cc
@@ -23,6 +23,7 @@
 ABSL_FLAG(uint32_t, port, 8080, "Port number.");
 ABSL_FLAG(bool, use_incoming_cpu, false,
           "If true uses incoming cpu of a socket in order to distribute incoming connections");
+ABSL_FLAG(std::string, password, "", "Protect the web interface with this password.");
 
 using namespace std;
 using namespace util;
@@ -63,6 +64,7 @@ void ServerRun(ProactorPool* pool) {
   http_req.Init(pool, {"type", "handle"});
 
   HttpListener<>* listener = new MyListener;
+  listener->SetPassword(absl::GetFlag(FLAGS_password));
   auto cb = [](const http::QueryArgs& args, HttpContext* send) {
     http::StringResponse resp = http::MakeStringResponse(h2::status::ok);
     resp.body() = "Bar";


### PR DESCRIPTION
We should probably protect the metrics page somehow, this is the quickest way to do it.

This is currently untested because testing is kind of a hassle (no http unit tests at all currently). However I tested it works locally and I'm willing to write a Python test with `requests` once it's merged :)
