### PR TITLE
Bump CMakeLists.txt minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.16)
 
 set(PACKAGE_NAME    "helio")
 set(PROJECT_CONTACT romange@gmail.com)


### PR DESCRIPTION
Newer CMakes start giving this error - "Compatibility with CMake < 3.5 will be removed from a future version of CMake."

3.16 is the version installed on Ubuntu 20.04