### PR TITLE
fix: errorneus check-fail due to redundant tls read

### DIFF
--- a/examples/echo_server.cc
+++ b/examples/echo_server.cc
@@ -511,7 +511,7 @@ size_t TLocalClient::Run() {
   ThisFiber::SetName("RunClient");
   base::Histogram hist;
 
-  LOG(INFO) << "RunClient " << p_->GetIndex();
+  LOG(INFO) << "RunClient " << p_->GetPoolIndex();
 
   vector<Fiber> fbs(drivers_.size());
   size_t res = 0;

--- a/util/connection.h
+++ b/util/connection.h
@@ -47,7 +47,6 @@ class Connection {
   // calls OnShutdown().
   void Shutdown();
 
-  util::ProactorBase* DEBUG_proactor = nullptr;
  protected:
   // The main loop for a connection. Runs in the same proactor thread as of socket_.
   virtual void HandleRequests() = 0;

--- a/util/fibers/epoll_proactor.cc
+++ b/util/fibers/epoll_proactor.cc
@@ -27,7 +27,7 @@
     }                                                                         \
   } while (false)
 
-#define VPRO(verbosity) VLOG(verbosity) << "PRO[" << tl_info_.proactor_index << "] "
+#define VPRO(verbosity) VLOG(verbosity) << "PRO[" << GetPoolIndex() << "] "
 
 using namespace std;
 
@@ -143,7 +143,8 @@ EpollProactor::~EpollProactor() {
   DVLOG(1) << "~EpollProactor";
 }
 
