### PR TITLE
fix(s3): fix url encoding s3 path

### DIFF
--- a/util/cloud/s3.cc
+++ b/util/cloud/s3.cc
@@ -259,6 +259,7 @@ io::Result<io::WriteFile*> S3Bucket::OpenWriteFile(std::string_view path) {
   } else {
     full_path = absl::StrCat(bucket_, "/", path);
   }
+
   unique_ptr http_client = std::move(http_client_);
   error_code ec = Connect(http_client->connect_timeout_ms());
   if (ec)

--- a/util/cloud/s3.h
+++ b/util/cloud/s3.h
@@ -22,9 +22,6 @@ using ListObjectsResult = io::Result<std::string>;
 // List all S3 buckets. Refresh AWS token if needed.
 ListBucketsResult ListS3Buckets(AWS* aws, http::Client* http_client);
 
-// Please note that all S3 paths should already be url encoded.
-// We can not do inside S3Bucket because then "/" will be encoded as well.
-// We expect that each path component is already encoded and "/" is being preserved.
 class S3Bucket {
  public:
   S3Bucket(const S3Bucket&) = delete;


### PR DESCRIPTION
Fixes https://github.com/dragonflydb/controlplane/issues/225, where if the bucket or key includes a character that AWS expects to be URL encoded, the signature will be invalid

AWS defines their own URL path encoding in https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html:
```
URI encode every byte. UriEncode() must enforce the following rules:
- URI encode every byte except the unreserved characters: 'A'-'Z', 'a'-'z', '0'-'9', '-', '.', '_', and '~'.
- The space character is a reserved character and must be encoded as "%20" (and not as "+").
- Each URI encoded byte is formed by a '%' and the two-digit hexadecimal value of the byte.
- Letters in the hexadecimal value must be uppercase, for example "%1A".
- Encode the forward slash character, '/', everywhere except in the object key name. For example, if the object key name is photos/Jan/sample.jpg, the forward slash in the key name is not encoded.

The standard UriEncode functions provided by your development platform may not work because of differences in implementation and related ambiguity in the underlying RFCs. We recommend that you write your own custom UriEncode function to ensure that your encoding will work.
```

This implementation is ported from the Go SDK https://github.com/aws/aws-sdk-go/blob/main/private/protocol/rest/build.go#L261