### PR TITLE
chore: track delays when context switching between fibers

### DIFF
--- a/util/fibers/detail/fiber_interface.h
+++ b/util/fibers/detail/fiber_interface.h
@@ -64,7 +64,7 @@ class FiberInterface {
 
   FI_ListHook fibers_hook;  // For a list of all fibers in the thread
 
-  ::boost::context::fiber_context SwitchTo();
+  ::boost::context::fiber_context SwitchTo(uint64_t now);
 
   using PrintFn = std::function<void(FiberInterface*)>;
 
@@ -79,7 +79,6 @@ class FiberInterface {
 
   void Join();
 
-  // inline
   void Yield();
 
   // inline
@@ -192,6 +191,7 @@ class FiberInterface {
 
   std::atomic<FiberInterface*> remote_next_{nullptr};
   std::chrono::steady_clock::time_point tp_;
+  uint64_t ready_ts_ = 0;  // when this fiber became ready in nanoseconds.
 
   char name_[24];
 };
@@ -260,7 +260,13 @@ FiberInterface* FiberActive() noexcept;
 void EnterFiberAtomicSection() noexcept;
 void LeaveFiberAtomicSection() noexcept;
 bool IsFiberAtomicSection() noexcept;
+
+// Returns the current epoch of the fiber scheduler.
 uint64_t FiberEpoch() noexcept;
+
+// Returns the aggregated delay between activation of fibers and
+// the time they were switched to.
+uint64_t FiberSwitchDelay() noexcept;
 
 void PrintAllFiberStackTraces();
 

--- a/util/fibers/detail/fiber_interface_impl.h
+++ b/util/fibers/detail/fiber_interface_impl.h
@@ -9,11 +9,6 @@ namespace util {
 namespace fb2 {
 namespace detail {
 
-inline void FiberInterface::Yield() {
-  scheduler_->AddReady(this);
-  scheduler_->Preempt();
-}
-
 inline bool FiberInterface::WaitUntil(std::chrono::steady_clock::time_point tp) {
   return scheduler_->WaitUntil(tp, this);
 }

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -3,6 +3,7 @@
 //
 #include "util/fibers/detail/scheduler.h"
 
+#include <absl/time/clock.h>
 #include <condition_variable>
 #include <mutex>
 
@@ -396,7 +397,7 @@ ctx::fiber DispatcherImpl::Run(ctx::fiber&& c) {
   // Like with worker fibers, we switch to another fiber, but in this case to the main fiber.
   // We will come back here during the deallocation of DispatcherImpl from intrusive_ptr_release
   // in order to return from Run() and come back to main context.
-  auto fc = scheduler_->main_context()->SwitchTo();
+  auto fc = scheduler_->main_context()->SwitchTo(absl::GetCurrentTimeNanos());
 
   DCHECK(fc);  // Should bring us back to main, into intrusive_ptr_release.
   return fc;
@@ -416,15 +417,17 @@ void DispatcherImpl::DefaultDispatch(Scheduler* sched) {
       sched->ProcessSleep();
     }
 
+    uint64_t now = absl::GetCurrentTimeNanos();
+
     if (sched->HasReady()) {
       FiberInterface* fi = sched->PopReady();
       DCHECK(!fi->list_hook.is_linked());
       DCHECK(!fi->sleep_hook.is_linked());
-      sched->AddReady(this);
+      sched->AddReady(now, this);
 
       DVLOG(2) << "Switching to " << fi->name();
       // qsbr_worker_fiber_online();
-      fi->SwitchTo();
+      fi->SwitchTo(now);
       DCHECK(!list_hook.is_linked());
       DCHECK(FiberActive() == this);
       // qsbr_worker_fiber_offline();
@@ -466,13 +469,13 @@ Scheduler::~Scheduler() {
   while (HasReady()) {
     FiberInterface* fi = PopReady();
     DCHECK(!fi->sleep_hook.is_linked());
-    fi->SwitchTo();
+    fi->SwitchTo(absl::GetCurrentTimeNanos());
   }
 
   DispatcherImpl* dimpl = static_cast<DispatcherImpl*>(dispatch_cntx_.get());
   if (!dimpl->is_terminating()) {
     DVLOG(1) << "~Scheduler switching to dispatch " << dispatch_cntx_->IsDefined();
-    auto fc = dispatch_cntx_->SwitchTo();
+    auto fc = dispatch_cntx_->SwitchTo(absl::GetCurrentTimeNanos());
     CHECK(!fc);
     CHECK(dimpl->is_terminating());
   }
@@ -495,20 +498,21 @@ ctx::fiber_context Scheduler::Preempt() {
 
   if (ready_queue_.empty()) {
     // All user fibers are inactive, we should switch back to the dispatcher.
-    return dispatch_cntx_->SwitchTo();
+    return dispatch_cntx_->SwitchTo(absl::GetCurrentTimeNanos());
   }
 
   DCHECK(!ready_queue_.empty());
   FiberInterface* fi = &ready_queue_.front();
   ready_queue_.pop_front();
 
-  return fi->SwitchTo();
+  return fi->SwitchTo(absl::GetCurrentTimeNanos());
 }
 
-void Scheduler::AddReady(FiberInterface* fibi) {
+void Scheduler::AddReady(uint64_t now_ns, FiberInterface* fibi) {
   DCHECK(!fibi->list_hook.is_linked());
   DVLOG(1) << "Adding " << fibi->name() << " to ready_queue_";
 
+  fibi->ready_ts_ = now_ns;
   ready_queue_.push_back(*fibi);
 
   // Case of notifications coming to a sleeping fiber.
@@ -606,6 +610,8 @@ bool Scheduler::WaitUntil(chrono::steady_clock::time_point tp, FiberInterface* m
 }
 
 void Scheduler::ProcessRemoteReady() {
+  uint64_t now = absl::GetCurrentTimeNanos();
+
   while (true) {
     FiberInterface* fi = remote_ready_queue_.Pop();
     if (!fi)
@@ -622,7 +628,7 @@ void Scheduler::ProcessRemoteReady() {
     // fiber to ready_queue.
     if (!fi->list_hook.is_linked()) {
       DVLOG(2) << "set ready " << fi->name();
-      AddReady(fi);
+      AddReady(now, fi);
     }
 
     // When we push fi to remote_ready_queue_ we increase the reference count.
@@ -646,6 +652,7 @@ void Scheduler::ProcessSleep() {
     DCHECK(!fi.list_hook.is_linked());
     DVLOG(2) << "timeout for " << fi.name();
     fi.tp_ = chrono::steady_clock::time_point::max();  // meaning it has timed out.
+    fi.ready_ts_ = absl::GetCurrentTimeNanos();
     ready_queue_.push_back(fi);
   } while (!sleep_queue_.empty());
 }

--- a/util/fibers/detail/scheduler.h
+++ b/util/fibers/detail/scheduler.h
@@ -26,7 +26,7 @@ class Scheduler {
   Scheduler(FiberInterface* main);
   ~Scheduler();
 
-  void AddReady(FiberInterface* fibi);
+  void AddReady(uint64_t now_ns, FiberInterface* fibi);
 
   // ScheduleFromRemote is called from a different thread than the one that runs the scheduler.
   // fibi must exist during the run of this function.

--- a/util/fibers/epoll_proactor.cc
+++ b/util/fibers/epoll_proactor.cc
@@ -295,10 +295,13 @@ void EpollProactor::MainLoop(detail::Scheduler* scheduler) {
       FiberInterface* fi = scheduler->PopReady();
       DCHECK(!fi->list_hook.is_linked());
       DCHECK(!fi->sleep_hook.is_linked());
-      scheduler->AddReady(dispatcher);
+      tl_info_.monotonic_time = GetClockNanos();
+
+      scheduler->AddReady(tl_info_.monotonic_time, dispatcher);
 
       DVLOG(2) << "Switching to " << fi->name();
-      fi->SwitchTo();
+
+      fi->SwitchTo(tl_info_.monotonic_time);
       cqe_count = 1;
     }
 

--- a/util/fibers/fiber2.h
+++ b/util/fibers/fiber2.h
@@ -88,6 +88,10 @@ inline uint64_t FiberSwitchEpoch() noexcept {
   return detail::FiberEpoch();
 }
 
+inline uint64_t FiberSwitchDelay() noexcept {
+  return detail::FiberSwitchDelay();
+}
+
 }  // namespace fb2
 
 template <typename Fn, typename... Arg> fb2::Fiber MakeFiber(Fn&& fn, Arg&&... arg) {

--- a/util/fibers/uring_proactor.cc
+++ b/util/fibers/uring_proactor.cc
@@ -562,11 +562,11 @@ void UringProactor::MainLoop(detail::Scheduler* scheduler) {
       FiberInterface* fi = scheduler->PopReady();
       DCHECK(!fi->list_hook.is_linked());
       DCHECK(!fi->sleep_hook.is_linked());
-      scheduler->AddReady(dispatcher);
+      tl_info_.monotonic_time = GetClockNanos();
+      scheduler->AddReady(tl_info_.monotonic_time, dispatcher);
 
       DVLOG(2) << "Switching to " << fi->name();
-
-      fi->SwitchTo();
+      fi->SwitchTo(tl_info_.monotonic_time);
     }
 
     if (cqe_count) {
@@ -592,7 +592,6 @@ void UringProactor::MainLoop(detail::Scheduler* scheduler) {
       scheduler->DestroyTerminated();
       scheduler->RunDeferred();
 
-      // Pause(spin_loops);
       continue;
     }
 


### PR DESCRIPTION
This metric should help us measuring responsiveness of fiber switching.