-void EpollProactor::Init() {
+void EpollProactor::Init(unsigned pool_index) {
+  pool_index_ = pool_index;
   if (thread_id_ != 0) {
     LOG(FATAL) << "Init was already called";
   }

--- a/util/fibers/epoll_proactor.h
+++ b/util/fibers/epoll_proactor.h
@@ -19,7 +19,7 @@ class EpollProactor : public ProactorBase {
   ~EpollProactor();
 
   // should be called from the thread that owns this EpollProactor before calling Run.
-  void Init();
+  void Init(unsigned pool_index);
 
   using IoResult = int;
 

--- a/util/fibers/fiber_socket_test.cc
+++ b/util/fibers/fiber_socket_test.cc
@@ -23,9 +23,9 @@ constexpr uint32_t kRingDepth = 8;
 #ifdef __linux__
 void InitProactor(ProactorBase* p) {
   if (p->GetKind() == ProactorBase::IOURING) {
-    static_cast<UringProactor*>(p)->Init(kRingDepth);
+    static_cast<UringProactor*>(p)->Init(0, kRingDepth);
   } else {
-    static_cast<EpollProactor*>(p)->Init();
+    static_cast<EpollProactor*>(p)->Init(0);
   }
 }
 #else

--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -96,14 +96,13 @@ ProactorThread::ProactorThread(unsigned index, ProactorBase::Kind kind) {
   }
 
   proactor_thread = thread{[this, kind, index] {
-    proactor->SetIndex(index);
     switch (kind) {
       case ProactorBase::Kind::EPOLL:
-        static_cast<EpollProactor*>(proactor.get())->Init();
+        static_cast<EpollProactor*>(proactor.get())->Init(index);
         break;
       case ProactorBase::Kind::IOURING:
 #ifdef __linux__
-        static_cast<UringProactor*>(proactor.get())->Init(kRingDepth);
+        static_cast<UringProactor*>(proactor.get())->Init(index, kRingDepth);
 #endif
         break;
     }
@@ -431,7 +430,6 @@ TEST_F(FiberTest, AtomicGuard) {
 
 TEST_P(ProactorTest, AsyncCall) {
   ASSERT_FALSE(ProactorBase::IsProactorThread());
-  ASSERT_EQ(-1, ProactorBase::GetIndex());
 
   for (unsigned i = 0; i < ProactorBase::kTaskQueueLen * 2; ++i) {
     VLOG(1) << "Dispatch: " << i;

--- a/util/fibers/listener_interface.cc
+++ b/util/fibers/listener_interface.cc
@@ -41,63 +41,11 @@ thread_local ListenerInterface::ListenerConnMap ListenerInterface::conn_list;
 struct ListenerInterface::TLConnList {
   ListType list;
   fb2::CondVarAny empty_cv;
+  int pool_index = -1;
 
-  void Link(Connection* c) {
-    DCHECK(!c->hook_.is_linked());
-    c->DEBUG_proactor = ProactorBase::me();
-    if (!list.empty()) {
-      CHECK_EQ(c->DEBUG_proactor, list.front().DEBUG_proactor);
-      CHECK_EQ(c->DEBUG_proactor, list.back().DEBUG_proactor);
-    }
-    list.push_back(*c);
-    DVLOG(3) << "List size " << list.size();
-  }
+  void Link(Connection* c);
 
-  void Unlink(Connection* c, ListenerInterface* l) {
-    CHECK(c->hook_.is_linked());
-
-    auto it = ListType::s_iterator_to(*c);
-
-    {
-      util::ProactorBase *left = nullptr, *right = nullptr;
-      if (auto lit = it; it != list.begin())
-        left = (--lit)->DEBUG_proactor;
-      if (auto rit = it; ++rit != list.end())
-        right = rit->DEBUG_proactor;
-
-      util::ProactorBase* exchanged = nullptr;
-      if (left != nullptr && left != c->DEBUG_proactor) {
-        if (right == nullptr || right == left)
-          exchanged = left;
-        else
-          LOG(ERROR) << "Mixmatched proactors " << left << " " << right << ", mine "
-                     << c->DEBUG_proactor << ", me() " << ProactorBase::me();
-      }
-
-      if (right != nullptr && right != c->DEBUG_proactor) {
-        if (left == nullptr || left == right)
-          exchanged = right;
-        else
-          LOG(ERROR) << "Mixmatched proactors " << left << " " << right << ", mine "
-                     << c->DEBUG_proactor << ", me() " << ProactorBase::me();
-      }
-
-      if (exchanged != nullptr) {
-        LOG(ERROR) << "Neighbors on same proactor: " << exchanged->GetIndex();
-        exchanged->Await([c, l, it]() { conn_list[l]->Unlink(c, l); });
-        return;
-      }
-    }
-
-    DCHECK(!list.empty());
-    list.erase(it);
-    c->DEBUG_proactor = nullptr;
-
-    DVLOG(2) << "Unlink conn, new list size: " << list.size();
-    if (list.empty()) {
-      empty_cv.notify_one();
-    }
-  }
+  void Unlink(Connection* c, ListenerInterface* l);
 
   void AwaitEmpty() {
     if (list.empty())
@@ -109,6 +57,30 @@ struct ListenerInterface::TLConnList {
     DVLOG(1) << "AwaitEmpty finished ";
   }
 };
+
+void ListenerInterface::TLConnList::Link(Connection* c) {
+  DCHECK(!c->hook_.is_linked());
+  list.push_back(*c);
+  CHECK_EQ(c->socket()->proactor()->GetPoolIndex(), this->pool_index);
+
+  DVLOG(3) << "List size " << list.size();
+}
+
+void ListenerInterface::TLConnList::Unlink(Connection* c, ListenerInterface* l) {
+  DCHECK(c->hook_.is_linked());
+
+  auto it = ListType::s_iterator_to(*c);
+  util::ProactorBase* conn_proactor = c->socket()->proactor();
+  CHECK_EQ(pool_index, conn_proactor->GetPoolIndex());
+
+  DCHECK(!list.empty());
+  list.erase(it);
+
+  DVLOG(2) << "Unlink conn, new list size: " << list.size();
+  if (list.empty()) {
+    empty_cv.notify_one();
+  }
+}
 
 auto __attribute__((noinline)) ListenerInterface::GetSafeTlsConnMap() -> ListenerConnMap* {
   // Prevents conn_list being cached when a function being migrated between threads.
@@ -131,9 +103,11 @@ void ListenerInterface::RunAcceptLoop() {
 
   PreAcceptLoop(sock_->proactor());
 
-  pool_->Await([this](auto*) {
+  pool_->Await([this](unsigned index, auto*) {
     DVLOG(1) << "Emplacing listener " << this;
-    conn_list.emplace(this, new TLConnList{});
+    auto res = conn_list.emplace(this, new TLConnList{});
+    CHECK(res.second);
+    res.first->second->pool_index = index;
   });
 
   while (true) {
@@ -277,7 +251,7 @@ void ListenerInterface::TraverseConnections(TraverseCB cb) {
 
 void ListenerInterface::TraverseConnectionsOnThread(TraverseCB cb) {
   DCHECK(ProactorBase::IsProactorThread());
-  unsigned index = ProactorBase::GetIndex();
+  unsigned index = ProactorBase::me()->GetPoolIndex();
 
   FiberAtomicGuard fg;
   auto it = conn_list.find(this);
@@ -290,12 +264,14 @@ void ListenerInterface::Migrate(Connection* conn, fb2::ProactorBase* dest) {
   fb2::ProactorBase* src_proactor = conn->socket()->proactor();
   DCHECK(src_proactor->InMyThread());
   CHECK(conn->listener() == this);
-  DCHECK_EQ(conn->DEBUG_proactor, ProactorBase::me());
+  DCHECK_EQ(src_proactor, ProactorBase::me());
 
   if (src_proactor == dest)
     return;
 
-  unsigned src_index = ProactorBase::GetIndex();
+  // We are careful to avoid accessing tls data structures if possible and use stack variables
+  // instead.
+  unsigned src_index = src_proactor->GetPoolIndex();
 
   ListenerConnMap* src_conn_map = GetSafeTlsConnMap();
   VLOG(1) << "Migrating from " << src_proactor->sys_tid() << "(" << src_index << ") "
@@ -303,7 +279,7 @@ void ListenerInterface::Migrate(Connection* conn, fb2::ProactorBase* dest) {
 
   conn->OnPreMigrateThread();
 
-  auto* src_clist = src_conn_map->find(this)->second;
+  TLConnList* src_clist = src_conn_map->find(this)->second;
   src_clist->Unlink(conn, this);
 
   src_proactor->Migrate(dest);
@@ -312,8 +288,8 @@ void ListenerInterface::Migrate(Connection* conn, fb2::ProactorBase* dest) {
   conn->socket()->SetProactor(dest);
 
   ListenerConnMap* dest_conn_map = GetSafeTlsConnMap();
-  VLOG(1) << "Migrated from " << src_index << " to " << ProactorBase::GetIndex() << " "
-          << dest_conn_map;
+  int dest_index = dest->GetPoolIndex();
+  VLOG(1) << "Migrated from " << src_index << " to " << dest_index << " " << dest_conn_map;
 
   CHECK_NE(dest_conn_map, src_conn_map);
   auto it = dest_conn_map->find(this);
@@ -321,9 +297,9 @@ void ListenerInterface::Migrate(Connection* conn, fb2::ProactorBase* dest) {
   // If the listener is being destroyed but the connection is in the middle of thread migration,
   // we do not need to link it again.
   if (it != dest_conn_map->end()) {
-    auto* dst_clist = it->second;
+    TLConnList* dst_clist = it->second;
     CHECK(dst_clist != src_clist);
-
+    CHECK_EQ(dst_clist->pool_index, dest_index);
     dst_clist->Link(conn);
   }
   conn->OnPostMigrateThread();

--- a/util/fibers/pool.cc
+++ b/util/fibers/pool.cc
@@ -41,18 +41,18 @@ ProactorBase* Pool::CreateProactor() {
   return nullptr;
 }
 
-void Pool::InitInThread(unsigned index) {
+void Pool::InitInThread(unsigned pool_index) {
   switch (kind_) {
     case ProactorBase::Kind::EPOLL: {
-      EpollProactor* p = static_cast<EpollProactor*>(proactor_[index]);
-      p->Init();
+      EpollProactor* p = static_cast<EpollProactor*>(proactor_[pool_index]);
+      p->Init(pool_index);
       break;
     }
 
     case ProactorBase::Kind::IOURING: {
 #ifdef __linux__
-      UringProactor* p = static_cast<UringProactor*>(proactor_[index]);
-      p->Init(ring_depth_);
+      UringProactor* p = static_cast<UringProactor*>(proactor_[pool_index]);
+      p->Init(pool_index, ring_depth_);
 #else
       CHECK(false);
 #endif

--- a/util/fibers/proactor_base.h
+++ b/util/fibers/proactor_base.h
@@ -100,14 +100,10 @@ class ProactorBase {
   }
 
   // Returns an 0 <= index < N, where N is the number of proactor threads in the pool of called
-  // from Proactor thread. Returns -1 if called from some other thread.
-  static int32_t GetIndex() {
-    return tl_info_.proactor_index;
-  }
-
-  // Internal, used by ProactorPool
-  static void SetIndex(uint32_t index) {
-    tl_info_.proactor_index = index;
+  // from Proactor thread. Returns -1 if Proactor is not part of the pool.
+  // Can be accessed from any thread.
+  int32_t GetPoolIndex() const {
+    return pool_index_;
   }
 
   bool IsTaskQueueFull() const {
@@ -229,7 +225,7 @@ class ProactorBase {
 
   pthread_t thread_id_ = 0U;
   int sys_thread_id_ = 0;
-
+  int32_t pool_index_ = -1;
   int wake_fd_ = -1;
   bool is_stopped_ = true;
 
@@ -265,7 +261,6 @@ class ProactorBase {
   absl::flat_hash_map<uint32_t, PeriodicItem*> periodic_map_;
 
   struct TLInfo {
-    int32_t proactor_index = -1;
     uint64_t monotonic_time = 0;  // in nanoseconds
     ProactorBase* owner = nullptr;
   };

--- a/util/fibers/proactor_pool.cc
+++ b/util/fibers/proactor_pool.cc
@@ -134,14 +134,13 @@ void ProactorPool::CheckRunningState() {
 void ProactorPool::Run() {
   SetupProactors();
 
-  Await([](unsigned index, auto*) {
+  Await([](unsigned index, ProactorBase* proactor) {
   // It seems to simplify things in kernel for io_uring.
   // https://github.com/axboe/liburing/issues/218
   // I am not sure what's how it impacts higher application levels.
 #ifdef __linux__
     unshare(CLONE_FS);
 #endif
-    ProactorBase::SetIndex(index);
   });
 
   LOG(INFO) << "Running " << pool_size_ << " io threads";

--- a/util/fibers/sliding_counter.cc
+++ b/util/fibers/sliding_counter.cc
@@ -23,7 +23,7 @@ void SlidingCounterBase::CheckInit() const {
 unsigned SlidingCounterBase::ProactorThreadIndex() const {
   int32_t tnum = CHECK_NOTNULL(pp_)->size();
 
-  int32_t indx = fb2::ProactorBase::GetIndex();
+  int32_t indx = fb2::ProactorBase::me()->GetPoolIndex();
   CHECK_GE(indx, 0) << "Must be called from proactor thread!";
   CHECK_LT(indx, tnum) << "Invalid thread index " << indx;
 

--- a/util/fibers/uring_proactor.h
+++ b/util/fibers/uring_proactor.h
@@ -25,7 +25,7 @@ class UringProactor : public ProactorBase {
   UringProactor();
   ~UringProactor();
 
-  void Init(size_t ring_size, int wq_fd = -1);
+  void Init(unsigned pool_index, size_t ring_size, int wq_fd = -1);
 
   using IoResult = int;
 

--- a/util/fibers/varz.cc
+++ b/util/fibers/varz.cc
@@ -37,7 +37,7 @@ void VarzMapAverage::Shutdown() {
 unsigned VarzMapAverage::ProactorThreadIndex() const {
   unsigned tnum = CHECK_NOTNULL(pp_)->size();
 
-  int32_t indx = ProactorBase::GetIndex();
+  int32_t indx = ProactorBase::me()->GetPoolIndex();
   CHECK_GE(indx, 0) << "Must be called from proactor thread!";
   CHECK_LT(unsigned(indx), tnum) << "Invalid thread index " << indx;
 
@@ -46,7 +46,7 @@ unsigned VarzMapAverage::ProactorThreadIndex() const {
 
 auto VarzMapAverage::FindSlow(string_view key) -> Map::iterator {
   auto str = pp_->GetString(key);
-  auto& map = avg_map_[ProactorBase::GetIndex()];
+  auto& map = avg_map_[ProactorBase::me()->GetPoolIndex()];
   auto res = map.emplace(str, SumCnt{});
 
   CHECK(res.second);

--- a/util/metrics/metrics.cc
+++ b/util/metrics/metrics.cc
@@ -33,7 +33,7 @@ void SingleFamily::Shutdown() {
 
 void SingleFamily::IncBy(absl::Span<const std::string_view> labels, double val) {
   CHECK_EQ(label_names_.size(), labels.size());
-  int32_t index = ProactorBase::GetIndex();
+  int32_t index = ProactorBase::me()->GetPoolIndex();
   if (index < 0)  // not in proactor thread, silently exit.
     return;
 
@@ -74,7 +74,7 @@ auto SingleFamily::GetDenseId(unsigned thread_index,
 
 void GaugeFamily::Set(absl::Span<const std::string_view> label_values, double val) {
   CHECK_EQ(label_names_.size(), label_values.size());
-  int32_t index = ProactorBase::GetIndex();
+  int32_t index = ProactorBase::me()->GetPoolIndex();
   if (index < 0)  // not in proactor thread, silently exit.
     return;
 


### PR DESCRIPTION
1. The failure in `TLConnList::List` has been reproduced on aarch64 due to `ProactorBase::me()` call that was substituted by the compiler with the wrong instance. The irony that we use this call to check our invariants.
2. I redesigned the access to ProactorBase::GetIndex and made it accessible from any thread.
3. Removed `DEBUG_proactor` data member and use `socket()->proactor()` instead.
4. Removed the fallback for unlinking in a differrent thread and introduced back the check-fail