### PR TITLE
feat(aws): remove crc32 checksum

### DIFF
--- a/util/aws/s3_write_file.cc
+++ b/util/aws/s3_write_file.cc
@@ -117,7 +117,6 @@ std::error_code S3WriteFile::Flush() {
   request.SetKey(key_);
   request.SetPartNumber(parts_.size() + 1);
   request.SetUploadId(upload_id_);
-  request.SetChecksumAlgorithm(Aws::S3::Model::ChecksumAlgorithm::CRC32);
 
   // Avoid copying by creating a stream that directly references the underlying
   // buffer. This is ok since we won't modify buf_ until the request completes.

--- a/util/aws/s3_write_file.h
+++ b/util/aws/s3_write_file.h
@@ -13,6 +13,11 @@ namespace aws {
 
 constexpr size_t kDefaultPartSize = 1ULL << 23;  // 8MB.
 
+struct PartMetadata {
+  std::string etag;
+  std::string crc32;
+};
+
 // File handle that writes to S3.
 //
 // This uses multipart uploads, where it will buffer upto the configured part
@@ -46,7 +51,7 @@ class S3WriteFile : public io::WriteFile {
   std::string upload_id_;
 
   // Etags of the uploaded parts.
-  std::vector<std::string> parts_;
+  std::vector<PartMetadata> parts_;
 
   // A buffer containing the pending bytes waiting to be uploaded. Only offset_
   // bytes have been written.


### PR DESCRIPTION
Using the CRC32 header works on MinIO, though running again on S3 before merging the dragonfly changes found S3 returning:
```
Checksum Type mismatch occurred, expected checksum Type: null, actual checksum Type: crc32
```

I don't understand why given it has headers:
```
x-amz-sdk-checksum-algorithm: CRC32\r\n
x-amz-checksum-crc32: uDr/9A==\r\n
```
So I don't know why it expects no checksum... I'm fairly certain it worked before, though maybe I was only testing MinIO (another argument for regression tests using S3 directly)

Will remove for now just to unblock merging the Dragonfly side (it was to improve resource usage rather than a functional requirement) - will look at next