### PR TITLE
An attempt fixing the bug with inconsistent state in fibers

### DIFF
--- a/base/mpsc_intrusive_queue.h
+++ b/base/mpsc_intrusive_queue.h
@@ -47,6 +47,7 @@ template <typename T> class MPSCIntrusiveQueue {
   MPSCIntrusiveQueue& operator=(MPSCIntrusiveQueue const&) = delete;
 
   // Pushes an item to the queue on producer thread.
+  // The queue grows from the tail.
   void Push(T* item) noexcept {
     // item becomes a new tail.
     MPSC_intrusive_store_next(item, nullptr);
@@ -56,6 +57,7 @@ template <typename T> class MPSCIntrusiveQueue {
     MPSC_intrusive_store_next(prev, item);
   }
 
+  // Poops the first item at the head or returns nullptr if the queue is empty.
   T* Pop() noexcept;
 
   // Can be run only on a consumer thread.

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -523,7 +523,7 @@ void Scheduler::ScheduleFromRemote(FiberInterface* cntx) {
   }
 
   if (cntx->IsScheduledRemotely()) {
-    // We schedule a fiber remotely one once.
+    // We schedule a fiber remotely only once.
     // This should not happen in general, because we usually schedule a fiber under
     // a spinlock when pulling it from the WaitQueue. However, there are ActivateOther calls
     // that happen due to I/O events that might break this assumption. To see if this happens,

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -511,18 +511,42 @@ void Scheduler::AddReady(FiberInterface* fibi) {
 }
 
 void Scheduler::ScheduleFromRemote(FiberInterface* cntx) {
-  DCHECK(cntx->remote_next_.load(memory_order_relaxed) == (FiberInterface*)kRemoteFree);
+  // This function is called from FiberInterface::ActivateOther from a remote scheduler.
+  // But the fiber belongs to this scheduler.
+  DCHECK(cntx->scheduler_ == this);
 
-  intrusive_ptr_add_ref(cntx);
-  remote_ready_queue_.Push(cntx);
+  // If someone else holds the bit - give up on scheduling by this call.
+  if ((cntx->flags_.fetch_or(FiberInterface::kScheduleRemote, memory_order_acquire) &
+       FiberInterface::kScheduleRemote) == 1) {
+    DVLOG(1) << "Already scheduled remotely " << cntx->name();
+    return;
+  }
 
-  DVLOG(1) << "ScheduleFromRemote " << cntx->name() << " " << cntx->use_count_.load();
+  if (cntx->IsScheduledRemotely()) {
+    // We schedule a fiber remotely one once.
+    // This should not happen in general, because we usually schedule a fiber under
+    // a spinlock when pulling it from the WaitQueue. However, there are ActivateOther calls
+    // that happen due to I/O events that might break this assumption. To see if this happens,
+    // I log the case and will investigate if it happens.
+    LOG(WARNING) << "Fiber " << cntx->name() << " is already scheduled remotely";
 
-  if (custom_policy_) {
-    custom_policy_->Notify();
+    // revert the flags.
+    cntx->flags_.fetch_and(~FiberInterface::kScheduleRemote, memory_order_release);
   } else {
-    DispatcherImpl* dimpl = static_cast<DispatcherImpl*>(dispatch_cntx_.get());
-    dimpl->Notify();
+    intrusive_ptr_add_ref(cntx);
+    remote_ready_queue_.Push(cntx);
+
+    // clear the bit after we pushed to the queue.
+    cntx->flags_.fetch_and(~FiberInterface::kScheduleRemote, memory_order_release);
+
+    DVLOG(1) << "ScheduleFromRemote " << cntx->name() << " " << cntx->use_count_.load();
+
+    if (custom_policy_) {
+      custom_policy_->Notify();
+    } else {
+      DispatcherImpl* dimpl = static_cast<DispatcherImpl*>(dispatch_cntx_.get());
+      dimpl->Notify();
+    }
   }
 }
 
@@ -572,7 +596,7 @@ void Scheduler::ProcessRemoteReady() {
       break;
 
     // Marks as free.
-    fi->remote_next_.store((FiberInterface*)kRemoteFree, memory_order_relaxed);
+    fi->remote_next_.store((FiberInterface*)FiberInterface::kRemoteFree, memory_order_relaxed);
 
     DVLOG(1) << "Pulled " << fi->name() << " " << fi->DEBUG_use_count();
 
@@ -585,7 +609,7 @@ void Scheduler::ProcessRemoteReady() {
       AddReady(fi);
     }
 
-    // Each time we push fi to remote_ready_queue_ we increase the reference count.
+    // When we push fi to remote_ready_queue_ we increase the reference count.
     intrusive_ptr_release(fi);
   }
 }

--- a/util/fibers/detail/wait_queue.cc
+++ b/util/fibers/detail/wait_queue.cc
@@ -21,12 +21,12 @@ void WaitQueue::NotifyAll(FiberInterface* active) {
     FiberInterface* cntx = waiter->cntx();
     DVLOG(2) << "Scheduling " << cntx->name() << " from " << active->name();
 
-    active->WakeOther(waiter->epoch(), cntx);
+    active->ActivateOther(cntx);
   }
 }
 
-void WaitQueue::NotifyImpl(uint32_t epoch, FiberInterface* suspended, FiberInterface* active) {
-  active->WakeOther(epoch, suspended);
+void WaitQueue::NotifyImpl(FiberInterface* suspended, FiberInterface* active) {
+  active->ActivateOther(suspended);
 }
 
 }  // namespace detail

--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -647,7 +647,7 @@ TEST_P(ProactorTest, DragonflyBug1591) {
     while (next_step < step) {
       ThisFiber::Yield();
     }
-    LOG(WARNING) << "step " << step;
+    LOG(INFO) << "step " << step;
   };
   auto end_step = [&next_step]() { next_step++; };
 

--- a/util/fibers/synchronization.h
+++ b/util/fibers/synchronization.h
@@ -209,8 +209,7 @@ class CondVarAny {
     }
     wait_queue_splk_.unlock();
 
-    if (clear_remote &&
-        MPSC_intrusive_load_next(*active) != (detail::FiberInterface*)detail::kRemoteFree) {
+    if (clear_remote && active->IsScheduledRemotely()) {
       // will eventually switch to the dispatcher loop, which will call ProcessRemoteReady, which
       // will clear the remote_next pointer.
       active->Yield();


### PR DESCRIPTION
Specifically, fix #130.
The code that crashed makes sure that a fiber is not in remote_ready queue when it wakes up: it yields if it is, and thus allows the dispatcher to empty the remote queue and pull the active fiber from there.

The code crashes because after the Yield call, it appears that the fiber is still in the remote queue. Based on the code inspection, it seems unprobable that a dispatcher won't empty the remote queue, therefore I suspect that remote queue was corrupted in the first place.

This fix focuses on ScheduleFromRemote (producer sider) that before that did not protect against concurrent calls for the same fiber. It was partly justified because ScheduleFromRemote is usually called from the WaitQueue code under lock. However, there are other cases that can call this function, and maybe they corrupted the queue.

In addition, we removed the epoch based notifications which did not contribute to the correctness.