### PR TITLE
fix: prevent compiler optimizations related to loading stale tls object

### DIFF
--- a/util/fibers/proactor_base.cc
+++ b/util/fibers/proactor_base.cc
@@ -107,6 +107,16 @@ void ProactorBase::Stop() {
   VLOG(1) << "Proactor::StopFinish";
 }
 
+bool ProactorBase::InMyThread() const {
+  // This function should not be inline by design.
+  // Together with this barrier, it makes sure that pthread_self() is not cached even when
+  // the caller stack migrates between threads.
+  // See: https://stackoverflow.com/a/75622732
+  asm volatile("");
+
+  return pthread_self() == thread_id_;
+}
+
 uint32_t ProactorBase::AddOnIdleTask(OnIdleTask f) {
   DCHECK(InMyThread());
 

--- a/util/fibers/proactor_base.h
+++ b/util/fibers/proactor_base.h
@@ -66,9 +66,7 @@ class ProactorBase {
    * @return true
    * @return false
    */
-  bool InMyThread() const {
-    return pthread_self() == thread_id_;
-  }
+  bool InMyThread() const;
 
   // pthread id.
   pthread_t thread_id() const {

--- a/util/listener_interface.h
+++ b/util/listener_interface.h
@@ -96,13 +96,16 @@ class ListenerInterface {
   }
 
  private:
+  struct TLConnList;  // threadlocal connection list. contains connections for that thread.
+  using ListenerConnMap = std::unordered_map<ListenerInterface*, TLConnList*>;
+
   void RunAcceptLoop();
 
   void RunSingleConnection(Connection* conn);
 
-  struct TLConnList;  // threadlocal connection list. contains connections for that thread.
+  static ListenerConnMap* GetSafeTlsConnMap();
 
-  static thread_local std::unordered_map<ListenerInterface*, TLConnList*> conn_list;
+  static thread_local ListenerConnMap conn_list;
 
   std::unique_ptr<FiberSocketBase> sock_;
   // Number of max connections. Unlimited by default.


### PR DESCRIPTION
Specifically, during the function stack migration between threads we may encounter faulty compiler optimizations in the release mode. See https://stackoverflow.com/questions/75592038/how-to-disable-clang-expression-elimination-for-thread-local-variable for more details.