### PR TITLE
enable macos ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
 
   build-macos:
     runs-on: macos-latest
-    if: ${{ false }}  # Disabled due to mysterious segfaults in fibers_test ✨
+    if: ${{ true }}  #  ✨
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -120,4 +120,5 @@ jobs:
           cd ${{github.workspace}}/build
           ninja -k 5 base/all io/all strings/all util/all echo_server ping_iouring_server \
             https_client_cli s3_demo
+          ./fibers_test --logtostderr --gtest_repeat=10
           ctest -V -L CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,7 @@ jobs:
 
   build-macos:
     runs-on: macos-latest
-    if: ${{ true }}  #  ✨
-    timeout-minutes: 30
+    timeout-minutes: 30  ✨✨✨✨
     steps:
       - uses: actions/checkout@v4
       - run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,28 @@ option (USE_MOLD "whether to use mold linker" OFF)
 set    (HELIO_MIMALLOC_OPTS "" CACHE STRING "additional mimalloc compile options")
 set    (HELIO_MIMALLOC_LIBNAME "libmimalloc.a" CACHE STRING "name of mimalloc library")
 
+include(CheckCXXCompilerFlag)
+
+set(CMAKE_REQUIRED_FLAGS "-fsanitize=address")
+check_cxx_source_compiles("int main() { return 0; }" SUPPORT_ASAN)
+
+set(CMAKE_REQUIRED_FLAGS "-fsanitize=undefined")
+check_cxx_source_compiles("int main() { return 0; }" SUPPORT_USAN)
+
+set(CMAKE_REQUIRED_FLAGS "")
+
+if (SUPPORT_ASAN)
+  # TODO: asan sanitizer is not working with fibers,
+  # but if we build Boost.context ourselves, it should work.
+  # See https://github.com/boostorg/context/issues/70
+  # It's possible today to build Boost.context with cmake separately.
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address")
+endif()
+
+if (SUPPORT_USAN)
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=undefined")
+endif()
+
 if (PARENT_PROJ_NAME)
   Message(STATUS "PARENT_PROJ_NAME ${PARENT_PROJ_NAME}")
 else()

--- a/cmake/internal.cmake
+++ b/cmake/internal.cmake
@@ -20,7 +20,6 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
-include(CheckCXXCompilerFlag)
 
 CHECK_CXX_COMPILER_FLAG("-std=c++17" COMPILER_SUPPORTS_CXX17)
 CHECK_CXX_COMPILER_FLAG("-std=c++20" COMPILER_SUPPORTS_CXX20)
@@ -37,23 +36,6 @@ if (COMPILER_SUPPORTS_CXX20)
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 endif()
-
-set(CMAKE_REQUIRED_FLAGS "-fsanitize=address")
-check_cxx_source_compiles("int main() { return 0; }" SUPPORT_ASAN)
-
-set(CMAKE_REQUIRED_FLAGS "-fsanitize=undefined")
-check_cxx_source_compiles("int main() { return 0; }" SUPPORT_USAN)
-
-if (SUPPORT_ASAN)
-  # There is some weird interaction with sanitizers and exceptions.
-  # It exists at least on gcc 11.2 and clang-13.
-  # set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address")
-endif()
-
-if (SUPPORT_USAN)
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=undefined")
-endif()
-set(CMAKE_REQUIRED_FLAGS "")
 
 check_cxx_source_compiles("
 #include <string.h>
@@ -77,8 +59,6 @@ endif()
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fdiagnostics-color=auto")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")
-  #set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -fsanitize=address -fsanitize=undefined \
-  #-fno-sanitize=vptr -DUNDEFINED_BEHAVIOR_SANITIZER")
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${HELIO_RELEASE_FLAGS}")
   set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${HELIO_RELEASE_FLAGS}")
 endif()

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -162,15 +162,18 @@ endif ()
 
 FetchContent_Declare(
   benchmark
-  URL https://github.com/google/benchmark/archive/v1.8.2.tar.gz
+  URL https://github.com/google/benchmark/archive/v1.8.3.tar.gz
 )
 
 FetchContent_GetProperties(benchmark)
 if (NOT benchmark_POPULATED)
     FetchContent_Populate(benchmark)
     set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "")
