### PR TITLE
feat(aws): add aws sdk support

### DIFF
--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -337,11 +337,14 @@ add_third_party(
   URL https://github.com/zeux/pugixml/archive/refs/tags/v1.13.tar.gz
 )
 
+set (AWS_PATCH_COMMAND patch -p1 -d ${THIRD_PARTY_DIR}/aws/ -i ${CMAKE_CURRENT_LIST_DIR}/../patches/aws-sdk-cpp-3e51fa016655eeb6b6610bdf8fe7cf33ebbf3e00.patch)
+
 add_third_party(
   aws
   GIT_REPOSITORY https://github.com/aws/aws-sdk-cpp.git
   GIT_TAG 3e51fa016655eeb6b6610bdf8fe7cf33ebbf3e00
   GIT_SHALLOW TRUE
+  PATCH_COMMAND "${AWS_PATCH_COMMAND}"
   CMAKE_PASS_FLAGS "-DBUILD_ONLY=s3 -DNO_HTTP_CLIENT=ON -DENABLE_TESTING=OFF -DAUTORUN_UNIT_TESTS=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_LIBDIR=lib"
   LIB libaws-cpp-sdk-s3.a libaws-cpp-sdk-core.a libaws-crt-cpp.a libaws-c-mqtt.a libaws-c-event-stream.a libaws-c-s3.a libaws-c-auth.a  libaws-c-http.a libaws-c-io.a libs2n.a libaws-c-compression.a libaws-c-cal.a libaws-c-sdkutils.a libaws-checksums.a libaws-c-common.a
 )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,7 +14,7 @@ add_executable(s3_demo s3_demo.cc)
 cxx_link(s3_demo aws_lib)
 
 add_executable(s3v2_demo s3v2_demo.cc)
-cxx_link(s3v2_demo base awsv2_lib)
+cxx_link(s3v2_demo base aws_lib awsv2_lib)
 
 add_executable(https_client_cli https_client_cli.cc)
 cxx_link(https_client_cli base fibers2 http_client_lib tls_lib)

--- a/examples/s3v2_demo.cc
+++ b/examples/s3v2_demo.cc
@@ -27,9 +27,9 @@ ABSL_FLAG(bool, epoll, false, "Whether to use epoll instead of io_uring");
 std::shared_ptr<Aws::S3::S3Client> OpenS3Client() {
   Aws::S3::S3ClientConfiguration s3_conf{};
   std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider =
-      Aws::MakeShared<util::aws::CredentialsProviderChain>("helio");
+      std::make_shared<util::aws::CredentialsProviderChain>();
   std::shared_ptr<Aws::S3::S3EndpointProviderBase> endpoint_provider =
-      Aws::MakeShared<util::aws::S3EndpointProvider>("helio", absl::GetFlag(FLAGS_endpoint));
+      std::make_shared<util::aws::S3EndpointProvider>(absl::GetFlag(FLAGS_endpoint));
   return std::make_shared<Aws::S3::S3Client>(credentials_provider, endpoint_provider, s3_conf);
 }
 

--- a/examples/s3v2_demo.cc
+++ b/examples/s3v2_demo.cc
@@ -1,11 +1,17 @@
 #include "util/aws/aws.h"
 
+#include "base/init.h"
+#include "base/flags.h"
 #include "base/logging.h"
 
+ABSL_FLAG(std::string, cmd, "list-buckets", "Command to run");
+
 int main(int argc, char* argv[]) {
+  MainInitGuard guard(&argc, &argv);
+
   util::aws::Init();
 
-  LOG(INFO) << "s3v2_demo";
+  LOG(INFO) << "s3v2_demo; cmd=" << absl::GetFlag(FLAGS_cmd);
 
   util::aws::Shutdown();
 }

--- a/examples/s3v2_demo.cc
+++ b/examples/s3v2_demo.cc
@@ -1,17 +1,91 @@
-#include "util/aws/aws.h"
+#include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/s3/S3Client.h>
+#include <aws/s3/model/ListObjectsV2Request.h>
+#include <aws/s3/model/PutObjectRequest.h>
 
 #include "base/init.h"
 #include "base/flags.h"
 #include "base/logging.h"
+#include "util/aws/aws.h"
+#include "util/aws/credentials_provider_chain.h"
+#include "util/fibers/pool.h"
 
 ABSL_FLAG(std::string, cmd, "list-buckets", "Command to run");
+ABSL_FLAG(std::string, bucket, "", "S3 bucket name");
+ABSL_FLAG(bool, epoll, false, "Whether to use epoll instead of io_uring");
+
+void ListBuckets() {
+  Aws::S3::S3ClientConfiguration s3_conf{};
+  std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider =
+      Aws::MakeShared<util::aws::CredentialsProviderChain>("helio");
+  Aws::S3::S3Client s3{credentials_provider, Aws::MakeShared<Aws::S3::S3EndpointProvider>("helio"),
+                       s3_conf};
+
+  Aws::S3::Model::ListBucketsOutcome outcome = s3.ListBuckets();
+  if (outcome.IsSuccess()) {
+    std::cout << "buckets:" << std::endl;
+    for (const Aws::S3::Model::Bucket& bucket : outcome.GetResult().GetBuckets()) {
+      std::cout << "* " << bucket.GetName() << std::endl;
+    }
+  } else {
+    LOG(ERROR) << "failed to list buckets: " << outcome.GetError().GetExceptionName();
+  }
+}
+
+void ListObjects(const std::string& bucket) {
+  if (bucket == "") {
+    LOG(ERROR) << "missing bucket name";
+    return;
+  }
+
+  Aws::S3::S3ClientConfiguration s3_conf{};
+  std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider =
+      Aws::MakeShared<util::aws::CredentialsProviderChain>("helio");
+  Aws::S3::S3Client s3{credentials_provider, Aws::MakeShared<Aws::S3::S3EndpointProvider>("helio"),
+                       s3_conf};
+
+  Aws::S3::Model::ListObjectsV2Request request;
+  request.SetBucket(bucket);
+
+  Aws::S3::Model::ListObjectsV2Outcome outcome = s3.ListObjectsV2(request);
+  if (outcome.IsSuccess()) {
+    std::cout << "objects in " << bucket << ":" << std::endl;
+    for (const auto& object : outcome.GetResult().GetContents()) {
+      std::cout << "* " << object.GetKey() << std::endl;
+    }
+  } else {
+    LOG(ERROR) << "failed to list objects: " << outcome.GetError().GetExceptionName();
+  }
+}
 
 int main(int argc, char* argv[]) {
   MainInitGuard guard(&argc, &argv);
 
-  util::aws::Init();
+  std::unique_ptr<util::ProactorPool> pp;
 
-  LOG(INFO) << "s3v2_demo; cmd=" << absl::GetFlag(FLAGS_cmd);
+#ifdef __linux__
+  if (absl::GetFlag(FLAGS_epoll)) {
+    pp.reset(util::fb2::Pool::Epoll());
+  } else {
+    pp.reset(util::fb2::Pool::IOUring(256));
+  }
+#else
+  pp.reset(util::fb2::Pool::Epoll());
+#endif
 
-  util::aws::Shutdown();
+  pp->Run();
+
+  pp->GetNextProactor()->Await([&] {
+    util::aws::Init();
+    std::string cmd = absl::GetFlag(FLAGS_cmd);
+    LOG(INFO) << "s3v2_demo; cmd=" << cmd;
+
+    if (cmd == "list-buckets") {
+      ListBuckets();
+    } else if (cmd == "list-objects") {
+      ListObjects(absl::GetFlag(FLAGS_bucket));
+    }
+
+    util::aws::Shutdown();
+  });
 }

--- a/examples/s3v2_demo.cc
+++ b/examples/s3v2_demo.cc
@@ -29,6 +29,7 @@ ABSL_FLAG(bool, epoll, false, "Whether to use epoll instead of io_uring");
 
 std::shared_ptr<Aws::S3::S3Client> OpenS3Client() {
   Aws::S3::S3ClientConfiguration s3_conf{};
+  s3_conf.payloadSigningPolicy = Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::ForceNever;
   std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider =
       std::make_shared<util::aws::CredentialsProviderChain>();
   std::shared_ptr<Aws::S3::S3EndpointProviderBase> endpoint_provider =

--- a/patches/aws-sdk-cpp-3e51fa016655eeb6b6610bdf8fe7cf33ebbf3e00.patch
+++ b/patches/aws-sdk-cpp-3e51fa016655eeb6b6610bdf8fe7cf33ebbf3e00.patch
@@ -1,0 +1,28 @@
+diff --git a/src/aws-cpp-sdk-core/include/aws/core/http/HttpClient.h b/src/aws-cpp-sdk-core/include/aws/core/http/HttpClient.h
+index cb6e928e7..ca9e1de3c 100644
+--- a/src/aws-cpp-sdk-core/include/aws/core/http/HttpClient.h
++++ b/src/aws-cpp-sdk-core/include/aws/core/http/HttpClient.h
+@@ -51,19 +51,19 @@ namespace Aws
+             /**
+              * Stops all requests in progress and prevents any others from initiating.
+              */
+-            void DisableRequestProcessing();
++            virtual void DisableRequestProcessing();
+             /**
+              * Enables/ReEnables request processing.
+              */
+-            void EnableRequestProcessing();
++            virtual void EnableRequestProcessing();
+             /**
+              * Returns true if request processing is enabled.
+              */
+-            bool IsRequestProcessingEnabled() const;
++            virtual bool IsRequestProcessingEnabled() const;
+             /**
+              * Sleeps current thread for sleepTime.
+              */
+-            void RetryRequestSleep(std::chrono::milliseconds sleepTime);
++            virtual void RetryRequestSleep(std::chrono::milliseconds sleepTime);
+ 
+             bool ContinueRequest(const Aws::Http::HttpRequest&) const;
+ 

--- a/patches/aws-sdk-cpp-3e51fa016655eeb6b6610bdf8fe7cf33ebbf3e00.patch
+++ b/patches/aws-sdk-cpp-3e51fa016655eeb6b6610bdf8fe7cf33ebbf3e00.patch
@@ -1,8 +1,25 @@
+diff --git a/src/aws-cpp-sdk-core/include/aws/core/auth/signer/AWSAuthV4Signer.h b/src/aws-cpp-sdk-core/include/aws/core/auth/signer/AWSAuthV4Signer.h
+index 62b9f91af..4c85d507a 100644
+--- a/src/aws-cpp-sdk-core/include/aws/core/auth/signer/AWSAuthV4Signer.h
++++ b/src/aws-cpp-sdk-core/include/aws/core/auth/signer/AWSAuthV4Signer.h
+@@ -66,7 +66,11 @@ namespace Aws
+                 /**
+                  * Never sign the body of the request
+                  */
+-                Never
++                Never,
++                /**
++                 * Never sign the body of the request, even over HTTP
++                 */
++                ForceNever,
+             };
+             /**
+              * credentialsProvider, source of AWS Credentials to sign requests with
 diff --git a/src/aws-cpp-sdk-core/include/aws/core/http/HttpClient.h b/src/aws-cpp-sdk-core/include/aws/core/http/HttpClient.h
-index cb6e928e7..ca9e1de3c 100644
+index cb6e928e7..49eb87f6d 100644
 --- a/src/aws-cpp-sdk-core/include/aws/core/http/HttpClient.h
 +++ b/src/aws-cpp-sdk-core/include/aws/core/http/HttpClient.h
-@@ -51,19 +51,19 @@ namespace Aws
+@@ -51,21 +51,21 @@ namespace Aws
              /**
               * Stops all requests in progress and prevents any others from initiating.
               */
