### PR TITLE
fix(io_buf): new/delete alignment missmatch

### DIFF
--- a/base/io_buf.cc
+++ b/base/io_buf.cc
@@ -50,7 +50,7 @@ void IoBuf::Reserve(size_t sz) {
     } else {
       size_ = offs_ = 0;
     }
-    delete[] buf_;
+    ::operator delete[](buf_, std::align_val_t{alignment_});
   }
 
   buf_ = nb;


### PR DESCRIPTION
The problem is that in `IoBuf::Reserve` method we allocate with:

```
uint8_t* nb = new (std::align_val_t{alignment_}) uint8_t[sz];

and later

delete[] buf_;
```
which causes an alignment mismatch