+    set(BENCHMARK_ENABLE_EXCEPTIONS OFF CACHE BOOL "")
     set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "")
     set(BENCHMARK_ENABLE_LIBPFM OFF CACHE BOOL "")
+    set(BENCHMARK_INSTALL_DOCS OFF CACHE BOOL "")
+    set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "")
     add_subdirectory(${benchmark_SOURCE_DIR} ${benchmark_BINARY_DIR})
 endif ()
 
@@ -284,7 +287,7 @@ set(MIMALLOC_INCLUDE_DIR ${THIRD_PARTY_LIB_DIR}/mimalloc/include)
 
 set (MIMALLOC_PATCH_COMMAND patch -p1 -d ${THIRD_PARTY_DIR}/mimalloc/ -i ${CMAKE_CURRENT_LIST_DIR}/../patches/mimalloc-v2.0.9.patch)
 
- add_third_party(mimalloc
+add_third_party(mimalloc
    #GIT_REPOSITORY https://github.com/microsoft/mimalloc.git
    #GIT_TAG v2.0.9
    URL https://github.com/microsoft/mimalloc/archive/refs/tags/v2.0.9.tar.gz

--- a/util/fibers/epoll_proactor.h
+++ b/util/fibers/epoll_proactor.h
@@ -45,7 +45,7 @@ class EpollProactor : public ProactorBase {
   void MainLoop(detail::Scheduler* sched) final;
   LinuxSocketBase* CreateSocket() final;
   void SchedulePeriodic(uint32_t id, PeriodicItem* item) final;
-  void CancelPeriodicInternal(uint32_t val1, uint32_t val2) final;
+  void CancelPeriodicInternal(PeriodicItem* item) final;
   void WakeRing() final;
   void PeriodicCb(PeriodicItem* item);
 

--- a/util/fibers/fiber_socket_test.cc
+++ b/util/fibers/fiber_socket_test.cc
@@ -31,7 +31,7 @@ void InitProactor(ProactorBase* p) {
 }
 #else
 void InitProactor(ProactorBase* p) {
-  static_cast<EpollProactor*>(p)->Init();
+  static_cast<EpollProactor*>(p)->Init(0);
 }
 #endif
 
@@ -241,8 +241,8 @@ TEST_P(FiberSocketTest, Poll) {
   EXPECT_TRUE(POLLRDHUP & conn_sock_err_mask_) << conn_sock_err_mask_;
 #endif
 
-  EXPECT_TRUE(POLLHUP & conn_sock_err_mask_);
-  EXPECT_TRUE(POLLERR & conn_sock_err_mask_);
+  // POLLERR does not appear on macos.
+  EXPECT_TRUE((POLLHUP | POLLERR) & conn_sock_err_mask_) << conn_sock_err_mask_;
 }
 
 TEST_P(FiberSocketTest, PollCancel) {

--- a/util/fibers/proactor_base.cc
+++ b/util/fibers/proactor_base.cc
@@ -199,13 +199,12 @@ void ProactorBase::CancelPeriodic(uint32_t id) {
 
   auto it = periodic_map_.find(id);
   CHECK(it != periodic_map_.end());
-  uint32_t val1 = it->second->val1;
-  uint32_t val2 = it->second->val2;
-  it->second->in_map = false;
+  PeriodicItem* item = it->second;
+  --item->ref_cnt;
 
   // we never deallocate here since there is a callback that holds pointer to the item.
   periodic_map_.erase(it);
-  CancelPeriodicInternal(val1, val2);
+  CancelPeriodicInternal(item);
 }
 
 void ProactorBase::Migrate(ProactorBase* dest) {

--- a/util/fibers/proactor_base.h
+++ b/util/fibers/proactor_base.h
@@ -190,7 +190,10 @@ class ProactorBase {
 
     uint32_t val1;  // implementation dependent payload.
     uint32_t val2;  // implementation dependent payload.
-    bool in_map = true;
+
+    // for iouring the completions arrive asynchronously. We need to keep the reference count
+    // to make sure this record is alive when the completion arrives.
+    uint8_t ref_cnt = 1;
   };
 
   // Called only from external threads.
@@ -200,7 +203,7 @@ class ProactorBase {
   void WakeupIfNeeded();
 
   virtual void SchedulePeriodic(uint32_t id, PeriodicItem* item) = 0;
-  virtual void CancelPeriodicInternal(uint32_t val1, uint32_t val2) = 0;
+  virtual void CancelPeriodicInternal(PeriodicItem* item) = 0;
 
   // Returns true if we should continue spinning or false otherwise.
   bool RunOnIdleTasks();

--- a/util/fibers/uring_proactor.cc
+++ b/util/fibers/uring_proactor.cc
@@ -18,7 +18,8 @@
 #include "util/fibers/detail/scheduler.h"
 #include "util/fibers/uring_socket.h"
 
-ABSL_FLAG(bool, enable_direct_fd, true, "If true tries to register file descriptors");
+// TODO: to fix the bug when running dragonfly regtests on 6.2.
+ABSL_FLAG(bool, enable_direct_fd, false, "If true tries to register file descriptors");
 
 #define URING_CHECK(x)                                                        \
   do {                                                                        \

--- a/util/fibers/uring_proactor.cc
+++ b/util/fibers/uring_proactor.cc
@@ -452,12 +452,12 @@ void UringProactor::SchedulePeriodic(uint32_t id, PeriodicItem* item) {
 
   se.PrepTimeout(&item->period, false);
   DVLOG(2) << "Scheduling timer " << item << " userdata: " << se.sqe()->user_data;
-
+  item->ref_cnt = 2;  // one for the map and one for the callback.
   item->val1 = se.sqe()->user_data;
 }
 
 void UringProactor::PeriodicCb(IoResult res, uint32 task_id, PeriodicItem* item) {
-  if (!item->in_map) {  // has been removed from the map.
+  if (item->ref_cnt <= 1) {  // has been removed from the map.
     delete item;
     return;
   }
@@ -466,16 +466,18 @@ void UringProactor::PeriodicCb(IoResult res, uint32 task_id, PeriodicItem* item)
   CHECK_EQ(res, -ETIME);
 
   DCHECK(periodic_map_.find(task_id) != periodic_map_.end());
+  DCHECK(item->task);
   item->task();
 
   schedule_periodic_list_.emplace_back(task_id, item);
 }
 
-void UringProactor::CancelPeriodicInternal(uint32_t val1, uint32_t val2) {
+void UringProactor::CancelPeriodicInternal(PeriodicItem* item) {
   auto* me = detail::FiberActive();
   auto cb = [me](detail::FiberInterface* current, IoResult res, uint32_t flags) {
     ActivateSameThread(current, me);
   };
+  uint32_t val1 = item->val1;
   SubmitEntry se = GetSubmitEntry(std::move(cb));
 
   DVLOG(1) << "Cancel timer " << val1 << ", cb userdata: " << se.sqe()->user_data;

--- a/util/fibers/uring_proactor.h
+++ b/util/fibers/uring_proactor.h
@@ -121,7 +121,7 @@ class UringProactor : public ProactorBase {
   // Used with older kernels with msgring_f_ == 0.
   void ArmWakeupEvent();
   void SchedulePeriodic(uint32_t id, PeriodicItem* item) final;
-  void CancelPeriodicInternal(uint32_t val1, uint32_t val2) final;
+  void CancelPeriodicInternal(PeriodicItem* item) final;
 
   void PeriodicCb(IoResult res, uint32_t task_id, PeriodicItem* item);
 


### PR DESCRIPTION
1. Fix cmake flags so that we could run with sanitizers.
   Note: due to fibers the address sanitizers is practically useless but
   we will fix it in subsequent PRs.
   The problem was that we need to compile abseil lib with the same debug flags like helio
   so I moved those settings to before we include third_party libs.
2. Fix periodic timer cancelation on macos.
   In general with epoll/kevent we can assume (for now) all the completions stop syncrhonously
   Once we cancel/delete the timer so we can just explicitly delete "item" in epoll_proactor.
   For io_uring the cancelation causes callback to run one more time so it will delete its item.
3. The rest is minor built/test fixes in fibers_test related to macos.
