### PR TITLE
chore: reimplement fiber migrate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,16 +37,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.3
-
-    - name: Configure Cache Env
-      uses: actions/github-script@v6
-      with:
-        script: |
-          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')
-
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
@@ -61,15 +51,16 @@ jobs:
             -DCMAKE_C_COMPILER="${{matrix.compiler.c}}" \
             -DCMAKE_CXX_COMPILER="${{matrix.compiler.cxx}}" \
             -DCMAKE_CXX_FLAGS_DEBUG="${{matrix.cxx_flags}}" \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_C_COMPILER_LAUNCHER=sccache
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
+
     - name: Build
       run: |
           cd ${{github.workspace}}/build
 
           ninja -k 5 base/all io/all strings/all util/all echo_server ping_iouring_server https_client_cli s3_demo
-          ${SCCACHE_PATH} --show-stats
 
     - name: Test
+      timeout-minutes: 2
       run: |
           cd ${{github.workspace}}/build
 

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -322,7 +322,7 @@ add_third_party(
 
 add_third_party(
   uring
-  URL https://github.com/axboe/liburing/archive/refs/tags/liburing-2.4.tar.gz
+  URL https://github.com/axboe/liburing/archive/refs/tags/liburing-2.5.tar.gz
 
   CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=${THIRD_PARTY_LIB_DIR}/uring
   BUILD_IN_SOURCE 1

--- a/util/fibers/detail/fiber_interface.cc
+++ b/util/fibers/detail/fiber_interface.cc
@@ -45,7 +45,6 @@ uint64_t g_tsc_cycles_per_ms = 0;
 
 }  // namespace
 
-
 // Per thread initialization structure.
 struct TL_FiberInitializer {
   TL_FiberInitializer* next = nullptr;
@@ -251,50 +250,38 @@ void FiberInterface::ActivateOther(FiberInterface* other) {
   }
 }
 
-void FiberInterface::DetachThread() {
+void FiberInterface::DetachScheduler() {
   scheduler_->DetachWorker(this);
   scheduler_ = nullptr;
 }
 
-void FiberInterface::AttachThread() {
+void FiberInterface::AttachScheduler() {
   scheduler_ = detail::FbInitializer().sched;
   scheduler_->Attach(this);
+  scheduler_->AddReady(this);
 }
 
 ctx::fiber_context FiberInterface::SwitchTo() {
-  // We can not assert !wait_hook.is_linked() here, because for timeout operations,
-  // the fiber can be activated with the wait_hook still linked.
-  FiberInterface* prev = this;
-
-  auto& fb_initializer = FbInitializer();
-  std::swap(fb_initializer.active, prev);
-
-  uint64_t tsc = CycleClock::Now();
-
-  // When a kernel suspends we may get a negative delta because TSC is reset.
-  // We ignore such cases (and they are very rare).
-  if (tsc > cpu_tsc_) {
-    ++fb_initializer.epoch;
-    DCHECK_GE(tsc, prev->cpu_tsc_);
-    fb_initializer.switch_delay_cycles += (tsc - cpu_tsc_);
-
-    // prev tsc points to the fiber that was active before this call.
-    uint64_t delta_cycles = tsc - prev->cpu_tsc_;
-    if (delta_cycles > g_tsc_cycles_per_ms) {
-      fb_initializer.long_runtime_cnt++;
-
-      // improve precision, instead of "delta_cycles / (g_tsc_cycles_per_ms / 1000)"
-      fb_initializer.long_runtime_usec += (delta_cycles * 1000) / g_tsc_cycles_per_ms;
-    }
-  }
-
-  cpu_tsc_ = tsc;
+  FiberInterface* prev = SwitchSetup();
 
   // pass pointer to the context that resumes `this`
   return std::move(entry_).resume_with([prev](ctx::fiber_context&& c) {
     DCHECK(!prev->entry_);
 
     prev->entry_ = std::move(c);  // update the return address in the context we just switch from.
+    return ctx::fiber_context{};
+  });
+}
+
+void FiberInterface::SwitchToAndExecute(std::function<void()> fn) {
+  FiberInterface* prev = SwitchSetup();
+
+  // pass pointer to the context that resumes `this`
+  entry_ = std::move(entry_).resume_with([prev, fn = std::move(fn)](ctx::fiber_context&& c) {
+    DCHECK(!prev->entry_);
+    prev->entry_ = std::move(c);  // update the return address in the context we just switch from.
+    fn();
+
     return ctx::fiber_context{};
   });
 }
@@ -328,6 +315,35 @@ void FiberInterface::ExecuteOnFiberStack(PrintFn fn) {
     c = std::move(c).resume();
     return std::move(c);
   });
+}
+
+FiberInterface* FiberInterface::SwitchSetup() {
+  FiberInterface* prev = this;
+
+  auto& fb_initializer = FbInitializer();
+  std::swap(fb_initializer.active, prev);
+
+  uint64_t tsc = CycleClock::Now();
+
+  // When a kernel suspends we may get a negative delta because TSC is reset.
+  // We ignore such cases (and they are very rare).
+  if (tsc > cpu_tsc_) {
+    ++fb_initializer.epoch;
+    DCHECK_GE(tsc, prev->cpu_tsc_);
+    fb_initializer.switch_delay_cycles += (tsc - cpu_tsc_);
+
+    // prev tsc points to the fiber that was active before this call.
+    uint64_t delta_cycles = tsc - prev->cpu_tsc_;
+    if (delta_cycles > g_tsc_cycles_per_ms) {
+      fb_initializer.long_runtime_cnt++;
+
+      // improve precision, instead of "delta_cycles / (g_tsc_cycles_per_ms / 1000)"
+      fb_initializer.long_runtime_usec += (delta_cycles * 1000) / g_tsc_cycles_per_ms;
+    }
+  }
+
+  cpu_tsc_ = tsc;
+  return prev;
 }
 
 void FiberInterface::PrintAllFiberStackTraces() {

--- a/util/fibers/detail/fiber_interface.h
+++ b/util/fibers/detail/fiber_interface.h
@@ -54,17 +54,19 @@ class FiberInterface {
  public:
   enum Type : uint8_t { MAIN, DISPATCH, WORKER };
 
+  // public hooks for intrusive data structures.
+  FI_ListHook list_hook;  // used to add to ready/terminate queues.
+  FI_SleepHook sleep_hook;
+  FI_ListHook fibers_hook;  // For a list of all fibers in the thread
+
   // init_count is the initial use_count of the fiber.
   FiberInterface(Type type, uint32_t init_count, std::string_view nm = std::string_view{});
 
   virtual ~FiberInterface();
 
-  FI_ListHook list_hook;  // used to add to ready queue.
-  FI_SleepHook sleep_hook;
-
-  FI_ListHook fibers_hook;  // For a list of all fibers in the thread
 
   ::boost::context::fiber_context SwitchTo();
+  void SwitchToAndExecute(std::function<void()> fn);
 
   using PrintFn = std::function<void(FiberInterface*)>;
 
@@ -91,11 +93,11 @@ class FiberInterface {
   void Suspend();
 
   // Detaches itself from the thread scheduler.
-  void DetachThread();
+  void DetachScheduler();
 
-  // Attaches itself to a thread scheduler.
+  // Attaches itself to a thread scheduler and makes it ready to run.
   // Must be detached first.
-  void AttachThread();
+  void AttachScheduler();
 
   bool IsDefined() const {
     return bool(entry_);
@@ -200,6 +202,11 @@ class FiberInterface {
   uint64_t cpu_tsc_ = 0;
 
   char name_[24];
+
+private:
+  // Handles all the stats and also updates the involved data structure before actually switching
+  // the fiber context. Returns the active fiber before the context switch.
+  FiberInterface* SwitchSetup();
 };
 
 template <typename Fn, typename... Arg> class WorkerFiberImpl : public FiberInterface {

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -377,6 +377,9 @@ void Scheduler::SuspendAndExecuteOnDispatcher(std::function<void()> fn) {
 
   // All our dispatch policies add dispatcher to ready queue, hence it must be there.
   CHECK(dispatch_cntx_->list_hook.is_linked());
+
+  // We must erase it from the ready queue because we switch to dispatcher "abnormally",
+  // not through Preempt().
   ready_queue_.erase(FI_Queue::s_iterator_to(*dispatch_cntx_));
 
   dispatch_cntx_->SwitchToAndExecute([fn = std::move(fn)] {

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -23,306 +23,6 @@ using namespace std;
 
 namespace {
 
-#if PARKING_ENABLED
-template <typename T> void WriteOnce(T src, T* dest) {
-  std::atomic_store_explicit(reinterpret_cast<std::atomic<T>*>(dest), src,
-                             std::memory_order_relaxed);
-}
-
-template <typename T> T ReadOnce(T* src) {
-  return std::atomic_load_explicit(reinterpret_cast<std::atomic<T>*>(src),
-                                   std::memory_order_relaxed);
-}
-
-// Thomas Wang's 64 bit Mix Function.
-inline uint64_t MixHash(uint64_t key) {
-  key += ~(key << 32);
-  key ^= (key >> 22);
-  key += ~(key << 13);
-  key ^= (key >> 8);
-  key += (key << 3);
-  key ^= (key >> 15);
-  key += ~(key << 27);
-  key ^= (key >> 31);
-  return key;
-}
-
-using WaitQueue = boost::intrusive::slist<
-    detail::FiberInterface,
-    boost::intrusive::member_hook<detail::FiberInterface, detail::FI_ListHook,
-                                  &detail::FiberInterface::list_hook>,
-    boost::intrusive::constant_time_size<false>, boost::intrusive::cache_last<true>>;
-
-struct ParkingBucket {
-  SpinLockType lock;
-  WaitQueue waiters;
-  bool was_rehashed = 0;
-};
-
-constexpr size_t kSzPB = sizeof(ParkingBucket);
-
-class ParkingHT {
-  struct SizedBuckets {
-    unsigned num_buckets;
-    ParkingBucket* arr;
-
-    SizedBuckets(unsigned shift) : num_buckets(1 << shift) {
-      arr = new ParkingBucket[num_buckets];
-    }
-
-    unsigned GetBucket(uint64_t hash) const {
-      return hash & bucket_mask();
-    }
-
-    unsigned bucket_mask() const {
-      return num_buckets - 1;
-    }
-  };
-
- public:
-  ParkingHT();
-  ~ParkingHT();
-
-  // if validate returns true, the fiber is not added to the queue.
-  bool Emplace(uint64_t token, FiberInterface* fi, absl::FunctionRef<bool()> validate);
-
-  FiberInterface* Remove(uint64_t token, absl::FunctionRef<void(FiberInterface*)> on_hit,
-                         absl::FunctionRef<void()> on_miss);
-  void RemoveAll(uint64_t token, WaitQueue* wq);
-
- private:
-  void TryRehash(SizedBuckets* cur_sb);
-
-  atomic<SizedBuckets*> buckets_;
-  atomic_uint32_t num_entries_{0};
-  atomic_bool rehashing_{false};
-};
-
-#endif
-
-// ParkingHT* g_parking_ht = nullptr;
-
-using QsbrEpoch = uint32_t;
-
-#if PARKING_ENABLED
-constexpr QsbrEpoch kEpochInc = 2;
-atomic<QsbrEpoch> qsbr_global_epoch{1};  // global is always non-zero.
-
-// TODO: we could move this checkpoint to the proactor loop.
-void qsbr_checkpoint() {
-  atomic_thread_fence(memory_order_seq_cst);
-
-  // syncs the local_epoch with the global_epoch.
-  WriteOnce(qsbr_global_epoch.load(memory_order_relaxed), &FbInitializer().local_epoch);
-}
-
-void qsbr_worker_fiber_offline() {
-  atomic_thread_fence(memory_order_release);
-  WriteOnce(0U, &FbInitializer().local_epoch);
-}
-
-void qsbr_worker_fiber_online() {
-  WriteOnce(qsbr_global_epoch.load(memory_order_relaxed), &FbInitializer().local_epoch);
-  atomic_thread_fence(memory_order_seq_cst);
-}
-
-bool qsbr_sync(uint64_t target) {
-  unique_lock lk(g_scheduler_lock, try_to_lock);
-
-  if (!lk)
-    return false;
-
-  FbInitializer().local_epoch = target;
-  for (TL_FiberInitializer* p = g_fiber_thread_list; p != nullptr; p = p->next) {
-    auto local_epoch = ReadOnce(&p->local_epoch);
-    if (local_epoch && local_epoch != target) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-ParkingHT::ParkingHT() {
-  SizedBuckets* sb = new SizedBuckets(6);
-  buckets_.store(sb, memory_order_release);
-}
-
-ParkingHT::~ParkingHT() {
-  SizedBuckets* sb = buckets_.load(memory_order_relaxed);
-
-  DVLOG(1) << "Destroying ParkingHT with " << sb->num_buckets << " buckets";
-
-  for (unsigned i = 0; i < sb->num_buckets; ++i) {
-    ParkingBucket* pb = sb->arr + i;
-    SpinLockHolder h(&pb->lock);
-    CHECK(pb->waiters.empty());
-  }
-  delete[] sb->arr;
-  delete sb;
-}
-
-// if validate returns true we do not park
-bool ParkingHT::Emplace(uint64_t token, FiberInterface* fi, absl::FunctionRef<bool()> validate) {
-  uint32_t num_items = 0;
-  unsigned bucket = 0;
-  SizedBuckets* sb = nullptr;
-  uint64_t hash = MixHash(token);
-  bool res = false;
-
-  while (true) {
-    sb = buckets_.load(memory_order_acquire);
-    DCHECK(sb);
-    bucket = sb->GetBucket(hash);
-    VLOG(1) << "Emplace: token=" << token << " bucket=" << bucket;
-
-    ParkingBucket* pb = sb->arr + bucket;
-    {
-      SpinLockHolder h(&pb->lock);
-
-      if (!pb->was_rehashed) {  // has grown
-        if (validate()) {
-          break;
-        }
-
-        fi->set_park_token(token);
-        pb->waiters.push_front(*fi);
-        num_items = num_entries_.fetch_add(1, memory_order_relaxed);
-        res = true;
-        break;
-      }
-    }
-  }
-
-  if (res) {
-    DVLOG(2) << "EmplaceEnd: token=" << token << " bucket=" << bucket;
-
-    if (num_items > sb->num_buckets) {
-      TryRehash(sb);
-    }
-  } else {
-    qsbr_checkpoint();
-  }
-
-  // we do not call qsbr_checkpoint here because we are going to park
-  // and call qsbr_worker_fiber_offline.
-  return res;
-}
-
-FiberInterface* ParkingHT::Remove(uint64_t token, absl::FunctionRef<void(FiberInterface*)> on_hit,
-                                  absl::FunctionRef<void()> on_miss) {
-  uint64_t hash = MixHash(token);
-  SizedBuckets* sb = nullptr;
-  while (true) {
-    sb = buckets_.load(memory_order_acquire);
-    unsigned bucket = sb->GetBucket(hash);
-    ParkingBucket* pb = sb->arr + bucket;
-    {
-      SpinLockHolder h(&pb->lock);
-      VLOG(1) << "Remove: token=" << token << " bucket=" << bucket;
-
-      if (!pb->was_rehashed) {
-        for (auto it = pb->waiters.begin(); it != pb->waiters.end(); ++it) {
-          if (it->park_token() == token) {
-            FiberInterface* fi = &*it;
-            pb->waiters.erase(it);
-            auto prev = num_entries_.fetch_sub(1, memory_order_relaxed);
-            DCHECK_GT(prev, 0u);
-            on_hit(fi);
-            // qsbr_checkpoint();
-
-            return fi;
-          }
-        }
-        on_miss();
-        return nullptr;
-      }
-    }
-  }
-
-  qsbr_checkpoint();
-  return nullptr;
-}
-
-void ParkingHT::RemoveAll(uint64_t token, WaitQueue* wq) {
-  uint64_t hash = MixHash(token);
-  SizedBuckets* sb = nullptr;
-
-  while (true) {
-    sb = buckets_.load(memory_order_acquire);
-    unsigned bucket = sb->GetBucket(hash);
-    ParkingBucket* pb = sb->arr + bucket;
-    {
-      SpinLockHolder h(&pb->lock);
-      if (!pb->was_rehashed) {
-        auto it = pb->waiters.begin();
-        while (it != pb->waiters.end()) {
-          if (it->park_token() != token) {
-            ++it;
-            continue;
-          }
-          FiberInterface* fi = &*it;
-          it = pb->waiters.erase(it);
-          wq->push_back(*fi);
-          auto prev = num_entries_.fetch_sub(1, memory_order_relaxed);
-          DCHECK_GT(prev, 0u);
-        }
-        break;
-      }
-    }
-  }
-  qsbr_checkpoint();
-}
-
-void ParkingHT::TryRehash(SizedBuckets* cur_sb) {
-  if (rehashing_.exchange(true, memory_order_acquire)) {
-    return;
-  }
-
-  SizedBuckets* sb = buckets_.load(memory_order_relaxed);
-  if (sb != cur_sb) {
-    rehashing_.store(false, memory_order_release);
-    return;
-  }
-
-  DVLOG(1) << "Rehashing parking hash table from " << sb->num_buckets;
-
-  // log2(x)
-  static_assert(__builtin_ctz(32) == 5);
-
-  SizedBuckets* new_sb = new SizedBuckets(__builtin_ctz(sb->num_buckets) + 2);
-  for (unsigned i = 0; i < sb->num_buckets; ++i) {
-    sb->arr[i].lock.Lock();
-  }
-  for (unsigned i = 0; i < sb->num_buckets; ++i) {
-    ParkingBucket* pb = sb->arr + i;
-    pb->was_rehashed = true;
-    while (!pb->waiters.empty()) {
-      FiberInterface* fi = &pb->waiters.front();
-      pb->waiters.pop_front();
-      uint64_t hash = MixHash(fi->park_token());
-      unsigned bucket = new_sb->GetBucket(hash);
-      ParkingBucket* new_pb = new_sb->arr + bucket;
-      new_pb->waiters.push_back(*fi);
-    }
-  }
-  buckets_.store(new_sb, memory_order_release);
-
-  for (unsigned i = 0; i < sb->num_buckets; ++i) {
-    sb->arr[i].lock.Unlock();
-  }
-
-  uint64_t next_epoch = qsbr_global_epoch.fetch_add(kEpochInc, memory_order_relaxed) + kEpochInc;
-
-  FbInitializer().sched->Defer(next_epoch, [sb] {
-    DVLOG(1) << "Destroying old SizedBuckets with " << sb->num_buckets << " buckets";
-    delete sb;
-  });
-
-  rehashing_.store(false, memory_order_release);
-}
-#endif
-
 class DispatcherImpl final : public FiberInterface {
  public:
   DispatcherImpl(ctx::preallocated const& palloc, ctx::fixedsize_stack&& salloc,
@@ -446,7 +146,6 @@ void DispatcherImpl::DefaultDispatch(Scheduler* sched) {
       }
       wake_suspend_ = false;
     }
-    sched->RunDeferred();
   }
   sched->DestroyTerminated();
 }
@@ -666,34 +365,23 @@ void Scheduler::AttachCustomPolicy(DispatchPolicy* policy) {
   custom_policy_ = policy;
 }
 
-void Scheduler::RunDeferred() {
-#if PARKING_ENABLED
-  bool skip_validation = false;
-
-  while (!deferred_cb_.empty()) {
-    const auto& k_v = deferred_cb_.back();
-    if (skip_validation) {
-      k_v.second();
-      deferred_cb_.pop_back();
-
-      continue;
-    }
-
-    if (!qsbr_sync(k_v.first))
-      break;
-
-    k_v.second();
-    skip_validation = true;
-    deferred_cb_.pop_back();
-  }
-#endif
-}
-
 void Scheduler::ExecuteOnAllFiberStacks(FiberInterface::PrintFn fn) {
   for (auto& fiber : fibers_) {
     DCHECK(fiber.scheduler() == this);
     fiber.ExecuteOnFiberStack(fn);
   }
+}
+
+void Scheduler::SuspendAndExecuteOnDispatcher(std::function<void()> fn) {
+  CHECK(FiberActive() != dispatch_cntx_.get());
+
+  // All our dispatch policies add dispatcher to ready queue, hence it must be there.
+  CHECK(dispatch_cntx_->list_hook.is_linked());
+  ready_queue_.erase(FI_Queue::s_iterator_to(*dispatch_cntx_));
+
+  dispatch_cntx_->SwitchToAndExecute([fn = std::move(fn)] {
+    fn();
+  });
 }
 
 void Scheduler::PrintAllFiberStackTraces() {

--- a/util/fibers/detail/scheduler.h
+++ b/util/fibers/detail/scheduler.h
@@ -83,14 +83,9 @@ class Scheduler {
     return custom_policy_;
   }
 
-  void Defer(uint64_t epoch, std::function<void()> fn) {
-    deferred_cb_.emplace_back(epoch, std::move(fn));
-  }
-
-  void RunDeferred();
-
   void PrintAllFiberStackTraces();
   void ExecuteOnAllFiberStacks(FiberInterface::PrintFn fn);
+  void SuspendAndExecuteOnDispatcher(std::function<void()> fn);
 
  private:
   // We use intrusive::list and not slist because slist has O(N) complexity for some operations
@@ -125,7 +120,6 @@ class Scheduler {
   FI_Queue ready_queue_, terminate_queue_;
   SleepQueue sleep_queue_;
   base::MPSCIntrusiveQueue<FiberInterface> remote_ready_queue_;
-  std::vector<std::pair<uint64_t, std::function<void()>>> deferred_cb_;
 
   // A list of all fibers in the thread.
   FI_List fibers_;

--- a/util/fibers/epoll_proactor.cc
+++ b/util/fibers/epoll_proactor.cc
@@ -319,7 +319,6 @@ void EpollProactor::MainLoop(detail::Scheduler* scheduler) {
 
     // TODO: to handle idle tasks.
     scheduler->DestroyTerminated();
-    scheduler->RunDeferred();
     Pause(spin_loops);
     ++spin_loops;
   }

--- a/util/fibers/proactor_base.cc
+++ b/util/fibers/proactor_base.cc
@@ -211,13 +211,13 @@ void ProactorBase::CancelPeriodic(uint32_t id) {
 void ProactorBase::Migrate(ProactorBase* dest) {
   CHECK(dest != this);
   detail::FiberInterface* me = detail::FiberActive();
-  Fiber tmp = LaunchFiber([me, dest] {
-    me->DetachThread();
-    VLOG(1) << "After me detach";
-    dest->AwaitBrief([me] { me->AttachThread(); });
-    VLOG(1) << "After Migrate/AwaitBrief";
+  me->scheduler()->SuspendAndExecuteOnDispatcher([me, dest] {
+    me->DetachScheduler();
+
+    dest->DispatchBrief([me] {
+      me->AttachScheduler();
+    });
   });
-  tmp.Join();
 }
 
 void ProactorBase::RegisterSignal(std::initializer_list<uint16_t> l, std::function<void(int)> cb) {

--- a/util/fibers/proactor_base.h
+++ b/util/fibers/proactor_base.h
@@ -332,28 +332,23 @@ template <typename Func> auto ProactorBase::AwaitBrief(Func&& f) -> decltype(f()
     // TODO:
   }
 
-  // auto* active = detail::FiberActive();
   using ResultType = decltype(f());
   util::detail::ResultMover<ResultType> mover;
   Done done;
 
-  // active->StartParking();
-
   // Store done-ptr by value to increase the refcount while lambda is running.
   DispatchBrief([&mover, f = std::forward<Func>(f), done]() mutable {
     mover.Apply(f);
-    // detail::FiberActive()->NotifyParked(active);
     done.Notify();
   });
 
-  // active->SuspendUntilWakeup();
   done.Wait();
 
   return std::move(mover).get();
 }
 
-// Runs possibly awating function 'f' safely in ContextThread and waits for it to finish,
-// If we are in the context thread already, runs 'f' directly, otherwise
+// Runs possibly awating function 'f' safely in proactor thread and waits for it to finish,
+// If we are in proactor thread already, runs 'f' directly, otherwise
 // runs it wrapped in a fiber. Should be used instead of 'Await' when 'f' itself
 // awaits on something.
 // To summarize: 'f' should not block its thread, but allowed to block its fiber.

--- a/util/fibers/proactor_base.h
+++ b/util/fibers/proactor_base.h
@@ -129,7 +129,7 @@ class ProactorBase {
   //! Similarly to DispatchBrief but waits 'f' to return.
   template <typename Func> auto AwaitBrief(Func&& brief) -> decltype(brief());
 
-  // Runs possibly awating function 'f' safely in Proactor thread and waits for it to finish,
+  // Runs possibly awaiting function 'f' safely in Proactor thread and waits for it to finish,
   // If we are in his thread already, runs 'f' directly, otherwise
   // runs it wrapped in a fiber. Should be used instead of 'AwaitBrief' when 'f' itself
   // awaits on something.

--- a/util/fibers/uring_proactor.cc
+++ b/util/fibers/uring_proactor.cc
@@ -595,7 +595,6 @@ void UringProactor::MainLoop(detail::Scheduler* scheduler) {
 
       // We should not spin too much using sched_yield or it burns a fuckload of cpu.
       scheduler->DestroyTerminated();
-      scheduler->RunDeferred();
 
       continue;
     }

--- a/util/fibers/uring_proactor.h
+++ b/util/fibers/uring_proactor.h
@@ -61,10 +61,6 @@ class UringProactor : public ProactorBase {
     return sqe_avail_.await([&] { return GetSubmitRingAvailability() >= threshold; });
   }
 
-  bool HasSqPoll() const {
-    return sqpoll_f_;
-  }
-
   bool HasRegisterFd() const {
     return register_fd_;
   }

--- a/util/fibers/uring_socket.cc
+++ b/util/fibers/uring_socket.cc
@@ -17,7 +17,7 @@ namespace util {
 namespace fb2 {
 
 using namespace std;
-using IoResult = Proactor::IoResult;
+using IoResult = UringProactor::IoResult;
 using nonstd::make_unexpected;
 
 namespace {
@@ -36,6 +36,9 @@ auto Unexpected(std::errc e) {
 }
 
 }  // namespace
+
+UringSocket::UringSocket(int fd, Proactor* p) : LinuxSocketBase(fd, p) {
+}
 
 UringSocket::~UringSocket() {
   DCHECK_LT(fd_, 0) << "Socket must have been closed explicitly.";
@@ -115,7 +118,6 @@ auto UringSocket::Connect(const endpoint_type& ep) -> error_code {
   VSOCK(1) << "Connect [" << fd << "] " << ep.address().to_string() << ":" << ep.port();
 
   Proactor* p = GetProactor();
-  CHECK(!p->HasSqPoll()) << "Not supported with SQPOLL, TBD";
 
   unsigned dense_id = fd;
 

--- a/util/fibers/uring_socket.h
+++ b/util/fibers/uring_socket.h
@@ -12,16 +12,15 @@
 namespace util {
 
 namespace fb2 {
-using Proactor = UringProactor;
 
 class UringSocket : public LinuxSocketBase {
  public:
+  using Proactor = UringProactor;
   using FiberSocketBase::AsyncWriteCb;
 
   template <typename T> using Result = io::Result<T>;
 
-  UringSocket(int fd, Proactor* p) : LinuxSocketBase(fd, p) {
-  }
+  UringSocket(int fd, Proactor* p);
 
   UringSocket(Proactor* p = nullptr) : UringSocket(-1, p) {
   }


### PR DESCRIPTION
Before, we used a temporary fiber to pass along the migrated fiber to another proactor. Now, we simplify the transition by using the dispatcher fiber that also handles I/O loop. We switch to it and execute the delegation to another proactor.

Also, remove the old code and get rid of sccache that is not very reliable.