### PR TITLE
chore: general improvements to fibers

### DIFF
--- a/util/accept_server_test.cc
+++ b/util/accept_server_test.cc
@@ -131,6 +131,7 @@ void AcceptServerTest::SetUp() {
   ep = FiberSocketBase::endpoint_type{address, kPort};
 
   pb->Await([&] {
+    ThisFiber::SetName("ClientConnect");
     FiberSocketBase::error_code ec = client_sock_->Connect(ep);
     CHECK(!ec) << ec.message();
   });

--- a/util/fibers/detail/fiber_interface.cc
+++ b/util/fibers/detail/fiber_interface.cc
@@ -120,7 +120,7 @@ FiberInterface* FiberActive() noexcept {
 }
 
 FiberInterface::FiberInterface(Type type, uint32_t cnt, string_view nm)
-    : use_count_(cnt), flags_(0), type_(type) {
+    : use_count_(cnt), type_(type) {
   remote_next_.store((FiberInterface*)kRemoteFree, memory_order_relaxed);
   size_t len = std::min(nm.size(), sizeof(name_) - 1);
   name_[len] = 0;
@@ -166,7 +166,7 @@ ctx::fiber_context FiberInterface::Terminate() {
     }
     CpuPause();
   }
-
+  trace_ = TRACE_TERMINATE;
   wait_queue_.NotifyAll(this);
 
   flags_.fetch_and(~kBusyBit, memory_order_release);

--- a/util/fibers/detail/fiber_interface.h
+++ b/util/fibers/detail/fiber_interface.h
@@ -64,7 +64,7 @@ class FiberInterface {
 
   virtual ~FiberInterface();
 
-
+  // Switch functions
   ::boost::context::fiber_context SwitchTo();
   void SwitchToAndExecute(std::function<void()> fn);
 
@@ -184,9 +184,17 @@ class FiberInterface {
   ::boost::context::fiber_context Terminate();
 
   std::atomic<uint32_t> use_count_;  // used for intrusive_ptr refcounting.
-  std::atomic<uint16_t> flags_;
 
+  // trace_ variable - used only for debugging purposes.
+  enum TraceState : uint8_t {
+    TRACE_NONE,
+    TRACE_SLEEP_WAKE,
+    TRACE_TERMINATE,
+    TRACE_READY
+  } trace_ = TRACE_NONE;
   Type type_;
+
+  std::atomic<uint16_t> flags_{0};
 
   // FiberInterfaces that join on this fiber to terminate are added here.
   WaitQueue wait_queue_;
@@ -203,7 +211,7 @@ class FiberInterface {
 
   char name_[24];
 
-private:
+ private:
   // Handles all the stats and also updates the involved data structure before actually switching
   // the fiber context. Returns the active fiber before the context switch.
   FiberInterface* SwitchSetup();

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -329,7 +329,7 @@ void Scheduler::ProcessRemoteReady(FiberInterface* active) {
     // because being in the remote queue means fi is still registered in the wait_queue of
     // some event. However, in case fi is waiting with timeout, ProcessSleep below can not
     // remove fi from the wait_queue and from the remote queue. In that case fi will be put
-    // into special transisitional state by adding it to ready_queue even though it's still
+    // into special transitional state by adding it to ready_queue even though it's still
     // blocked on the wait queue. When fi runs, it first unregisters itself from the
     // wait queue atomically and pulls itself from the remote queue.
     // There is a race condition between ProcessSleep and ProcessRemoteReady,

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -325,8 +325,8 @@ void Scheduler::ProcessRemoteReady(FiberInterface* active) {
 
     DCHECK(fi->scheduler_ == this);
 
-    // Generally, fi should not be in the ready queue if it's still in the remote queue.
-    // Because being in the remote queue means fi is still registered in the wait_queue of
+    // Generally, fi should not be in the ready queue if it's still in the remote queue,
+    // because being in the remote queue means fi is still registered in the wait_queue of
     // some event. However, in case fi is waiting with timeout, ProcessSleep below can not
     // remove fi from the wait_queue and from the remote queue. In that case fi will be put
     // into special transisitional state by adding it to ready_queue even though it's still

--- a/util/fibers/detail/scheduler.h
+++ b/util/fibers/detail/scheduler.h
@@ -76,7 +76,9 @@ class Scheduler {
 
   void DestroyTerminated();
   void ProcessRemoteReady(FiberInterface* active);
-  void ProcessSleep();
+
+  // Returns number of sleeping fibers being activated from sleep.
+  unsigned ProcessSleep();
 
   void AttachCustomPolicy(DispatchPolicy* policy);
 

--- a/util/fibers/proactor_base.cc
+++ b/util/fibers/proactor_base.cc
@@ -250,7 +250,7 @@ void ProactorBase::RegisterSignal(std::initializer_list<uint16_t> l, std::functi
   }
 }
 
-void ProactorBase::ProcessSleepFibers(detail::Scheduler* scheduler) {
+unsigned ProactorBase::ProcessSleepFibers(detail::Scheduler* scheduler) {
   // avoid calling steady_clock::now() too much.
   // Cycles count can reset, for example when CPU is suspended, therefore we also allow
   // "returning  into past". False positive is possible but it's not a big deal.
@@ -262,10 +262,12 @@ void ProactorBase::ProcessSleepFibers(detail::Scheduler* scheduler) {
     now = last_sleep_cycle_ + cycles_per_10us;
   }
 
+  unsigned result = 0;
   if (now >= last_sleep_cycle_ + cycles_per_10us) {
     last_sleep_cycle_ = now;
-    scheduler->ProcessSleep();
+    result = scheduler->ProcessSleep();
   }
+  return result;
 }
 
 void ProactorBase::Pause(unsigned count) {

--- a/util/fibers/proactor_base.h
+++ b/util/fibers/proactor_base.h
@@ -214,7 +214,8 @@ class ProactorBase {
     return absl::GetCurrentTimeNanos();
   }
 
-  void ProcessSleepFibers(detail::Scheduler* scheduler);
+  // Returns number of sleeping fibers being activated.
+  unsigned ProcessSleepFibers(detail::Scheduler* scheduler);
 
   pthread_t thread_id_ = 0U;
   int sys_thread_id_ = 0;

--- a/util/fibers/uring_proactor.h
+++ b/util/fibers/uring_proactor.h
@@ -108,7 +108,8 @@ class UringProactor : public ProactorBase {
   void EpollDel(EpollIndex id);
 
  private:
-  void DispatchCqe(detail::FiberInterface* current, const io_uring_cqe& cqe);
+  void ProcessCqeBatch(unsigned count, io_uring_cqe** cqes, detail::FiberInterface* current);
+  void ReapCompletions(unsigned count, io_uring_cqe** cqes, detail::FiberInterface* current);
 
   void RegrowCentries();
 

--- a/util/fibers/uring_socket.cc
+++ b/util/fibers/uring_socket.cc
@@ -89,6 +89,7 @@ auto UringSocket::Close() -> error_code {
       LOG(WARNING) << "Error unregistering fd " << direct_fd;
       return ec;
     }
+    is_direct_fd_ = 0;
   } else {
     fd = native_handle();
   }


### PR DESCRIPTION
The main change is that we now rely on liburing function io_uring_peek_batch_cqe
 to peek for completions instead of manually iterating with `io_uring_for_each_cqe` call.
 The reason for this is that iouring API evolved, and the logic for peeking completions became
 non-trivial: it requires calling a system call in some rare cases. So
 in terms correctness and ease of maintainance it's better to rely on the library function to do the right job.
 In addition, fibers scheduler code has non-functional changes:

 a. Added a trace variable to ease with debugging: it shows the last transitioned state of the fiber
     in ambigous situations.
 b. ProcessSleep now returns the number of woken fibers.