### PR TITLE
feat: Add preliminary support to provided buffer rings

### DIFF
--- a/examples/pingserver/ping_iouring_server.cc
+++ b/examples/pingserver/ping_iouring_server.cc
@@ -133,7 +133,7 @@ void PingConnection::HandleRequests() {
 
   VLOG(1) << "Connection shutting down";
   error_code err = socket_->Shutdown(SHUT_RDWR);
-  LOG_IF(WARNING, !err) << "Shutdown failed: " << err.message();
+  LOG_IF(WARNING, err) << "Shutdown failed: " << err.message();
 }
 
 class PingListener : public ListenerInterface {

--- a/util/fibers/submit_entry.h
+++ b/util/fibers/submit_entry.h
@@ -189,6 +189,11 @@ class SubmitEntry {
     sqe_->rw_flags = 0;
   }
 
+  void PrepCancel(int fd, unsigned flags) {
+    PrepFd(IORING_OP_ASYNC_CANCEL, fd);
+    sqe_->cancel_flags = flags;
+  }
+
   io_uring_sqe* sqe() {
     return sqe_;
   }


### PR DESCRIPTION
These provided buffer rings can be used by kernel for multishot operations to read the data directly into these buffers. No functionality changes yet, a test will be followed up with socket changes.

Also did some code clean ups on a way with echo server and ping_iouring_server (no functionality changes).