### PR TITLE
fix: improve time measurement performance in fibers

### DIFF
--- a/examples/raw_echo_server.cc
+++ b/examples/raw_echo_server.cc
@@ -18,6 +18,7 @@
 #include "base/mpmc_bounded_queue.h"
 #include "base/pthread_utils.h"
 #include "util/fibers/fibers.h"
+#include "util/fibers/detail/utils.h"
 
 ABSL_FLAG(int16_t, port, 8081, "Echo server port");
 ABSL_FLAG(uint32_t, size, 512, "Message size");
@@ -333,10 +334,9 @@ void RunEventLoop(int worker_id, io_uring* ring, fb2::detail::Scheduler* sched) 
     if (sched->HasReady()) {
       do {
         FiberInterface* fi = sched->PopReady();
-        uint64_t now = absl::GetCurrentTimeNanos();
-        sched->AddReady(now, dispatcher);
+        sched->AddReady(dispatcher);
 
-        auto fc = fi->SwitchTo(now);
+        auto fc = fi->SwitchTo();
         DCHECK(!fc);
       } while (sched->HasReady());
       continue;

--- a/util/fibers/CMakeLists.txt
+++ b/util/fibers/CMakeLists.txt
@@ -5,7 +5,8 @@ endif()
 
 add_library(fibers2 fibers.cc proactor_base.cc synchronization.cc
             fiber_file.cc epoll_proactor.cc epoll_socket.cc pool.cc
-            detail/scheduler.cc detail/fiber_interface.cc detail/wait_queue.cc accept_server.cc
+            detail/scheduler.cc detail/fiber_interface.cc detail/wait_queue.cc detail/utils.cc
+            accept_server.cc
             fiber_socket_base.cc listener_interface.cc
             prebuilt_asio.cc proactor_pool.cc stacktrace.cc
             sliding_counter.cc varz.cc fiberqueue_threadpool.cc dns_resolve.cc

--- a/util/fibers/detail/fiber_interface.h
+++ b/util/fibers/detail/fiber_interface.h
@@ -64,7 +64,7 @@ class FiberInterface {
 
   FI_ListHook fibers_hook;  // For a list of all fibers in the thread
 
-  ::boost::context::fiber_context SwitchTo(uint64_t now);
+  ::boost::context::fiber_context SwitchTo();
 
   using PrintFn = std::function<void(FiberInterface*)>;
 
@@ -194,8 +194,8 @@ class FiberInterface {
   // used for sleeping with a timeout. Specifies the time when this fiber should be woken up.
   std::chrono::steady_clock::time_point tp_;
 
-  // A timestamp of when this fiber becames ready or becomes active (in ns).
-  uint64_t ts_ns_ = 0;
+  // A tsc of when this fiber becames ready or becomes active (in cycles).
+  uint64_t cpu_tsc_ = 0;
 
   char name_[24];
 };

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -11,6 +11,7 @@
 
 #include "base/logging.h"
 #include "util/fibers/stacktrace.h"
+#include "util/fibers/detail/utils.h"
 
 namespace util {
 namespace fb2 {
@@ -399,7 +400,7 @@ ctx::fiber DispatcherImpl::Run(ctx::fiber&& c) {
   // Like with worker fibers, we switch to another fiber, but in this case to the main fiber.
   // We will come back here during the deallocation of DispatcherImpl from intrusive_ptr_release
   // in order to return from Run() and come back to main context.
-  auto fc = scheduler_->main_context()->SwitchTo(absl::GetCurrentTimeNanos());
+  auto fc = scheduler_->main_context()->SwitchTo();
 
   DCHECK(fc);  // Should bring us back to main, into intrusive_ptr_release.
   return fc;
@@ -419,20 +420,17 @@ void DispatcherImpl::DefaultDispatch(Scheduler* sched) {
       sched->ProcessSleep();
     }
 
-    uint64_t now = absl::GetCurrentTimeNanos();
-
     if (sched->HasReady()) {
       FiberInterface* fi = sched->PopReady();
       DCHECK(!fi->list_hook.is_linked());
       DCHECK(!fi->sleep_hook.is_linked());
-      sched->AddReady(now, this);
+      sched->AddReady(this);
 
       DVLOG(2) << "Switching to " << fi->name();
-      // qsbr_worker_fiber_online();
-      fi->SwitchTo(now);
+
+      fi->SwitchTo();
       DCHECK(!list_hook.is_linked());
       DCHECK(FiberActive() == this);
-      // qsbr_worker_fiber_offline();
     } else {
       sched->DestroyTerminated();
 
@@ -471,13 +469,13 @@ Scheduler::~Scheduler() {
   while (HasReady()) {
     FiberInterface* fi = PopReady();
     DCHECK(!fi->sleep_hook.is_linked());
-    fi->SwitchTo(absl::GetCurrentTimeNanos());
+    fi->SwitchTo();
   }
 
   DispatcherImpl* dimpl = static_cast<DispatcherImpl*>(dispatch_cntx_.get());
   if (!dimpl->is_terminating()) {
     DVLOG(1) << "~Scheduler switching to dispatch " << dispatch_cntx_->IsDefined();
-    auto fc = dispatch_cntx_->SwitchTo(absl::GetCurrentTimeNanos());
+    auto fc = dispatch_cntx_->SwitchTo();
     CHECK(!fc);
     CHECK(dimpl->is_terminating());
   }
@@ -500,21 +498,21 @@ ctx::fiber_context Scheduler::Preempt() {
 
   if (ready_queue_.empty()) {
     // All user fibers are inactive, we should switch back to the dispatcher.
-    return dispatch_cntx_->SwitchTo(absl::GetCurrentTimeNanos());
+    return dispatch_cntx_->SwitchTo();
   }
 
   DCHECK(!ready_queue_.empty());
   FiberInterface* fi = &ready_queue_.front();
   ready_queue_.pop_front();
 
-  return fi->SwitchTo(absl::GetCurrentTimeNanos());
+  return fi->SwitchTo();
 }
 
-void Scheduler::AddReady(uint64_t now_ns, FiberInterface* fibi) {
+void Scheduler::AddReady(FiberInterface* fibi) {
   DCHECK(!fibi->list_hook.is_linked());
   DVLOG(1) << "Adding " << fibi->name() << " to ready_queue_";
 
-  fibi->ts_ns_ = now_ns;
+  fibi->cpu_tsc_ = CycleClock::Now();
   ready_queue_.push_back(*fibi);
 
   // Case of notifications coming to a sleeping fiber.
@@ -612,8 +610,6 @@ bool Scheduler::WaitUntil(chrono::steady_clock::time_point tp, FiberInterface* m
 }
 
 void Scheduler::ProcessRemoteReady() {
-  uint64_t now = absl::GetCurrentTimeNanos();
-
   while (true) {
     FiberInterface* fi = remote_ready_queue_.Pop();
     if (!fi)
@@ -630,7 +626,7 @@ void Scheduler::ProcessRemoteReady() {
     // fiber to ready_queue.
     if (!fi->list_hook.is_linked()) {
       DVLOG(2) << "set ready " << fi->name();
-      AddReady(now, fi);
+      AddReady(fi);
     }
 
     // When we push fi to remote_ready_queue_ we increase the reference count.
@@ -654,7 +650,7 @@ void Scheduler::ProcessSleep() {
     DCHECK(!fi.list_hook.is_linked());
     DVLOG(2) << "timeout for " << fi.name();
     fi.tp_ = chrono::steady_clock::time_point::max();  // meaning it has timed out.
-    fi.ts_ns_ = absl::GetCurrentTimeNanos();
+    fi.cpu_tsc_ = CycleClock::Now();
     ready_queue_.push_back(fi);
   } while (!sleep_queue_.empty());
 }

--- a/util/fibers/detail/scheduler.h
+++ b/util/fibers/detail/scheduler.h
@@ -26,7 +26,7 @@ class Scheduler {
   Scheduler(FiberInterface* main);
   ~Scheduler();
 
-  void AddReady(uint64_t now_ns, FiberInterface* fibi);
+  void AddReady(FiberInterface* fibi);
 
   // ScheduleFromRemote is called from a different thread than the one that runs the scheduler.
   // fibi must exist during the run of this function.

--- a/util/fibers/detail/utils.cc
+++ b/util/fibers/detail/utils.cc
@@ -1,0 +1,76 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#include "util/fibers/detail/utils.h"
+
+#include <time.h>
+
+#include "base/logging.h"
+
+namespace util {
+namespace fb2 {
+
+namespace detail {
+namespace {
+
+#if defined(__x86_64__)
+
+inline uint64_t clock_nanos() {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (uint64_t)ts.tv_sec * 1000000000 + ts.tv_nsec;
+}
+
+constexpr uint64_t kDelayNs = 1000000; // 1ms
+
+// Returns the number of cycles per millisecond.
+uint64_t do_sample() {
+  asm volatile ("" : : : "memory");   // compiler fence to prevent reordering
+  uint64_t start = clock_nanos();
+  uint64_t tscbefore = CycleClock::Now();
+  uint64_t now;
+  do {
+    now = clock_nanos();
+  } while (now < start + kDelayNs);
+
+  uint64_t tscafter = CycleClock::Now();
+  return (tscafter - tscbefore) * 1000000u / (now - start);
+}
+
+// Returns the number of cycles per microsecond.
+static uint64_t tsc_from_cal() {
+  constexpr unsigned kSamples = 74;
+  uint64_t samples[kSamples];
+
+  for (size_t s = 0; s < kSamples; s++) {
+    samples[s] = do_sample();
+  }
+
+  uint64_t sum = 0;
+  // discard the first half of the samples.
+  for (unsigned s = kSamples / 2; s < kSamples; s++) {
+    sum += samples[s];
+  }
+
+  uint64_t avg = sum / (kSamples / 2);
+  // round to the nearest multiple of 1000.
+  return (avg + 500) / 1000;
+}
+#endif
+}  // namespace
+
+uint64_t CycleClock::FrequencyUsec() {
+  uint64_t res;
+#if defined(__x86_64__)
+  res = tsc_from_cal();
+#elif defined(__aarch64__)
+  __asm__ volatile("mrs %0, cntfrq_el0" : "=r"(res));
+  res /= 1000000;
+#endif
+  return res;
+}
+
+}  // namespace detail
+}  // namespace fb2
+}  // namespace util

--- a/util/fibers/detail/utils.h
+++ b/util/fibers/detail/utils.h
@@ -1,0 +1,48 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <cstdint>
+
+namespace util {
+namespace fb2 {
+
+namespace detail {
+
+inline void CpuPause() {
+#if defined(__i386__) || defined(__amd64__)
+  __asm__ __volatile__("pause");
+#elif defined(__aarch64__)
+  /* Use an isb here as we've found it's much closer in duration to
+   * the x86 pause instruction vs. yield which is a nop and thus the
+   * loop count is lower and the interconnect gets a lot more traffic
+   * from loading the ticket above. */
+  __asm__ __volatile__("isb");
+#endif
+}
+
+class CycleClock {
+ public:
+  static uint64_t Now() {
+#if defined(__x86_64__)
+    uint64_t low, high;
+    __asm__ volatile("rdtsc" : "=a"(low), "=d"(high));
+    return (high << 32) | low;
+#elif defined(__aarch64__)
+    uint64_t val;
+    __asm__ volatile("mrs %0, cntvct_el0" : "=r"(val));
+    return val;
+#else
+#error "Unsupported architecture"
+#endif
+  }
+
+  // number of cycles per millisecond.
+  static uint64_t FrequencyUsec();
+};
+
+}  // namespace detail
+}  // namespace fb2
+}  // namespace util

--- a/util/fibers/epoll_proactor.cc
+++ b/util/fibers/epoll_proactor.cc
@@ -303,13 +303,12 @@ void EpollProactor::MainLoop(detail::Scheduler* scheduler) {
       FiberInterface* fi = scheduler->PopReady();
       DCHECK(!fi->list_hook.is_linked());
       DCHECK(!fi->sleep_hook.is_linked());
-      tl_info_.monotonic_time = GetClockNanos();
 
-      scheduler->AddReady(tl_info_.monotonic_time, dispatcher);
+      scheduler->AddReady(dispatcher);
 
       DVLOG(2) << "Switching to " << fi->name();
-
-      fi->SwitchTo(tl_info_.monotonic_time);
+      tl_info_.monotonic_time = GetClockNanos();
+      fi->SwitchTo();
       cqe_count = 1;
     }
 

--- a/util/fibers/fiber2.h
+++ b/util/fibers/fiber2.h
@@ -87,14 +87,14 @@ class Fiber {
 uint64_t FiberSwitchEpoch() noexcept;
 
 // Returns the aggregated delay between activation of fibers and
-// the time they were switched to.
-uint64_t FiberSwitchDelay() noexcept;
+// the time they were switched to in microseconds.
+uint64_t FiberSwitchDelayUsec() noexcept;
 
 // Exposes the number of times fiber were running for a "long" time (longer than 1ms).
 uint64_t FiberLongRunCnt() noexcept;
 
 // Exposes total duration of fibers running for a "long" time (longer than 1ms).
-uint64_t FiberLongRunSum() noexcept;
+uint64_t FiberLongRunSumUsec() noexcept;
 
 }  // namespace fb2
 

--- a/util/fibers/uring_proactor.cc
+++ b/util/fibers/uring_proactor.cc
@@ -565,11 +565,11 @@ void UringProactor::MainLoop(detail::Scheduler* scheduler) {
       FiberInterface* fi = scheduler->PopReady();
       DCHECK(!fi->list_hook.is_linked());
       DCHECK(!fi->sleep_hook.is_linked());
-      tl_info_.monotonic_time = GetClockNanos();
-      scheduler->AddReady(tl_info_.monotonic_time, dispatcher);
+      scheduler->AddReady(dispatcher);
 
       DVLOG(2) << "Switching to " << fi->name();
-      fi->SwitchTo(tl_info_.monotonic_time);
+      tl_info_.monotonic_time = GetClockNanos();
+      fi->SwitchTo();
     }
 
     if (cqe_count) {


### PR DESCRIPTION
Replace fiber switch latency measurement with cycle clock, assuming that modern CPUs have constant tsc cycle and these measurements are not critical for correctness.