### PR TITLE
fix: macos thread blocking in `EpollProactor::PeriodicCb`

### DIFF
--- a/util/fibers/epoll_proactor.cc
+++ b/util/fibers/epoll_proactor.cc
@@ -461,10 +461,13 @@ void EpollProactor::PeriodicCb(PeriodicItem* item) {
   }
 
   item->task();
+
+#ifdef __linux__
   uint64_t res;
   if (read(item->val1, &res, sizeof(res)) == -1) {
     LOG(ERROR) << "Error reading from timer, errno " << errno;
   }
+#endif
 }
 
 void EpollProactor::DispatchCompletions(const void* cevents, unsigned count) {


### PR DESCRIPTION
The `read` call at https://github.com/romange/helio/blob/4c261c19f415ffde5ec9af09915d4d3704e330fe/util/fibers/epoll_proactor.cc#L465 blocks forever meaning that thread is just blocked. That `read` makes sense with Linux `timerfd_create` though I don't understand it for `kqueue`