### PR TITLE
fix: expand on a check-fail output that crashed in a test

### DIFF
--- a/util/tls/tls_engine.cc
+++ b/util/tls/tls_engine.cc
@@ -117,6 +117,17 @@ auto Engine::PeekOutputBuf() -> BufResult {
 
 void Engine::ConsumeOutputBuf(unsigned sz) {
   int res = BIO_nread(external_bio_, NULL, sz);
+  if (res <= 0) {
+    unsigned long error = ::ERR_get_error();
+    char buf[256];
+    ERR_error_string_n(error, buf, sizeof(buf));
+    char* ebuf = nullptr;
+
+    long res = BIO_ctrl(external_bio_, BIO_C_NREAD0, 0, &ebuf);
+
+    LOG(FATAL) << "Unexpected error " << buf << " " << error << " when consuming " << sz
+               << " bytes from BIO, BIO_C_NREAD0 returns " << res;
+  }
   CHECK_GT(res, 0);
   CHECK_EQ(unsigned(res), sz);
 }


### PR DESCRIPTION
see https://github.com/dragonflydb/dragonfly/actions/runs/6436749970/job/17480707509?pr=1998#step:10:1424

We peek into tls engine to see if it produced some output to write into a socket, then we write some and then we consume (drain) the output that we written. The flow is not atomic so it may definitely create errors but unfortunately I still do not understand context well enough to fix the code.