@@ -24,5 +41,66 @@ index cb6e928e7..ca9e1de3c 100644
 -            void RetryRequestSleep(std::chrono::milliseconds sleepTime);
 +            virtual void RetryRequestSleep(std::chrono::milliseconds sleepTime);
  
-             bool ContinueRequest(const Aws::Http::HttpRequest&) const;
+-            bool ContinueRequest(const Aws::Http::HttpRequest&) const;
++            virtual bool ContinueRequest(const Aws::Http::HttpRequest&) const;
+ 
+             explicit operator bool() const
+             {
+diff --git a/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp b/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp
+index dfe0bfba3..580d83983 100644
+--- a/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp
++++ b/src/aws-cpp-sdk-core/source/auth/signer/AWSAuthV4Signer.cpp
+@@ -36,7 +36,6 @@ static const char* X_AMZ_SIGNED_HEADERS = "X-Amz-SignedHeaders";
+ static const char* X_AMZ_ALGORITHM = "X-Amz-Algorithm";
+ static const char* X_AMZ_CREDENTIAL = "X-Amz-Credential";
+ static const char* UNSIGNED_PAYLOAD = "UNSIGNED-PAYLOAD";
+-static const char* STREAMING_UNSIGNED_PAYLOAD_TRAILER = "STREAMING-UNSIGNED-PAYLOAD-TRAILER";
+ static const char* X_AMZ_SIGNATURE = "X-Amz-Signature";
+ static const char* USER_AGENT = "user-agent";
+ static const char* EMPTY_STRING_SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+@@ -201,6 +200,7 @@ bool AWSAuthV4Signer::SignRequest(Aws::Http::HttpRequest& request, const char* r
+     request.SetSigningAccessKey(credentials.GetAWSAccessKeyId());
+     request.SetSigningRegion(signingRegion);
+ 
++    bool signBodyOverHttp = true;
+     Aws::String payloadHash(UNSIGNED_PAYLOAD);
+     switch(m_payloadSigningPolicy)
+     {
+@@ -210,6 +210,10 @@ bool AWSAuthV4Signer::SignRequest(Aws::Http::HttpRequest& request, const char* r
+         case PayloadSigningPolicy::Never:
+             signBody = false;
+             break;
++        case PayloadSigningPolicy::ForceNever:
++            signBody = false;
++            signBodyOverHttp = false;
++            break;
+         case PayloadSigningPolicy::RequestDependent:
+             // respect the request setting
+         default:
+@@ -228,7 +232,7 @@ bool AWSAuthV4Signer::SignRequest(Aws::Http::HttpRequest& request, const char* r
+         request.SetAwsSessionToken(credentials.GetSessionToken());
+     }
+ 
+-    if(signBody || request.GetUri().GetScheme() != Http::Scheme::HTTPS)
++    if(signBody || (signBodyOverHttp && request.GetUri().GetScheme() != Http::Scheme::HTTPS))
+     {
+         payloadHash = ComputePayloadHash(request);
+         if (payloadHash.empty())
+@@ -249,13 +253,10 @@ bool AWSAuthV4Signer::SignRequest(Aws::Http::HttpRequest& request, const char* r
+                 << " http scheme=" << Http::SchemeMapper::ToString(request.GetUri().GetScheme()));
+         if (request.GetRequestHash().second != nullptr)
+         {
+-            payloadHash = STREAMING_UNSIGNED_PAYLOAD_TRAILER;
+-            Aws::String trailerHeaderValue = Aws::String("x-amz-checksum-") + request.GetRequestHash().first;
+-            request.SetHeaderValue(Http::AWS_TRAILER_HEADER, trailerHeaderValue);
+-            request.SetTransferEncoding(CHUNKED_VALUE);
+-            request.SetHeaderValue(Http::CONTENT_ENCODING_HEADER, Http::AWS_CHUNKED_VALUE);
+-            request.SetHeaderValue(Http::DECODED_CONTENT_LENGTH_HEADER, request.GetHeaderValue(Http::CONTENT_LENGTH_HEADER));
+-            request.DeleteHeader(Http::CONTENT_LENGTH_HEADER);
++            Aws::String checksumHeaderKey = Aws::String("x-amz-checksum-") + request.GetRequestHash().first;
++            Aws::String checksumHeaderValue = HashingUtils::Base64Encode(request.GetRequestHash().second->Calculate(*(request.GetContentBody())).GetResult());
++            request.SetHeaderValue(checksumHeaderKey, checksumHeaderValue);
++            request.SetRequestHash("", nullptr);
+         }
+     }
  

--- a/util/aws/CMakeLists.txt
+++ b/util/aws/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(OpenSSL)
 find_package(ZLIB)
 
-add_library(awsv2_lib aws.cc logger.cc)
+add_library(awsv2_lib aws.cc logger.cc http_client_factory.cc)
 
 if (APPLE)
   find_library(SECURITY Security)

--- a/util/aws/CMakeLists.txt
+++ b/util/aws/CMakeLists.txt
@@ -2,7 +2,8 @@ find_package(OpenSSL)
 find_package(ZLIB)
 
 add_library(awsv2_lib aws.cc credentials_provider_chain.cc logger.cc
-            http_client.cc http_client_factory.cc s3_endpoint_provider.cc)
+            http_client.cc http_client_factory.cc s3_endpoint_provider.cc
+            s3_write_file.cc)
 
 if (APPLE)
   find_library(SECURITY Security)

--- a/util/aws/CMakeLists.txt
+++ b/util/aws/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(OpenSSL)
 find_package(ZLIB)
 
-add_library(awsv2_lib aws.cc)
+add_library(awsv2_lib aws.cc logger.cc)
 
 if (APPLE)
   find_library(SECURITY Security)
@@ -9,7 +9,7 @@ else()
   set(S2N_LIRARY TRDP::s2n)
 endif()
 
-cxx_link(awsv2_lib TRDP::aws-cpp-sdk-s3 TRDP::aws-cpp-sdk-core
+cxx_link(awsv2_lib base TRDP::aws-cpp-sdk-s3 TRDP::aws-cpp-sdk-core
          TRDP::aws-crt-cpp TRDP::aws-c-mqtt TRDP::aws-c-event-stream
          TRDP::aws-c-s3 TRDP::aws-c-auth  TRDP::aws-c-http TRDP::aws-c-io
          ${S2N_LIRARY} TRDP::aws-c-compression TRDP::aws-c-cal TRDP::aws-c-sdkutils

--- a/util/aws/CMakeLists.txt
+++ b/util/aws/CMakeLists.txt
@@ -2,7 +2,7 @@ find_package(OpenSSL)
 find_package(ZLIB)
 
 add_library(awsv2_lib aws.cc credentials_provider_chain.cc logger.cc
-            http_client.cc http_client_factory.cc)
+            http_client.cc http_client_factory.cc s3_endpoint_provider.cc)
 
 if (APPLE)
   find_library(SECURITY Security)

--- a/util/aws/CMakeLists.txt
+++ b/util/aws/CMakeLists.txt
@@ -1,7 +1,8 @@
 find_package(OpenSSL)
 find_package(ZLIB)
 
-add_library(awsv2_lib aws.cc logger.cc http_client_factory.cc)
+add_library(awsv2_lib aws.cc credentials_provider_chain.cc logger.cc
+            http_client.cc http_client_factory.cc)
 
 if (APPLE)
   find_library(SECURITY Security)
@@ -9,7 +10,7 @@ else()
   set(S2N_LIRARY TRDP::s2n)
 endif()
 
-cxx_link(awsv2_lib base TRDP::aws-cpp-sdk-s3 TRDP::aws-cpp-sdk-core
+cxx_link(awsv2_lib base http_utils http_client_lib TRDP::aws-cpp-sdk-s3 TRDP::aws-cpp-sdk-core
          TRDP::aws-crt-cpp TRDP::aws-c-mqtt TRDP::aws-c-event-stream
          TRDP::aws-c-s3 TRDP::aws-c-auth  TRDP::aws-c-http TRDP::aws-c-io
          ${S2N_LIRARY} TRDP::aws-c-compression TRDP::aws-c-cal TRDP::aws-c-sdkutils

--- a/util/aws/CMakeLists.txt
+++ b/util/aws/CMakeLists.txt
@@ -3,7 +3,7 @@ find_package(ZLIB)
 
 add_library(awsv2_lib aws.cc credentials_provider_chain.cc logger.cc
             http_client.cc http_client_factory.cc s3_endpoint_provider.cc
-            s3_write_file.cc)
+            s3_read_file.cc s3_write_file.cc)
 
 if (APPLE)
   find_library(SECURITY Security)

--- a/util/aws/aws.cc
+++ b/util/aws/aws.cc
@@ -24,7 +24,7 @@ void Init() {
   // use trace logging to get all logs from AWS then filter in the logger.
   options.loggingOptions.logger_create_fn =
       []() -> std::shared_ptr<Aws::Utils::Logging::LogSystemInterface> {
-    return Aws::MakeShared<Logger>("helio");
+    return std::make_shared<Logger>();
   };
   options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Trace;
 
@@ -35,7 +35,7 @@ void Init() {
   // We must use non-blocking network IO so use our own fiber based HTTP client.
   options.httpOptions.httpClientFactory_create_fn =
       []() -> std::shared_ptr<Aws::Http::HttpClientFactory> {
-    return Aws::MakeShared<HttpClientFactory>("helio");
+    return std::make_shared<HttpClientFactory>();
   };
 
   Aws::InitAPI(options);

--- a/util/aws/aws.cc
+++ b/util/aws/aws.cc
@@ -4,6 +4,9 @@
 #include "util/aws/aws.h"
 
 #include <aws/core/Aws.h>
+#include <aws/core/utils/logging/LogSystemInterface.h>
+
+#include "util/aws/logger.h"
 
 namespace util {
 namespace aws {
@@ -16,6 +19,14 @@ static Aws::SDKOptions options;
 }  // namespace
 
 void Init() {
+  // Add a glog based logger. The logger handles discarding logs by level so
+  // use trace logging to get all logs from AWS then filter in the logger.
+  options.loggingOptions.logger_create_fn =
+      []() -> std::shared_ptr<Aws::Utils::Logging::LogSystemInterface> {
+    return Aws::MakeShared<Logger>("helio");
+  };
+  options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Trace;
+
   Aws::InitAPI(options);
 }
 

--- a/util/aws/credentials_provider_chain.cc
+++ b/util/aws/credentials_provider_chain.cc
@@ -1,0 +1,26 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#include "util/aws/credentials_provider_chain.h"
+
+#include <aws/core/platform/Environment.h>
+
+#include "base/logging.h"
+
+namespace util {
+namespace aws {
+
+CredentialsProviderChain::CredentialsProviderChain() {
+  AddProvider(Aws::MakeShared<Aws::Auth::EnvironmentAWSCredentialsProvider>("helio"));
+  AddProvider(Aws::MakeShared<Aws::Auth::ProfileConfigFileAWSCredentialsProvider>("helio"));
+
+  const auto ec2_metadata_disabled = Aws::Environment::GetEnv("AWS_EC2_METADATA_DISABLED");
+  if (Aws::Utils::StringUtils::ToLower(ec2_metadata_disabled.c_str()) != "true") {
+    AddProvider(Aws::MakeShared<Aws::Auth::InstanceProfileCredentialsProvider>("helio"));
+  } else {
+    LOG(INFO) << "aws: disabled EC2 metadata";
+  }
+}
+
+}  // namespace aws
+}  // namespace util

--- a/util/aws/credentials_provider_chain.cc
+++ b/util/aws/credentials_provider_chain.cc
@@ -11,12 +11,12 @@ namespace util {
 namespace aws {
 
 CredentialsProviderChain::CredentialsProviderChain() {
-  AddProvider(Aws::MakeShared<Aws::Auth::EnvironmentAWSCredentialsProvider>("helio"));
-  AddProvider(Aws::MakeShared<Aws::Auth::ProfileConfigFileAWSCredentialsProvider>("helio"));
+  AddProvider(std::make_shared<Aws::Auth::EnvironmentAWSCredentialsProvider>());
+  AddProvider(std::make_shared<Aws::Auth::ProfileConfigFileAWSCredentialsProvider>());
 
   const auto ec2_metadata_disabled = Aws::Environment::GetEnv("AWS_EC2_METADATA_DISABLED");
   if (Aws::Utils::StringUtils::ToLower(ec2_metadata_disabled.c_str()) != "true") {
-    AddProvider(Aws::MakeShared<Aws::Auth::InstanceProfileCredentialsProvider>("helio"));
+    AddProvider(std::make_shared<Aws::Auth::InstanceProfileCredentialsProvider>());
   } else {
     LOG(INFO) << "aws: disabled EC2 metadata";
   }

--- a/util/aws/credentials_provider_chain.h
+++ b/util/aws/credentials_provider_chain.h
@@ -1,0 +1,25 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#pragma once
+
+#include <aws/core/auth/AWSCredentialsProviderChain.h>
+
+namespace util {
+namespace aws {
+
+// Loads a chain of providers:
+// 1. Environment variables
+// 2. Local configuration file
+// 3. EC2 metadata (unless the AWS_EC2_METADATA_DISABLED environment variable
+// is set to 'true')
+//
+// Note we avoid using the default credentials chain to avoid blocking the
+// thread, such as we don't support the process credential provider.
+class CredentialsProviderChain : public Aws::Auth::AWSCredentialsProviderChain {
+ public:
+  CredentialsProviderChain();
+};
+
+}  // namespace aws
+}  // namespace util

--- a/util/aws/http_client.cc
+++ b/util/aws/http_client.cc
@@ -1,0 +1,187 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#include "util/aws/http_client.h"
+
+#include <aws/core/http/HttpRequest.h>
+#include <aws/core/http/HttpResponse.h>
+#include <aws/core/http/standard/StandardHttpResponse.h>
+
+#include <boost/beast/http/empty_body.hpp>
+#include <boost/beast/http/message.hpp>
+#include <boost/beast/http/read.hpp>
+#include <boost/beast/http/string_body.hpp>
+#include <boost/beast/http/write.hpp>
+
+#include "base/logging.h"
+#include "util/asio_stream_adapter.h"
+#include "util/fibers/dns_resolve.h"
+
+namespace util {
+namespace aws {
+
+namespace h2 = boost::beast::http;
+
+namespace {
+
+// TODO(andydunstall): Check what versions boost supports
+constexpr unsigned kHttpVersion1_1 = 11;
+
+h2::verb BoostMethod(Aws::Http::HttpMethod method) {
+  switch (method) {
+    case Aws::Http::HttpMethod::HTTP_GET:
+      return h2::verb::get;
+    case Aws::Http::HttpMethod::HTTP_POST:
+      return h2::verb::post;
+    case Aws::Http::HttpMethod::HTTP_DELETE:
+      return h2::verb::delete_;
+    case Aws::Http::HttpMethod::HTTP_PUT:
+      return h2::verb::put;
+    case Aws::Http::HttpMethod::HTTP_HEAD:
+      return h2::verb::head;
+    case Aws::Http::HttpMethod::HTTP_PATCH:
+      return h2::verb::patch;
+    default:
+      LOG(ERROR) << "aws: http client: invalid http method: " << static_cast<int>(method);
+      return h2::verb::unknown;
+  }
+}
+
+}  // namespace
+
+HttpClient::HttpClient(const Aws::Client::ClientConfiguration& client_conf)
+    : client_conf_{client_conf} {
+  // TODO(andydunstall): Handle client conf
+  proactor_ = ProactorBase::me();
+  CHECK(proactor_) << "must run in a proactor thread";
+}
+
+std::shared_ptr<Aws::Http::HttpResponse> HttpClient::MakeRequest(
+    const std::shared_ptr<Aws::Http::HttpRequest>& request,
+    Aws::Utils::RateLimits::RateLimiterInterface* readLimiter,
+    Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter) const {
+  // TODO(andydunstall): We currently only support HTTP.
+  request->GetUri().SetScheme(Aws::Http::Scheme::HTTP);
+
+  VLOG(1) << "aws: http client: request; method="
+          << Aws::Http::HttpMethodMapper::GetNameForHttpMethod(request->GetMethod())
+          << "; url=" << request->GetUri().GetURIString()
+          << "; scheme=" << Aws::Http::SchemeMapper::ToString(request->GetUri().GetScheme());
+  for (const auto& h : request->GetHeaders()) {
+    DVLOG(2) << "aws: http client: request; header=" << h.first << "=" << h.second;
+  }
+
+  h2::request<h2::string_body> boost_req{BoostMethod(request->GetMethod()),
+                                         request->GetUri().GetURIString(), kHttpVersion1_1};
+  for (const auto& h : request->GetHeaders()) {
+    boost_req.set(h.first, h.second);
+  }
+  // TODO(andydunstall) We can avoid this copy by adding a custom body type
+  // that reads directly from the body std::iostream.
+  if (request->GetContentBody()) {
+    int content_size;
+    absl::SimpleAtoi(request->GetContentLength(), &content_size);
+    std::string s(content_size, '0');
+    request->GetContentBody()->read(s.data(), s.size());
+    boost_req.body() = s;
+  }
+
+  std::shared_ptr<Aws::Http::HttpResponse> response =
+      Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>("helio", request);
+
+  // TODO(andydunstall): Cache connections
+  io::Result<std::unique_ptr<FiberSocketBase>> connect_res =
+      Connect(request->GetUri().GetAuthority(), request->GetUri().GetPort());
+  if (!connect_res) {
+    response->SetClientErrorType(Aws::Client::CoreErrors::NETWORK_CONNECTION);
+    return response;
+  }
+  std::unique_ptr<FiberSocketBase> conn = std::move(*connect_res);
+
+  boost::system::error_code ec;
+  AsioStreamAdapter<> adapter(*conn);
+  h2::write(adapter, boost_req, ec);
+  if (ec) {
+    LOG(WARNING) << "aws: http client: failed to send request; method="
+                 << Aws::Http::HttpMethodMapper::GetNameForHttpMethod(request->GetMethod())
+                 << "; url=" << request->GetUri().GetURIString() << "; error=" << ec;
+    response->SetClientErrorType(Aws::Client::CoreErrors::NETWORK_CONNECTION);
+    return response;
+  }
+  h2::response<h2::string_body> boost_resp;
+  h2::read(adapter, buf_, boost_resp, ec);
+  if (ec) {
+    LOG(WARNING) << "aws: http client: failed to read response; method="
+                 << Aws::Http::HttpMethodMapper::GetNameForHttpMethod(request->GetMethod())
+                 << "; url=" << request->GetUri().GetURIString() << "; error=" << ec;
+    response->SetClientErrorType(Aws::Client::CoreErrors::NETWORK_CONNECTION);
+    return response;
+  }
+
+  response->SetResponseCode(static_cast<Aws::Http::HttpResponseCode>(boost_resp.result_int()));
+  for (const auto& h : boost_resp.base()) {
+    response->AddHeader(h.name_string(), h.value());
+  }
+  // TODO(andydunstall) We can avoid this copy by adding a custom body type
+  // that writes directly from the body std::iostream.
+  response->GetResponseBody().write(boost_resp.body().data(), boost_resp.body().size());
+
+  VLOG(1) << "aws: http client: response; status=" << boost_resp.result_int();
+  for (const auto& h : response->GetHeaders()) {
+    DVLOG(2) << "aws: http client: response; header=" << h.first << "=" << h.second;
+  }
+
+  conn->Close();
+
+  return response;
+}
+
+io::Result<std::unique_ptr<FiberSocketBase>> HttpClient::Connect(const std::string& host,
+                                                                 uint16_t port) const {
+  VLOG(1) << "aws: http client: connecting; host=" << host << "; port=" << port;
+
+  io::Result<boost::asio::ip::address> addr = Resolve(host);
+  if (!addr) {
+    return nonstd::make_unexpected(addr.error());
+  }
+
+  std::unique_ptr<FiberSocketBase> socket;
+  socket.reset(proactor_->CreateSocket());
+  FiberSocketBase::endpoint_type ep{*addr, port};
+  // TODO(andydunstall): Add connect timeout (client_conf_.connectTimeoutMs)
+  std::error_code ec = socket->Connect(ep);
+  if (ec) {
+    LOG(WARNING) << "aws: http client: failed to connect; host=" << host << "; error=" << ec;
+    socket->Close();
+    return nonstd::make_unexpected(ec);
+  }
+
+  VLOG(1) << "aws: http client: connected; host=" << host << "; port=" << port;
+
+  return socket;
+}
+
+io::Result<boost::asio::ip::address> HttpClient::Resolve(const std::string& host) const {
+  VLOG(1) << "aws: http client: resolving host; host=" << host;
+
+  char ip[INET_ADDRSTRLEN];
+  std::error_code ec = fb2::DnsResolve(host.data(), client_conf_.connectTimeoutMs, ip, proactor_);
+  if (ec) {
+    LOG(WARNING) << "aws: http client: failed to resolve host; host=" << host << "; error=" << ec;
+    return nonstd::make_unexpected(ec);
+  }
+
+  boost::system::error_code bec;
+  boost::asio::ip::address address = boost::asio::ip::make_address(ip, bec);
+  if (bec) {
+    LOG(ERROR) << "aws: http client: resolved invalid address; error=" << ec;
+    return nonstd::make_unexpected(ec);
+  }
+
+  VLOG(1) << "aws: http client: resolved host; host=" << host << "; ip=" << address;
+
+  return address;
+}
+
+}  // namespace aws
+}  // namespace util

--- a/util/aws/http_client.cc
+++ b/util/aws/http_client.cc
@@ -129,7 +129,7 @@ std::shared_ptr<Aws::Http::HttpResponse> HttpClient::MakeRequest(
 
   response->SetResponseCode(static_cast<Aws::Http::HttpResponseCode>(boost_resp.result_int()));
   for (const auto& h : boost_resp.base()) {
-    response->AddHeader(h.name_string(), h.value());
+    response->AddHeader(std::string(h.name_string()), std::string(h.value()));
   }
   // TODO(andydunstall) We can avoid this copy by adding a custom body type
   // that writes directly from the body std::iostream.

--- a/util/aws/http_client.cc
+++ b/util/aws/http_client.cc
@@ -85,7 +85,7 @@ std::shared_ptr<Aws::Http::HttpResponse> HttpClient::MakeRequest(
   }
 
   std::shared_ptr<Aws::Http::HttpResponse> response =
-      Aws::MakeShared<Aws::Http::Standard::StandardHttpResponse>("helio", request);
+      std::make_shared<Aws::Http::Standard::StandardHttpResponse>(request);
 
   // TODO(andydunstall): So the HTTP client can be accessed by multiple
   // threads/proactors, we reconnect on each request.

--- a/util/aws/http_client.cc
+++ b/util/aws/http_client.cc
@@ -60,9 +60,6 @@ std::shared_ptr<Aws::Http::HttpResponse> HttpClient::MakeRequest(
     const std::shared_ptr<Aws::Http::HttpRequest>& request,
     Aws::Utils::RateLimits::RateLimiterInterface* readLimiter,
     Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter) const {
-  // TODO(andydunstall): We currently only support HTTP.
-  request->GetUri().SetScheme(Aws::Http::Scheme::HTTP);
-
   VLOG(1) << "aws: http client: request; method="
           << Aws::Http::HttpMethodMapper::GetNameForHttpMethod(request->GetMethod())
           << "; url=" << request->GetUri().GetURIString()

--- a/util/aws/http_client.cc
+++ b/util/aws/http_client.cc
@@ -112,6 +112,7 @@ std::shared_ptr<Aws::Http::HttpResponse> HttpClient::MakeRequest(
                  << Aws::Http::HttpMethodMapper::GetNameForHttpMethod(request->GetMethod())
                  << "; url=" << request->GetUri().GetURIString() << "; error=" << ec;
     response->SetClientErrorType(Aws::Client::CoreErrors::NETWORK_CONNECTION);
+    conn->Close();
     return response;
   }
   h2::response<h2::string_body> boost_resp;
@@ -122,6 +123,7 @@ std::shared_ptr<Aws::Http::HttpResponse> HttpClient::MakeRequest(
                  << Aws::Http::HttpMethodMapper::GetNameForHttpMethod(request->GetMethod())
                  << "; url=" << request->GetUri().GetURIString() << "; error=" << ec;
     response->SetClientErrorType(Aws::Client::CoreErrors::NETWORK_CONNECTION);
+    conn->Close();
     return response;
   }
 

--- a/util/aws/http_client.h
+++ b/util/aws/http_client.h
@@ -26,6 +26,8 @@ class HttpClient : public Aws::Http::HttpClient {
   // network error on a connection that was previously healthy. HTTP requests
   // are considered idempotent it they have methods GET, HEAD, OPTIONS, or
   // TRACE.
+  //
+  // Note we don't support readLimiter or writeLimiter.
   std::shared_ptr<Aws::Http::HttpResponse> MakeRequest(
       const std::shared_ptr<Aws::Http::HttpRequest>& request,
       Aws::Utils::RateLimits::RateLimiterInterface* readLimiter = nullptr,
@@ -45,6 +47,8 @@ class HttpClient : public Aws::Http::HttpClient {
 
   io::Result<boost::asio::ip::address> Resolve(const std::string& host,
                                                ProactorBase* proactor) const;
+
+  std::error_code EnableKeepAlive(int fd) const;
 
   Aws::Client::ClientConfiguration client_conf_;
 };

--- a/util/aws/http_client.h
+++ b/util/aws/http_client.h
@@ -22,11 +22,6 @@ class HttpClient : public Aws::Http::HttpClient {
 
   // Sends the given HTTP request to the server and returns a response.
   //
-  // Requests will only be retried if the request is idempotent and it gets a
-  // network error on a connection that was previously healthy. HTTP requests
-  // are considered idempotent it they have methods GET, HEAD, OPTIONS, or
-  // TRACE.
-  //
   // Note we don't support readLimiter or writeLimiter.
   std::shared_ptr<Aws::Http::HttpResponse> MakeRequest(
       const std::shared_ptr<Aws::Http::HttpRequest>& request,

--- a/util/aws/http_client.h
+++ b/util/aws/http_client.h
@@ -1,0 +1,49 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#pragma once
+
+#include <aws/core/client/ClientConfiguration.h>
+#include <aws/core/http/HttpClient.h>
+
+#include <boost/beast/core/flat_buffer.hpp>
+
+#include "util/fibers/proactor_base.h"
+
+namespace util {
+namespace aws {
+
+// HTTP client manages connecting to and sending HTTP requests.
+//
+// It is NOT thread OR fiber safe, so must only accessed by a single fiber. It
+// may block the fiber but not the thread.
+class HttpClient : public Aws::Http::HttpClient {
+ public:
+  HttpClient(const Aws::Client::ClientConfiguration& client_conf);
+
+  // Sends the given HTTP request to the server and returns a response.
+  //
+  // Requests will only be retried if the request is idempotent and it gets a
+  // network error on a connection that was previously healthy. HTTP requests
+  // are considered idempotent it they have methods GET, HEAD, OPTIONS, or
+  // TRACE.
+  std::shared_ptr<Aws::Http::HttpResponse> MakeRequest(
+      const std::shared_ptr<Aws::Http::HttpRequest>& request,
+      Aws::Utils::RateLimits::RateLimiterInterface* readLimiter = nullptr,
+      Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter = nullptr) const override;
+
+ private:
+  io::Result<std::unique_ptr<FiberSocketBase>> Connect(const std::string& host,
+                                                       uint16_t port) const;
+
+  io::Result<boost::asio::ip::address> Resolve(const std::string& host) const;
+
+  mutable boost::beast::flat_buffer buf_;
+
+  Aws::Client::ClientConfiguration client_conf_;
+
+  ProactorBase* proactor_;
+};
+
+}  // namespace aws
+}  // namespace util

--- a/util/aws/http_client.h
+++ b/util/aws/http_client.h
@@ -32,6 +32,14 @@ class HttpClient : public Aws::Http::HttpClient {
       Aws::Utils::RateLimits::RateLimiterInterface* readLimiter = nullptr,
       Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter = nullptr) const override;
 
+  void DisableRequestProcessing() override;
+
+  void EnableRequestProcessing() override;
+
+  bool IsRequestProcessingEnabled() const override;
+
+  void RetryRequestSleep(std::chrono::milliseconds sleep_time) override;
+
  private:
   io::Result<std::unique_ptr<FiberSocketBase>> Connect(const std::string& host,
                                                        uint16_t port) const;
@@ -43,6 +51,12 @@ class HttpClient : public Aws::Http::HttpClient {
   Aws::Client::ClientConfiguration client_conf_;
 
   ProactorBase* proactor_;
+
+  std::atomic<bool> disable_request_processing_;
+
+  fb2::Mutex request_processing_signal_lock_;
+
+  fb2::CondVarAny request_processing_signal_;
 };
 
 }  // namespace aws

--- a/util/aws/http_client_factory.cc
+++ b/util/aws/http_client_factory.cc
@@ -1,0 +1,27 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#include "util/aws/http_client_factory.h"
+
+namespace util {
+namespace aws {
+
+std::shared_ptr<Aws::Http::HttpClient> HttpClientFactory::CreateHttpClient(
+    const Aws::Client::ClientConfiguration& clientConfiguration) const {
+  return nullptr;
+}
+
+std::shared_ptr<Aws::Http::HttpRequest> HttpClientFactory::CreateHttpRequest(
+    const Aws::String& uri, Aws::Http::HttpMethod method,
+    const Aws::IOStreamFactory& streamFactory) const {
+  return nullptr;
+}
+
+std::shared_ptr<Aws::Http::HttpRequest> HttpClientFactory::CreateHttpRequest(
+    const Aws::Http::URI& uri, Aws::Http::HttpMethod method,
+    const Aws::IOStreamFactory& streamFactory) const {
+  return nullptr;
+}
+
+}  // namespace aws
+}  // namespace util

--- a/util/aws/http_client_factory.cc
+++ b/util/aws/http_client_factory.cc
@@ -3,24 +3,30 @@
 
 #include "util/aws/http_client_factory.h"
 
+#include <aws/core/http/standard/StandardHttpRequest.h>
+
+#include "util/aws/http_client.h"
+
 namespace util {
 namespace aws {
 
 std::shared_ptr<Aws::Http::HttpClient> HttpClientFactory::CreateHttpClient(
-    const Aws::Client::ClientConfiguration& clientConfiguration) const {
-  return nullptr;
+    const Aws::Client::ClientConfiguration& client_conf) const {
+  return Aws::MakeShared<HttpClient>("helio", client_conf);
 }
 
 std::shared_ptr<Aws::Http::HttpRequest> HttpClientFactory::CreateHttpRequest(
     const Aws::String& uri, Aws::Http::HttpMethod method,
-    const Aws::IOStreamFactory& streamFactory) const {
-  return nullptr;
+    const Aws::IOStreamFactory& stream_factory) const {
+  return CreateHttpRequest(Aws::Http::URI(uri), method, stream_factory);
 }
 
 std::shared_ptr<Aws::Http::HttpRequest> HttpClientFactory::CreateHttpRequest(
     const Aws::Http::URI& uri, Aws::Http::HttpMethod method,
-    const Aws::IOStreamFactory& streamFactory) const {
-  return nullptr;
+    const Aws::IOStreamFactory& stream_factory) const {
+  auto request = Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>("helio", uri, method);
+  request->SetResponseStreamFactory(stream_factory);
+  return request;
 }
 
 }  // namespace aws

--- a/util/aws/http_client_factory.cc
+++ b/util/aws/http_client_factory.cc
@@ -12,7 +12,7 @@ namespace aws {
 
 std::shared_ptr<Aws::Http::HttpClient> HttpClientFactory::CreateHttpClient(
     const Aws::Client::ClientConfiguration& client_conf) const {
-  return Aws::MakeShared<HttpClient>("helio", client_conf);
+  return std::make_shared<HttpClient>(client_conf);
 }
 
 std::shared_ptr<Aws::Http::HttpRequest> HttpClientFactory::CreateHttpRequest(
@@ -24,7 +24,7 @@ std::shared_ptr<Aws::Http::HttpRequest> HttpClientFactory::CreateHttpRequest(
 std::shared_ptr<Aws::Http::HttpRequest> HttpClientFactory::CreateHttpRequest(
     const Aws::Http::URI& uri, Aws::Http::HttpMethod method,
     const Aws::IOStreamFactory& stream_factory) const {
-  auto request = Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>("helio", uri, method);
+  auto request = std::make_shared<Aws::Http::Standard::StandardHttpRequest>(uri, method);
   request->SetResponseStreamFactory(stream_factory);
   return request;
 }

--- a/util/aws/http_client_factory.h
+++ b/util/aws/http_client_factory.h
@@ -1,0 +1,28 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#pragma once
+
+#include <aws/core/http/HttpClientFactory.h>
+
+#include <memory>
+
+namespace util {
+namespace aws {
+
+class HttpClientFactory : public Aws::Http::HttpClientFactory {
+ public:
+  std::shared_ptr<Aws::Http::HttpClient> CreateHttpClient(
+      const Aws::Client::ClientConfiguration& clientConfiguration) const override;
+
+  std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
+      const Aws::String& uri, Aws::Http::HttpMethod method,
+      const Aws::IOStreamFactory& streamFactory) const override;
+
+  std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
+      const Aws::Http::URI& uri, Aws::Http::HttpMethod method,
+      const Aws::IOStreamFactory& streamFactory) const override;
+};
+
+}  // namespace aws
+}  // namespace util

--- a/util/aws/http_client_factory.h
+++ b/util/aws/http_client_factory.h
@@ -13,15 +13,15 @@ namespace aws {
 class HttpClientFactory : public Aws::Http::HttpClientFactory {
  public:
   std::shared_ptr<Aws::Http::HttpClient> CreateHttpClient(
-      const Aws::Client::ClientConfiguration& clientConfiguration) const override;
+      const Aws::Client::ClientConfiguration& client_conf) const override;
 
   std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
       const Aws::String& uri, Aws::Http::HttpMethod method,
-      const Aws::IOStreamFactory& streamFactory) const override;
+      const Aws::IOStreamFactory& stream_factory) const override;
 
   std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
       const Aws::Http::URI& uri, Aws::Http::HttpMethod method,
-      const Aws::IOStreamFactory& streamFactory) const override;
+      const Aws::IOStreamFactory& stream_factory) const override;
 };
 
 }  // namespace aws

--- a/util/aws/logger.cc
+++ b/util/aws/logger.cc
@@ -20,6 +20,7 @@ Aws::Utils::Logging::LogLevel Logger::GetLogLevel() const {
 void Logger::Log(Aws::Utils::Logging::LogLevel level, const char* tag, const char* format_str,
                  ...) {
   // Note Logger::Log is almost unused by the SDK, it instead uses LogStream.
+  // Copied formatting vararg from the AWS SDK.
 
   std::stringstream ss;
 

--- a/util/aws/logger.cc
+++ b/util/aws/logger.cc
@@ -1,0 +1,95 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#include "util/aws/logger.h"
+
+#include <absl/strings/str_format.h>
+#include <aws/core/utils/logging/LogLevel.h>
+
+#include <cstdarg>
+
+#include "base/logging.h"
+
+namespace util {
+namespace aws {
+
+Aws::Utils::Logging::LogLevel Logger::GetLogLevel() const {
+  return Aws::Utils::Logging::LogLevel::Debug;
+}
+
+void Logger::Log(Aws::Utils::Logging::LogLevel level, const char* tag, const char* format_str,
+                 ...) {
+  // Note Logger::Log is almost unused by the SDK, it instead uses LogStream.
+
+  std::stringstream ss;
+
+  va_list args;
+  va_start(args, format_str);
+
+  va_list tmp_args;
+  va_copy(tmp_args, args);
+  const int len = vsnprintf(nullptr, 0, format_str, tmp_args) + 1;
+  va_end(tmp_args);
+
+  std::vector<char> buf(len);
+  vsnprintf(buf.data(), len, format_str, args);
+
+  ss << buf.data();
+
+  va_end(args);
+
+  switch (level) {
+    case Aws::Utils::Logging::LogLevel::Trace:
+      DVLOG(2) << "aws: " << tag << ": " << ss.str();
+      break;
+    case Aws::Utils::Logging::LogLevel::Debug:
+      VLOG(1) << "aws: " << tag << ": " << ss.str();
+      break;
+    case Aws::Utils::Logging::LogLevel::Info:
+      LOG(INFO) << "aws: " << tag << ": " << ss.str();
+      break;
+    case Aws::Utils::Logging::LogLevel::Warn:
+      LOG(WARNING) << "aws: " << tag << ": " << ss.str();
+      break;
+    case Aws::Utils::Logging::LogLevel::Error:
+      LOG(WARNING) << "aws: " << tag << ": " << ss.str();
+      break;
+    case Aws::Utils::Logging::LogLevel::Fatal:
+      LOG(FATAL) << "aws: " << tag << ": " << ss.str();
+      break;
+    default:
+      break;
+  }
+}
+
+void Logger::LogStream(Aws::Utils::Logging::LogLevel level, const char* tag,
+                       const Aws::OStringStream& message_stream) {
+  switch (level) {
+    case Aws::Utils::Logging::LogLevel::Trace:
+      DVLOG(2) << "aws: " << tag << ": " << message_stream.str();
+      break;
+    case Aws::Utils::Logging::LogLevel::Debug:
+      VLOG(1) << "aws: " << tag << ": " << message_stream.str();
+      break;
+    case Aws::Utils::Logging::LogLevel::Info:
+      LOG(INFO) << "aws: " << tag << ": " << message_stream.str();
+      break;
+    case Aws::Utils::Logging::LogLevel::Warn:
+      LOG(WARNING) << "aws: " << tag << ": " << message_stream.str();
+      break;
+    case Aws::Utils::Logging::LogLevel::Error:
+      LOG(WARNING) << "aws: " << tag << ": " << message_stream.str();
+      break;
+    case Aws::Utils::Logging::LogLevel::Fatal:
+      LOG(FATAL) << "aws: " << tag << ": " << message_stream.str();
+      break;
+    default:
+      break;
+  }
+}
+
+void Logger::Flush() {
+}
+
+}  // namespace aws
+}  // namespace util

--- a/util/aws/logger.h
+++ b/util/aws/logger.h
@@ -1,0 +1,25 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#pragma once
+
+#include <aws/core/utils/logging/LogSystemInterface.h>
+
+namespace util {
+namespace aws {
+
+class Logger : public Aws::Utils::Logging::LogSystemInterface {
+ public:
+  Aws::Utils::Logging::LogLevel GetLogLevel() const override;
+
+  void Log(Aws::Utils::Logging::LogLevel level, const char* tag, const char* format_str,
+           ...) override;
+
+  void LogStream(Aws::Utils::Logging::LogLevel level, const char* tag,
+                 const Aws::OStringStream& message_stream) override;
+
+  void Flush() override;
+};
+
+}  // namespace aws
+}  // namespace util

--- a/util/aws/logger.h
+++ b/util/aws/logger.h
@@ -8,6 +8,7 @@
 namespace util {
 namespace aws {
 
+// A glog based logger for AWS.
 class Logger : public Aws::Utils::Logging::LogSystemInterface {
  public:
   Aws::Utils::Logging::LogLevel GetLogLevel() const override;

--- a/util/aws/s3_endpoint_provider.cc
+++ b/util/aws/s3_endpoint_provider.cc
@@ -18,7 +18,7 @@ Aws::Endpoint::ResolveEndpointOutcome S3EndpointProvider::ResolveEndpoint(
     Aws::Endpoint::ResolveEndpointOutcome outcome =
         Aws::S3::S3EndpointProvider::ResolveEndpoint(endpoint_params);
     if (outcome.IsSuccess()) {
-      // TODO(andydunstall): We currently only support HTTP.
+      // We currently only support HTTP.
       Aws::Http::URI uri = outcome.GetResult().GetURI();
       uri.SetScheme(Aws::Http::Scheme::HTTP);
       outcome.GetResult().SetURI(uri);
@@ -27,7 +27,7 @@ Aws::Endpoint::ResolveEndpointOutcome S3EndpointProvider::ResolveEndpoint(
   }
 
   // If a custom endpoint is configured, construct the URL. Note this misses
-  // lots of functionality of Aws::S3::S3EndpointProvider, though we are
+  // some functionality of Aws::S3::S3EndpointProvider, though we are
   // currently only using the custom endpoint for testing.
 
   std::string bucket;
@@ -38,7 +38,7 @@ Aws::Endpoint::ResolveEndpointOutcome S3EndpointProvider::ResolveEndpoint(
   }
 
   Aws::Endpoint::AWSEndpoint endpoint;
-  // TODO(andydunstall): We currently only support HTTP.
+  // We currently only support HTTP.
   if (bucket != "") {
     endpoint.SetURL("http://" + endpoint_ + "/" + bucket);
   } else {

--- a/util/aws/s3_endpoint_provider.cc
+++ b/util/aws/s3_endpoint_provider.cc
@@ -1,0 +1,51 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#include "util/aws/s3_endpoint_provider.h"
+
+#include "base/logging.h"
+
+namespace util {
+namespace aws {
+
+S3EndpointProvider::S3EndpointProvider(const std::string& endpoint) : endpoint_{endpoint} {
+}
+
+Aws::Endpoint::ResolveEndpointOutcome S3EndpointProvider::ResolveEndpoint(
+    const Aws::Endpoint::EndpointParameters& endpoint_params) const {
+  // If no custom endpoint is configured, use the aws default.
+  if (endpoint_ == "") {
+    Aws::Endpoint::ResolveEndpointOutcome outcome =
+        Aws::S3::S3EndpointProvider::ResolveEndpoint(endpoint_params);
+    if (outcome.IsSuccess()) {
+      // TODO(andydunstall): We currently only support HTTP.
+      Aws::Http::URI uri = outcome.GetResult().GetURI();
+      uri.SetScheme(Aws::Http::Scheme::HTTP);
+      outcome.GetResult().SetURI(uri);
+    }
+    return outcome;
+  }
+
+  // If a custom endpoint is configured, construct the URL. Note this misses
+  // lots of functionality of Aws::S3::S3EndpointProvider, though we are
+  // currently only using the custom endpoint for testing.
+
+  std::string bucket;
+  for (auto p : endpoint_params) {
+    if (p.GetName() == "Bucket") {
+      CHECK(p.GetString(bucket) == Aws::Endpoint::EndpointParameter::GetSetResult::SUCCESS);
+    }
+  }
+
+  Aws::Endpoint::AWSEndpoint endpoint;
+  // TODO(andydunstall): We currently only support HTTP.
+  if (bucket != "") {
+    endpoint.SetURL("http://" + endpoint_ + "/" + bucket);
+  } else {
+    endpoint.SetURL("http://" + endpoint_);
+  }
+  return Aws::Endpoint::ResolveEndpointOutcome(std::move(endpoint));
+}
+
+}  // namespace aws
+}  // namespace util

--- a/util/aws/s3_endpoint_provider.h
+++ b/util/aws/s3_endpoint_provider.h
@@ -12,6 +12,8 @@ namespace aws {
 //
 // We override the default to support configuring custom endpoints, which the
 // C++ SDK doesn't yet support.
+//
+// We also only support HTTP.
 class S3EndpointProvider : public Aws::S3::S3EndpointProvider {
  public:
   // Configure a non-empty endpoint string to configure a custom endpoint.

--- a/util/aws/s3_endpoint_provider.h
+++ b/util/aws/s3_endpoint_provider.h
@@ -1,0 +1,28 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#pragma once
+
+#include <aws/s3/S3Client.h>
+
+namespace util {
+namespace aws {
+
+// S3 endpoint provider.
+//
+// We override the default to support configuring custom endpoints, which the
+// C++ SDK doesn't yet support.
+class S3EndpointProvider : public Aws::S3::S3EndpointProvider {
+ public:
+  // Configure a non-empty endpoint string to configure a custom endpoint.
+  S3EndpointProvider(const std::string& endpoint = "");
+
+  Aws::Endpoint::ResolveEndpointOutcome ResolveEndpoint(
+      const Aws::Endpoint::EndpointParameters& endpoint_params) const override;
+
+ private:
+  std::string endpoint_;
+};
+
+}  // namespace aws
+}  // namespace util

--- a/util/aws/s3_read_file.cc
+++ b/util/aws/s3_read_file.cc
@@ -1,0 +1,103 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#include "util/aws/s3_read_file.h"
+
+#include <absl/strings/numbers.h>
+#include <absl/strings/str_format.h>
+#include <absl/strings/str_split.h>
+#include <aws/s3/model/GetObjectRequest.h>
+
+#include "base/logging.h"
+
+namespace util {
+namespace aws {
+
+// TODO(andydunstall): Currently just using a very simple and inefficient
+// read. Need to re-implement properly.
+
+S3ReadFile::S3ReadFile(const std::string& bucket, const std::string& key,
+                       std::shared_ptr<Aws::S3::S3Client> client, size_t chunk_size)
+    : bucket_{bucket}, key_{key}, buf_(chunk_size), client_{client} {
+}
+
+io::Result<size_t> S3ReadFile::Read(size_t offset, const iovec* v, uint32_t len) {
+  if (file_size_ > 0 && read_ == file_size_) {
+    VLOG(2) << "aws: s3 read file: read complete; file_size=" << file_size_;
+    return 0;
+  }
+
+  size_t read_n = 0;
+  for (uint32_t i = 0; i != len; i++) {
+    if (start_ == end_) {
+      std::error_code ec = DownloadChunk();
+      if (ec) {
+        return nonstd::make_unexpected(ec);
+      }
+    }
+
+    size_t n = v[i].iov_len;
+    if (n > end_ - start_) {
+      n = end_ - start_;
+    }
+    memcpy(v[i].iov_base, buf_.data() + start_, n);
+    start_ += n;
+    read_n += n;
+    read_ += n;
+  }
+
+  VLOG(2) << "aws: s3 read file: read=" << read_n;
+
+  return read_n;
+}
+
+std::error_code S3ReadFile::Close() {
+  return std::error_code{};
+}
+
+size_t S3ReadFile::Size() const {
+  return file_size_;
+}
+
+int S3ReadFile::Handle() const {
+  return -1;
+}
+
+std::error_code S3ReadFile::DownloadChunk() {
+  Aws::S3::Model::GetObjectRequest request;
+  request.SetBucket(bucket_);
+  request.SetKey(key_);
+  request.SetRange(NextByteRange());
+  Aws::S3::Model::GetObjectOutcome outcome = client_->GetObject(request);
+  if (outcome.IsSuccess()) {
+    VLOG(2) << "aws: s3 read file: downloaded chunk: length="
+            << outcome.GetResult().GetContentLength();
+
+    outcome.GetResult().GetBody().read(reinterpret_cast<char*>(buf_.data()),
+                                       outcome.GetResult().GetContentLength());
+    start_ = 0;
+    end_ = outcome.GetResult().GetContentLength();
+
+    if (file_size_ == 0) {
+      if (outcome.GetResult().GetContentRange() == "") {
+        file_size_ = outcome.GetResult().GetContentLength();
+      } else {
+        std::vector<std::string_view> parts =
+            absl::StrSplit(outcome.GetResult().GetContentRange(), "/");
+        absl::SimpleAtoi(parts[1], &file_size_);
+      }
+    }
+    return std::error_code{};
+  } else {
+    LOG(ERROR) << "aws: s3 write file: failed to read chunk: "
+               << outcome.GetError().GetExceptionName();
+    return std::make_error_code(std::errc::io_error);
+  }
+}
+
+std::string S3ReadFile::NextByteRange() const {
+  return absl::StrFormat("bytes=%d-%d", read_, read_ + buf_.size() - 1);
+}
+
+}  // namespace aws
+}  // namespace util

--- a/util/aws/s3_read_file.cc
+++ b/util/aws/s3_read_file.cc
@@ -28,7 +28,8 @@ io::Result<size_t> S3ReadFile::Read(size_t offset, const iovec* v, uint32_t len)
     read_n += *n;
   }
 
-  VLOG(2) << "aws: s3 read file: read=" << read_n << "; file_read=" << file_read_ << "; file_size=" << file_size_;
+  VLOG(2) << "aws: s3 read file: read=" << read_n << "; file_read=" << file_read_
+          << "; file_size=" << file_size_;
 
   if (read_n == 0) {
     VLOG(2) << "aws: s3 read file: read complete; file_size=" << file_size_;
@@ -125,14 +126,15 @@ std::error_code S3ReadFile::ParseFileSize(const Aws::S3::Model::GetObjectResult&
   if (result.GetContentRange() == "") {
     file_size_ = result.GetContentLength();
   } else {
-    std::vector<std::string_view> parts =
-        absl::StrSplit(result.GetContentRange(), "/");
+    std::vector<std::string_view> parts = absl::StrSplit(result.GetContentRange(), "/");
     if (parts.size() < 2) {
-      LOG(ERROR) << "aws: s3 read file: failed to parse file size: range=" << result.GetContentRange();
+      LOG(ERROR) << "aws: s3 read file: failed to parse file size: range="
+                 << result.GetContentRange();
       return std::make_error_code(std::errc::io_error);
     }
     if (!absl::SimpleAtoi(parts[1], &file_size_)) {
-      LOG(ERROR) << "aws: s3 read file: failed to parse file size: range=" << result.GetContentRange();
+      LOG(ERROR) << "aws: s3 read file: failed to parse file size: range="
+                 << result.GetContentRange();
       return std::make_error_code(std::errc::io_error);
     }
   }

--- a/util/aws/s3_read_file.cc
+++ b/util/aws/s3_read_file.cc
@@ -13,40 +13,26 @@
 namespace util {
 namespace aws {
 
-// TODO(andydunstall): Currently just using a very simple and inefficient
-// read. Need to re-implement properly.
-
 S3ReadFile::S3ReadFile(const std::string& bucket, const std::string& key,
                        std::shared_ptr<Aws::S3::S3Client> client, size_t chunk_size)
     : bucket_{bucket}, key_{key}, buf_(chunk_size), client_{client} {
 }
 
 io::Result<size_t> S3ReadFile::Read(size_t offset, const iovec* v, uint32_t len) {
-  if (file_size_ > 0 && read_ == file_size_) {
-    VLOG(2) << "aws: s3 read file: read complete; file_size=" << file_size_;
-    return 0;
-  }
-
   size_t read_n = 0;
   for (uint32_t i = 0; i != len; i++) {
-    if (start_ == end_) {
-      std::error_code ec = DownloadChunk();
-      if (ec) {
-        return nonstd::make_unexpected(ec);
-      }
+    io::Result<size_t> n = Read(v[i]);
+    if (!n) {
+      return n;
     }
-
-    size_t n = v[i].iov_len;
-    if (n > end_ - start_) {
-      n = end_ - start_;
-    }
-    memcpy(v[i].iov_base, buf_.data() + start_, n);
-    start_ += n;
-    read_n += n;
-    read_ += n;
+    read_n += *n;
   }
 
-  VLOG(2) << "aws: s3 read file: read=" << read_n;
+  VLOG(2) << "aws: s3 read file: read=" << read_n << "; file_read=" << file_read_ << "; file_size=" << file_size_;
+
+  if (read_n == 0) {
+    VLOG(2) << "aws: s3 read file: read complete; file_size=" << file_size_;
+  }
 
   return read_n;
 }
@@ -63,7 +49,45 @@ int S3ReadFile::Handle() const {
   return -1;
 }
 
+io::Result<size_t> S3ReadFile::Read(iovec v) {
+  size_t read_n = 0;
+  while (true) {
+    // If we're read the whole file we're done.
+    if (file_size_ > 0 && file_read_ == file_size_) {
+      return read_n;
+    }
+
+    // Take as many bytes from the downloaded chunk as possible.
+    size_t n = v.iov_len - read_n;
+    if (n == 0) {
+      return read_n;
+    }
+    if (n > end_idx_ - start_idx_) {
+      n = end_idx_ - start_idx_;
+    }
+    uint8_t* b = reinterpret_cast<uint8_t*>(v.iov_base);
+    memcpy(b + read_n, buf_.data() + start_idx_, n);
+    start_idx_ += n;
+    read_n += n;
+    file_read_ += n;
+
+    // If we don't have sufficient bytes to fill v and haven't read the whole
+    // file, read again.
+    if (read_n < v.iov_len) {
+      std::error_code ec = DownloadChunk();
+      if (ec) {
+        return nonstd::make_unexpected(ec);
+      }
+    }
+  }
+}
+
 std::error_code S3ReadFile::DownloadChunk() {
+  // If we're read the whole file we're done.
+  if (file_size_ > 0 && file_read_ == file_size_) {
+    return std::error_code{};
+  }
+
   Aws::S3::Model::GetObjectRequest request;
   request.SetBucket(bucket_);
   request.SetKey(key_);
@@ -75,16 +99,14 @@ std::error_code S3ReadFile::DownloadChunk() {
 
     outcome.GetResult().GetBody().read(reinterpret_cast<char*>(buf_.data()),
                                        outcome.GetResult().GetContentLength());
-    start_ = 0;
-    end_ = outcome.GetResult().GetContentLength();
+    start_idx_ = 0;
+    end_idx_ = outcome.GetResult().GetContentLength();
 
+    // If this is the first download, read the file size.
     if (file_size_ == 0) {
-      if (outcome.GetResult().GetContentRange() == "") {
-        file_size_ = outcome.GetResult().GetContentLength();
-      } else {
-        std::vector<std::string_view> parts =
-            absl::StrSplit(outcome.GetResult().GetContentRange(), "/");
-        absl::SimpleAtoi(parts[1], &file_size_);
+      std::error_code ec = ParseFileSize(outcome.GetResult());
+      if (ec) {
+        return ec;
       }
     }
     return std::error_code{};
@@ -96,7 +118,26 @@ std::error_code S3ReadFile::DownloadChunk() {
 }
 
 std::string S3ReadFile::NextByteRange() const {
-  return absl::StrFormat("bytes=%d-%d", read_, read_ + buf_.size() - 1);
+  return absl::StrFormat("bytes=%d-%d", file_read_, file_read_ + buf_.size() - 1);
+}
+
+std::error_code S3ReadFile::ParseFileSize(const Aws::S3::Model::GetObjectResult& result) {
+  if (result.GetContentRange() == "") {
+    file_size_ = result.GetContentLength();
+  } else {
+    std::vector<std::string_view> parts =
+        absl::StrSplit(result.GetContentRange(), "/");
+    if (parts.size() < 2) {
+      LOG(ERROR) << "aws: s3 read file: failed to parse file size: range=" << result.GetContentRange();
+      return std::make_error_code(std::errc::io_error);
+    }
+    if (!absl::SimpleAtoi(parts[1], &file_size_)) {
+      LOG(ERROR) << "aws: s3 read file: failed to parse file size: range=" << result.GetContentRange();
+      return std::make_error_code(std::errc::io_error);
+    }
+  }
+
+  return std::error_code{};
 }
 
 }  // namespace aws

--- a/util/aws/s3_read_file.h
+++ b/util/aws/s3_read_file.h
@@ -11,7 +11,9 @@
 namespace util {
 namespace aws {
 
-constexpr size_t kDefaultChunkSize = 10 * (1 << 20);
+// TODO(andydunstall) Using 10MB fails with a boost body_limit error.
+// Not sure what this limit is.
+constexpr size_t kDefaultChunkSize = 1 * (1 << 20);
 
 class S3ReadFile final : public io::ReadonlyFile {
  public:

--- a/util/aws/s3_read_file.h
+++ b/util/aws/s3_read_file.h
@@ -1,0 +1,52 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#pragma once
+
+#include <aws/s3/S3Client.h>
+
+#include "io/file.h"
+#include "io/io.h"
+
+namespace util {
+namespace aws {
+
+constexpr size_t kDefaultChunkSize = 10 * (1 << 20);
+
+class S3ReadFile final : public io::ReadonlyFile {
+ public:
+  S3ReadFile(const std::string& bucket, const std::string& key,
+             std::shared_ptr<Aws::S3::S3Client> client, size_t chunk_size = kDefaultChunkSize);
+
+  io::Result<size_t> Read(size_t offset, const iovec* v, uint32_t len) override;
+
+  std::error_code Close() override;
+
+  size_t Size() const override;
+
+  int Handle() const override;
+
+ private:
+  std::error_code DownloadChunk();
+
+  std::string NextByteRange() const;
+
+  std::string bucket_;
+
+  std::string key_;
+
+  std::shared_ptr<Aws::S3::S3Client> client_;
+
+  std::vector<uint8_t> buf_;
+
+  size_t start_ = 0;
+
+  size_t end_ = 0;
+
+  size_t read_ = 0;
+
+  size_t file_size_ = 0;
+};
+
+}  // namespace aws
+}  // namespace util

--- a/util/aws/s3_read_file.h
+++ b/util/aws/s3_read_file.h
@@ -6,6 +6,7 @@
 #include <aws/s3/S3Client.h>
 #include <aws/s3/model/GetObjectResult.h>
 
+#include "base/io_buf.h"
 #include "io/file.h"
 #include "io/io.h"
 
@@ -46,15 +47,9 @@ class S3ReadFile final : public io::ReadonlyFile {
 
   std::string key_;
 
-  // Buffers the last downloaded chunk. Note may not fill buf_ if we're reading
-  // the last chunk, so uses start_idx_ and end_idx_ to indicate the remaining
-  // bytes to be consumed.
-  std::vector<uint8_t> buf_;
+  base::IoBuf buf_;
 
-  size_t start_idx_ = 0;
-
-  size_t end_idx_ = 0;
-
+  // Total bytes in the file read.
   size_t file_read_ = 0;
 
   // Size of the target file to read. Set on first download.

--- a/util/aws/s3_write_file.cc
+++ b/util/aws/s3_write_file.cc
@@ -118,7 +118,7 @@ std::error_code S3WriteFile::Flush() {
 
   // TODO(andydunstall): Look at avoiding this copy. We're copying to an IO
   // stream, then back to a buffer in HTTP client.
-  std::shared_ptr<Aws::IOStream> object_stream = Aws::MakeShared<Aws::StringStream>("helio");
+  std::shared_ptr<Aws::IOStream> object_stream = std::make_shared<Aws::StringStream>();
   object_stream->write((const char*)buf_.data(), offset_);
   request.SetBody(object_stream);
 

--- a/util/aws/s3_write_file.cc
+++ b/util/aws/s3_write_file.cc
@@ -69,7 +69,7 @@ std::error_code S3WriteFile::Close() {
   Aws::S3::Model::CompleteMultipartUploadOutcome outcome =
       client_->CompleteMultipartUpload(request);
   if (outcome.IsSuccess()) {
-    LOG(INFO) << "aws: s3 write file: completed multipart upload; parts=" << parts_.size();
+    VLOG(2) << "aws: s3 write file: completed multipart upload; parts=" << parts_.size();
   } else {
     LOG(ERROR) << "aws: s3 write file: failed to complete multipart upload: "
                << outcome.GetError().GetExceptionName();
@@ -124,7 +124,7 @@ std::error_code S3WriteFile::Flush() {
 
   Aws::S3::Model::UploadPartOutcome outcome = client_->UploadPart(request);
   if (outcome.IsSuccess()) {
-    LOG(INFO) << "aws: s3 write file: upload part; part_number=" << parts_.size() + 1;
+    VLOG(2) << "aws: s3 write file: upload part; part_number=" << parts_.size() + 1;
 
     parts_.push_back(outcome.GetResult().GetETag());
     offset_ = 0;

--- a/util/aws/s3_write_file.cc
+++ b/util/aws/s3_write_file.cc
@@ -1,0 +1,141 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#include "util/aws/s3_write_file.h"
+
+#include <aws/s3/model/CompleteMultipartUploadRequest.h>
+#include <aws/s3/model/CreateMultipartUploadRequest.h>
+#include <aws/s3/model/UploadPartRequest.h>
+
+#include "base/logging.h"
+
+namespace util {
+namespace aws {
+
+io::Result<size_t> S3WriteFile::WriteSome(const iovec* v, uint32_t len) {
+  // Fill the pending buffer until we reach the part size, then flush and
+  // keep writing.
+  size_t total = 0;
+  for (size_t i = 0; i < len; ++i) {
+    const uint8_t* buf = reinterpret_cast<const uint8_t*>(v[i].iov_base);
+    const size_t len = v[i].iov_len;
+
+    size_t written = 0;
+    while (written < len) {
+      size_t n = len - written;
+      if (n > buf_.size() - offset_) {
+        // Limit to avoid exceeding the buffer size.
+        n = buf_.size() - offset_;
+      }
+      memcpy(buf_.data() + offset_, buf + written, n);
+      written += n;
+      total += n;
+      offset_ += n;
+
+      if (buf_.size() == offset_) {
+        std::error_code ec = Flush();
+        if (ec) {
+          return nonstd::make_unexpected(ec);
+        }
+      }
+    }
+  }
+
+  return total;
+}
+
+// Closes the object and completes the multipart upload. Therefore the object
+// will not be uploaded unless Close is called.
+std::error_code S3WriteFile::Close() {
+  std::error_code ec = Flush();
+  if (ec) {
+    return ec;
+  }
+
+  Aws::S3::Model::CompletedMultipartUpload completed_upload;
+  for (size_t i = 0; i != parts_.size(); i++) {
+    Aws::S3::Model::CompletedPart part;
+    part.SetPartNumber(i + 1);
+    part.SetETag(parts_[i]);
+    completed_upload.AddParts(part);
+  }
+
+  Aws::S3::Model::CompleteMultipartUploadRequest request;
+  request.SetBucket(bucket_);
+  request.SetKey(key_);
+  request.SetUploadId(upload_id_);
+  request.SetMultipartUpload(completed_upload);
+
+  Aws::S3::Model::CompleteMultipartUploadOutcome outcome =
+      client_->CompleteMultipartUpload(request);
+  if (outcome.IsSuccess()) {
+    LOG(INFO) << "aws: s3 write file: completed multipart upload; parts=" << parts_.size();
+  } else {
+    LOG(ERROR) << "aws: s3 write file: failed to complete multipart upload: "
+               << outcome.GetError().GetExceptionName();
+    return std::make_error_code(std::errc::io_error);
+  }
+
+  return std::error_code{};
+}
+
+io::Result<S3WriteFile> S3WriteFile::Open(const std::string& bucket, const std::string& key,
+                                          std::shared_ptr<Aws::S3::S3Client> client,
+                                          size_t part_size) {
+  Aws::S3::Model::CreateMultipartUploadRequest request;
+  request.SetBucket(bucket);
+  request.SetKey(key);
+  Aws::Utils::Outcome<Aws::S3::Model::CreateMultipartUploadResult, Aws::S3::S3Error> outcome =
+      client->CreateMultipartUpload(request);
+  if (outcome.IsSuccess()) {
+    VLOG(2) << "aws: s3 write file: created multipart upload; upload_id="
+            << outcome.GetResult().GetUploadId();
+    return S3WriteFile{bucket, key, outcome.GetResult().GetUploadId(), client, part_size};
+  } else {
+    LOG(ERROR) << "aws: s3 write file: failed to create multipart upload: "
+               << outcome.GetError().GetExceptionName();
+    return nonstd::make_unexpected(std::make_error_code(std::errc::io_error));
+  }
+}
+
+S3WriteFile::S3WriteFile(const std::string& bucket, const std::string& key,
+                         const std::string& upload_id, std::shared_ptr<Aws::S3::S3Client> client,
+                         size_t part_size)
+    : io::WriteFile{""}, bucket_{bucket}, key_{key}, upload_id_{upload_id},
+      buf_(part_size), client_{client} {
+}
+
+std::error_code S3WriteFile::Flush() {
+  if (offset_ == 0) {
+    return std::error_code{};
+  }
+
+  Aws::S3::Model::UploadPartRequest request;
+  request.SetBucket(bucket_);
+  request.SetKey(key_);
+  request.SetPartNumber(parts_.size() + 1);
+  request.SetUploadId(upload_id_);
+
+  // TODO(andydunstall): Look at avoiding this copy. We're copying to an IO
+  // stream, then back to a buffer in HTTP client.
+  std::shared_ptr<Aws::IOStream> object_stream = Aws::MakeShared<Aws::StringStream>("helio");
+  object_stream->write((const char*)buf_.data(), offset_);
+  request.SetBody(object_stream);
+
+  Aws::S3::Model::UploadPartOutcome outcome = client_->UploadPart(request);
+  if (outcome.IsSuccess()) {
+    LOG(INFO) << "aws: s3 write file: upload part; part_number=" << parts_.size() + 1;
+
+    parts_.push_back(outcome.GetResult().GetETag());
+    offset_ = 0;
+    return std::error_code{};
+  } else {
+    LOG(ERROR) << "aws: s3 write file: failed to upload part: "
+               << outcome.GetError().GetExceptionName();
+    return std::make_error_code(std::errc::io_error);
+  }
+  return std::error_code{};
+}
+
+}  // namespace aws
+}  // namespace util

--- a/util/aws/s3_write_file.cc
+++ b/util/aws/s3_write_file.cc
@@ -120,8 +120,8 @@ std::error_code S3WriteFile::Flush() {
 
   // Avoid copying by creating a stream that directly references the underlying
   // buffer. This is ok since we won't modify buf_ until the request completes.
-  std::shared_ptr<Aws::IOStream> stream =
-      std::make_shared<boost::interprocess::bufferstream>(reinterpret_cast<char*>(buf_.data()), offset_);
+  std::shared_ptr<Aws::IOStream> stream = std::make_shared<boost::interprocess::bufferstream>(
+      reinterpret_cast<char*>(buf_.data()), offset_);
   request.SetBody(stream);
 
   Aws::S3::Model::UploadPartOutcome outcome = client_->UploadPart(request);

--- a/util/aws/s3_write_file.cc
+++ b/util/aws/s3_write_file.cc
@@ -117,6 +117,7 @@ std::error_code S3WriteFile::Flush() {
   request.SetKey(key_);
   request.SetPartNumber(parts_.size() + 1);
   request.SetUploadId(upload_id_);
+  request.SetChecksumAlgorithm(Aws::S3::Model::ChecksumAlgorithm::CRC32);
 
   // Avoid copying by creating a stream that directly references the underlying
   // buffer. This is ok since we won't modify buf_ until the request completes.

--- a/util/aws/s3_write_file.h
+++ b/util/aws/s3_write_file.h
@@ -1,0 +1,62 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#pragma once
+
+#include <aws/s3/S3Client.h>
+
+#include "io/file.h"
+#include "io/io.h"
+
+namespace util {
+namespace aws {
+
+constexpr size_t kDefaultPartSize = 10 * (1 << 20);
+
+// File handle that writes to S3.
+//
+// This uses multipart uploads, where it will buffer upto the configured part
+// size before uploading.
+class S3WriteFile : public io::WriteFile {
+ public:
+  // Writes bytes to the S3 object. This will either buffer internally or
+  // write a part to S3.
+  io::Result<size_t> WriteSome(const iovec* v, uint32_t len) override;
+
+  // Closes the object and completes the multipart upload. Therefore the object
+  // will not be uploaded unless Close is called.
+  std::error_code Close() override;
+
+  static io::Result<S3WriteFile> Open(const std::string& bucket, const std::string& key,
+                                      std::shared_ptr<Aws::S3::S3Client> client,
+                                      size_t part_size = kDefaultPartSize);
+
+ private:
+  S3WriteFile(const std::string& bucket, const std::string& key, const std::string& upload_id,
+              std::shared_ptr<Aws::S3::S3Client> client, size_t part_size = kDefaultPartSize);
+
+  // Uploads the data buffered in buf_. Note this must not be called until
+  // there are at least 5MB bytes in buf_, unless it is the last upload.
+  std::error_code Flush();
+
+  std::string bucket_;
+
+  std::string key_;
+
+  std::string upload_id_;
+
+  // Etags of the uploaded parts.
+  std::vector<std::string> parts_;
+
+  // A buffer containing the pending bytes waiting to be uploaded. Only offset_
+  // bytes have been written.
+  std::vector<uint8_t> buf_;
+
+  // Offset of the consumed bytes in buf_.
+  size_t offset_ = 0;
+
+  std::shared_ptr<Aws::S3::S3Client> client_;
+};
+
+}  // namespace aws
+}  // namespace util

--- a/util/aws/s3_write_file.h
+++ b/util/aws/s3_write_file.h
@@ -11,7 +11,7 @@
 namespace util {
 namespace aws {
 
-constexpr size_t kDefaultPartSize = 10 * (1 << 20);
+constexpr size_t kDefaultPartSize = 1ULL << 23;  // 8MB.
 
 // File handle that writes to S3.
 //


### PR DESCRIPTION
Adds support for using the AWS SDK.

Using the AWS SDK isn't ideal as it doesn't work that well with fibers and is slow and complex to build given it has lots of dependencies, though it seems like the simplest and fastest way to build a reliable S3 client for snapshots. Long term we may want to copy the subset of the SDK we use and re-implement, though that would still be a lot of work given theres a lot of complexity and edge cases...

# Changes

## Logger
Adds a custom AWS logger that uses glog, rather than the default AWS logger which writes to a file so requires separate configuration

This has some duplication, though I'm not sure how to avoid that. Since we're using glog, if the log is disabled the right side of the log won't run, including `message_stream.str()` which does a copy, so if we refactored that into a method or something we'd be copying the message without logging it...

## Credentials
Adds a custom credential provider chain that supports:
- Environment
- Local profile configuration
- EC2 metadata (which can be disabled with `AWS_EC2_METADATA_DISABLED`)

Reading the environment won't block, and EC2 metadata uses the non-blocking HTTP client which is fine. Though loading the local profile configuration uses a blocking system call to read the file, however this happens very rarely (once on startup then whenever the credentials expire, if they ever expire) so less then a millisecond of thread blocking, no more than once every few hours seems ok for now. It will also only block when a snapshot is in progress which will already have overhead.

## HTTP Client
We must extend the SDK with a non-thread-blocking HTTP client.

### Thread Safe
The SDK creates a global HTTP client for EC2 metadata that may be used by any thread when fetching new credentials, therefore the HTTP client must be thread safe and usable by multiple proactors. This also means we only need a single S3 client that can be used by all threads which means we only have to load config and credentials once.

Since socket connections must be created and used by the same proactor, and we must never block the thread, the simplest option to make a thread safe HTTP client is to make the HTTP client stateless for now and create a new connection per request.

Since our S3 requests are large (8MB request/response), the overhead of connections is negligible so seems ok just to reconnect on each request. Benchmarking didn't see any difference with/without caching. Later we could do something like have `HttpClient::MakeRequest` get a set of cached connections for the current fiber from an array `proactor_clients_[proactor.id]` to avoid having to use a global thread blocking lock. (Connecting may have a bigger overhead with HTTPS? Though so far we only support HTTP so will leave)

### Retries
When the AWS client retries, it backs off by putting the thread to sleep. Fortunately this sleep is done by the HTTP client in `HttpClient::RetryRequestSleep`, but unfortunately the method isn't virtual so can't be overridden by our custom HTTP client. Therefore this applies a simple patch in CMake to make the method virtual so we can block the fiber but not the thread.

Note the `HttpClient` has methods like `EnableRequestProcessing` which disable request processing, though they are only used for testing so not implementing in our client as it would be complex given it must be thread safe.

### Redirects
The SDK handles redirects for us so we don't need it in the HTTP client.

### Performance
#### Upload
When uploading, to map AWS HTTP requests to boost HTTP requests, this uses `boost::interprocess::bufferstream` so the `Aws::IoStream` uses a fixed underlying buffer, then the HTTP client just writes this underlying buffer directly to the socket and avoids any copies. This is a bit of a hack but significantly improves performance.

The remaining performance issues are:
* The SDK signs the payload rather than just the headers which requires an `SHA-256` hash and adds a `SHA-256` content header
  * The SDK requires it signs the payload if sent over HTTP not HTTPS, though we could patch if needed
* The SDK calculates an MD5 header of the uploaded payload

The old client doesn't do either of these (the signature only includes the headers)

Benchmarking a 5GB upload (using `s3v2_demo`):
* New client without MD5 or signature: 10% CPU, 26s
* New client with MD5 but no SHA-256 signature: 40% CPU, 26s
* New client with SHA-256 signature but no MD5: 25% CPU, 30s
* Legacy client: 10% CPU, 26s

So without the MD5 header and signing the payload (which is the same behaviour as the old client), the performance is the same as the old client. Though adding MD5 and payload signature adds latency and resource usage.

Having both the MD5 and payload signature seems redundant. Therefore we can remove the MD5 header and just keep the payload signature. Removing the MD5 will require patching the SDK to allow disabling the checksum in the `UploadPartRequest`. (Though the MD5 is a SOC2 requirement, so it depends if a payload SHA-256 signature is enough)

Note the SDK only includes the payload in the signature when using HTTP rather than HTTPS, so if we add HTTPS support we may have to add back the MD5 header

Note if high resource usage becomes an issue and is too disruptive to normal traffic, we can add client side rate limiting to slow down.

#### Downloads
The download is a bit slower than the old client, though its not as much of an issue given it only happens once on boot. Once integrated with Dragonfly can benchmark and look at improving.

### Timeouts
The HTTP client is configured with connection and request timeouts which we should support, will add in another PR.

### HTTPS
Not including HTTPS support in this PR. Can include later if required.

## Custom Endpoint
We need to be able to configure custom S3 endpoints to test locally (such as MinIO).

According to https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html, custom endpoints are not supported by the C++ SDK, therefore this uses a custom S3 endpoint provider to support custom endpoints ourselves.

## S3
The SDK has a 'transfer manager', though that is built for uploading local files rather than our 'writer' and 'reader' file interface, plus it also has some complex 'executor' event loop which we don't need.

Therefore we add our own `S3ReadFile` and `S3WriteFile` implementations.

The `S3ReadFile` uses [`GetObject`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html) which accepts a byte range to fetch, so we can fetch large objects in 10MB chunks.

The `S3WriteFile` uses [multipart uploads](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html) with `CreateMultipartUpload`, `UploadPart`, and `CompleteMultipartUpload`, where we upload 10MB parts and S3 aggregates the result.

Both of these match how the SDK handles large downloads and uploads (mostly reading the Go SDK)

## Testing and Performance
Added some upload/download benchmarks above.

Will add more benchmarks and testing on the Dragonfly integration PR (see https://github.com/dragonflydb/dragonfly/pull/1929). Also assuming to leave automated regression tests to Dragonfly rather than Helio...