### PR TITLE
fix: disable stack protector that does not work well with gperftools

### DIFF
--- a/base/mpsc_intrusive_queue.h
+++ b/base/mpsc_intrusive_queue.h
@@ -65,7 +65,7 @@ template <typename T> class MPSCIntrusiveQueue {
     T* head = head_;
     T* next = MPSC_intrusive_load_next(*head);
 
-    return stub() == head && next == nullptr;
+    return reinterpret_cast<const T*>(&storage_) == head && next == nullptr;
   }
 };
 

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -15,7 +15,8 @@ option (WITH_UNWIND "Enable libunwind support" ON)
 set(THIRD_PARTY_LIB_DIR "${THIRD_PARTY_DIR}/libs")
 file(MAKE_DIRECTORY ${THIRD_PARTY_LIB_DIR})
 
-set(THIRD_PARTY_CXX_FLAGS "-std=c++14 -O3 -DNDEBUG -fPIC")
+set(THIRD_PARTY_CXX_FLAGS "-std=c++14 -O3 -DNDEBUG -fPIC -fno-stack-protector \
+    -fno-stack-clash-protection")
 
 find_package(Threads REQUIRED)
 

--- a/util/fibers/detail/fiber_interface.cc
+++ b/util/fibers/detail/fiber_interface.cc
@@ -298,8 +298,12 @@ void FiberInterface::PullMyselfFromRemoteReadyQueue() {
   // Therefore we process all the items and since this function is called after the fiber
   // was pulled from the wait queue, it is guaranteed that other threads won't add this object
   // back to the remote_ready_queue.
-  scheduler_->ProcessRemoteReady(this);
-  CHECK(!IsScheduledRemotely());
+  bool res = scheduler_->ProcessRemoteReady(this);
+  if (IsScheduledRemotely()) {
+    LOG(FATAL) << "Failed to pull " << name_ << " from remote_ready_queue. res=" << res
+               << " remotenext: " << uint64_t(remote_next_.load(std::memory_order_relaxed))
+               <<  " remotempty: " << scheduler_->RemoteEmpty();
+  }
 }
 
 void FiberInterface::ExecuteOnFiberStack(PrintFn fn) {

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -317,7 +317,8 @@ bool Scheduler::WaitUntil(chrono::steady_clock::time_point tp, FiberInterface* m
   return has_timed_out;
 }
 
-void Scheduler::ProcessRemoteReady(FiberInterface* active) {
+bool Scheduler::ProcessRemoteReady(FiberInterface* active) {
+  bool res = false;
   while (true) {
     FiberInterface* fi = remote_ready_queue_.Pop();
     if (!fi)
@@ -330,6 +331,8 @@ void Scheduler::ProcessRemoteReady(FiberInterface* active) {
 
     DCHECK(fi->scheduler_ == this);
 
+    if (fi == active)
+      res = true;
     // Generally, fi should not be in the ready queue if it's still in the remote queue,
     // because being in the remote queue means fi is still registered in the wait_queue of
     // some event. However, in case fi is waiting with timeout, ProcessSleep below can not
@@ -350,6 +353,8 @@ void Scheduler::ProcessRemoteReady(FiberInterface* active) {
       AddReady(fi);
     }
   }
+
+  return res;
 }
 
 unsigned Scheduler::ProcessSleep() {

--- a/util/fibers/detail/scheduler.h
+++ b/util/fibers/detail/scheduler.h
@@ -75,7 +75,9 @@ class Scheduler {
   }
 
   void DestroyTerminated();
-  void ProcessRemoteReady(FiberInterface* active);
+
+  // Returns true if active fiber was pulled from the queue.
+  bool ProcessRemoteReady(FiberInterface* active);
 
   // Returns number of sleeping fibers being activated from sleep.
   unsigned ProcessSleep();
@@ -90,6 +92,9 @@ class Scheduler {
   void ExecuteOnAllFiberStacks(FiberInterface::PrintFn fn);
   void SuspendAndExecuteOnDispatcher(std::function<void()> fn);
 
+  bool RemoteEmpty() const {
+    return remote_ready_queue_.Empty();
+  }
  private:
   // We use intrusive::list and not slist because slist has O(N) complexity for some operations
   // which may be time consuming for long lists.


### PR DESCRIPTION
1.  `readelf --debug-dump=info ./echo_server | grep "DW_AT_producer"` shows that helio is compiled  with stack protection flags on my laptop,  even in O2 mode. Seems like some distro tweaking of gcc because I have not seen it before. As a result, when CPU profiling is enabled, dragonfly can crash with a message "stack smashing detected" . The stacktrace shows the failure happens inside `CpuProfiler::prof_handler` which is a signal handler of gperftools. Seems like a bad interaction of signal handling and stack protection code. Therefore, I disabled these stack flags for thirdpary libraries.
2. Unrelated, I added more logs inside fiber code for a check-fail that sometimes happens in dragonfly unit tests like this one: https://github.com/dragonflydb/dragonfly/actions/runs/7862807475/job/21452699281?pr=2570#step:10:6509 