### PR TITLE
feat(s3): pass ownership of http client to s3 read file

### DIFF
--- a/util/cloud/aws.h
+++ b/util/cloud/aws.h
@@ -68,6 +68,7 @@ class AWS {
     connection_data_.region = region;
   }
 
+  // Init must be run in a proactor thread.
   std::error_code Init();
 
   const AwsConnectionData& connection_data() const {

--- a/util/cloud/s3.cc
+++ b/util/cloud/s3.cc
@@ -255,7 +255,7 @@ io::Result<io::ReadonlyFile*> S3Bucket::OpenReadFile(string_view path,
   if (ec)
     return make_unexpected(ec);
 
-  return OpenS3ReadFile(region_, full_path, aws_, http_client.release(), opts);
+  return OpenS3ReadFile(region_, full_path, aws_, std::move(http_client), opts);
 }
 
 io::Result<io::WriteFile*> S3Bucket::OpenWriteFile(std::string_view path) {
@@ -271,7 +271,7 @@ io::Result<io::WriteFile*> S3Bucket::OpenWriteFile(std::string_view path) {
   if (ec)
     return make_unexpected(ec);
 
-  return OpenS3WriteFile(region_, full_path, aws_, http_client.release());
+  return OpenS3WriteFile(region_, full_path, aws_, std::move(http_client));
 }
 
 string S3Bucket::GetHost() const {

--- a/util/cloud/s3_file.h
+++ b/util/cloud/s3_file.h
@@ -12,12 +12,13 @@ namespace util {
 namespace cloud {
 
 io::Result<io::ReadonlyFile*> OpenS3ReadFile(
-    std::string_view region, std::string_view path, const AWS& aws, http::Client* client,
+    std::string_view region, std::string_view path, const AWS& aws,
+    std::unique_ptr<http::Client> client,
     const io::ReadonlyFile::Options& opts = io::ReadonlyFile::Options{});
 
 // Takes ownership over client.
 io::Result<io::WriteFile*> OpenS3WriteFile(std::string_view region, std::string_view key_path,
-                                           const AWS& aws, http::Client* client);
+                                           const AWS& aws, std::unique_ptr<http::Client> client);
 
 }  // namespace cloud
 }  // namespace util


### PR DESCRIPTION
When opening a read file, pass ownership of the HTTP client to the read file - this matches the behaviour of `OpenWriteFile`

Can refactor more later to make this a bit cleaner, though adding for now to get loading snapshots from S3 working (otherwise the bucket must not be destructed before the file which is messy to implement when the 'S3' file is used as a generic interface)