### PR TITLE
feat: enable direct-fd sockets

### DIFF
--- a/util/fiber_socket_base.h
+++ b/util/fiber_socket_base.h
@@ -129,7 +129,6 @@ class FiberSocketBase : public io::Sink, public io::AsyncSink, public io::Source
 class LinuxSocketBase : public FiberSocketBase {
  public:
   using FiberSocketBase::native_handle_type;
-  constexpr static unsigned kFdShift = 4;
 
   virtual ~LinuxSocketBase();
 
@@ -175,6 +174,8 @@ class LinuxSocketBase : public FiberSocketBase {
   }
 
  protected:
+  constexpr static unsigned kFdShift = 4;
+
   LinuxSocketBase(int fd, ProactorBase* pb)
       : FiberSocketBase(pb), fd_(fd > 0 ? fd << kFdShift : fd) {
   }

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -159,6 +159,7 @@ Scheduler::Scheduler(FiberInterface* main_cntx) : main_cntx_(main_cntx) {
 
   fibers_.push_back(*main_cntx);
   fibers_.push_back(*dispatch_cntx_);
+  AddReady(dispatch_cntx_.get());
 }
 
 Scheduler::~Scheduler() {
@@ -197,11 +198,7 @@ Scheduler::~Scheduler() {
 ctx::fiber_context Scheduler::Preempt() {
   DCHECK(FiberActive() != dispatch_cntx_.get()) << "Should not preempt dispatcher";
   DCHECK(!IsFiberAtomicSection()) << "Preempting inside of atomic section";
-
-  if (ready_queue_.empty()) {
-    // All user fibers are inactive, we should switch back to the dispatcher.
-    return dispatch_cntx_->SwitchTo();
-  }
+  DCHECK(!ready_queue_.empty());  // dispatcher fiber is always in the ready queue.
 
   DCHECK(!ready_queue_.empty());
   FiberInterface* fi = &ready_queue_.front();

--- a/util/fibers/fiber_socket_base.cc
+++ b/util/fibers/fiber_socket_base.cc
@@ -42,8 +42,8 @@ void FiberSocketBase::SetProactor(ProactorBase* p) {
     proactor_ = nullptr;
   }
   proactor_ = p;
-
-  OnSetProactor();
+  if (p)
+    OnSetProactor();
 }
 
 Result<size_t> FiberSocketBase::Recv(const iovec* ptr, size_t len) {

--- a/util/fibers/uring_proactor.h
+++ b/util/fibers/uring_proactor.h
@@ -153,7 +153,8 @@ class UringProactor : public ProactorBase {
   uint32_t pending_cb_cnt_ = 0;
   uint32_t next_free_index_ = 0;  // next available fd for register files.
   uint32_t direct_fds_cnt_ = 0;
-  uint32_t get_entry_sq_full_ = 0, get_entry_submit_fail_ = 0, get_entry_await_ = 0;
+  uint32_t get_entry_sq_full_ = 0, get_entry_await_ = 0;
+  uint64_t reaped_cqe_cnt_ = 0;
 
   int32_t free_req_buf_id_ = -1;
   std::unique_ptr<uint8_t[]> registered_buf_;

--- a/util/fibers/uring_socket.h
+++ b/util/fibers/uring_socket.h
@@ -63,8 +63,15 @@ class UringSocket : public LinuxSocketBase {
     return static_cast<const UringProactor*>(proactor());
   }
 
+  void OnSetProactor() final;
+  void OnResetProactor();
+
   uint8_t register_flag() const {
     return is_direct_fd_ ? IOSQE_FIXED_FILE : 0;
+  }
+
+  void UpdateDfVal(unsigned val) {
+    fd_ = (val << kFdShift) | (fd_ & ((1 << kFdShift) - 1));
   }
 
   uint32_t error_cb_id_ = UINT32_MAX;


### PR DESCRIPTION
1. Fixed socket migration code.
2. Enabled direct-fd feature for server side sockets for kernels that support it.
3. Added some stats about cqe completions to uring_proactor.
4. Added `maxclients` flag to echo_server. 

memtier load: `memtier_benchmark -s 172.31.36.182 --command=PING -t 16 -c 18 -n 60000 --hide-histogram --distinct-client-seed`

## dragonfly on helio master
```
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Pings      968745.62         0.30147         0.30300         0.43900         0.51900     19866.85
```

## dragonfly on this PR:
```
==================================================================================================
Type         Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec
--------------------------------------------------------------------------------------------------
Pings     1083269.17         0.28287         0.27900         0.42300         0.51100     22215.48
```