### PR TITLE
fix: mpsc intrusive queue now reports its precise state during Pop

### DIFF
--- a/util/fibers/detail/fiber_interface.h
+++ b/util/fibers/detail/fiber_interface.h
@@ -170,8 +170,6 @@ class FiberInterface {
 
   void PullMyselfFromRemoteReadyQueue();
 
-  bool DEBUG_wait_state = false;
-
  protected:
   bool IsScheduledRemotely() const {
     return uint64_t(remote_next_.load(std::memory_order_relaxed)) != kRemoteFree;

--- a/util/fibers/detail/fiber_interface_impl.h
+++ b/util/fibers/detail/fiber_interface_impl.h
@@ -20,7 +20,6 @@ inline void FiberInterface::Suspend() {
 
 inline void WaitQueue::Link(Waiter* waiter) {
   wait_list_.push_back(*waiter);
-  waiter->cntx()->DEBUG_wait_state = true;
 }
 
 }  // namespace detail

--- a/util/fibers/detail/scheduler.h
+++ b/util/fibers/detail/scheduler.h
@@ -76,7 +76,7 @@ class Scheduler {
 
   void DestroyTerminated();
 
-  // Returns true if active fiber was pulled from the queue.
+  // Returns whether the active fiber was pulled from the queue and the queue state.
   bool ProcessRemoteReady(FiberInterface* active);
 
   // Returns number of sleeping fibers being activated from sleep.

--- a/util/fibers/synchronization.cc
+++ b/util/fibers/synchronization.cc
@@ -29,7 +29,6 @@ std::cv_status EventCount::wait_until(uint32_t epoch,
 
     // We must protect wait_hook because we modify it in notification thread.
     lk.lock();
-    active->DEBUG_wait_state = false;
     if (waiter.IsLinked()) {
       assert(!wait_queue_.empty());
 
@@ -57,7 +56,6 @@ void Mutex::lock() {
   while (true) {
     detail::Waiter waiter(active->CreateWaiter());
     wait_queue_splk_.lock();
-    active->DEBUG_wait_state = false;
     if (nullptr == owner_) {
       DCHECK(!waiter.IsLinked());
 

--- a/util/fibers/synchronization.h
+++ b/util/fibers/synchronization.h
@@ -168,10 +168,6 @@ class CondVarAny {
 
     active->Suspend();
 
-    wait_queue_splk_.lock();
-    active->DEBUG_wait_state = false;
-    wait_queue_splk_.unlock();
-
     // relock external again before returning
     try {
       lt.lock();
@@ -204,8 +200,6 @@ class CondVarAny {
     bool clear_remote = true;
 
     wait_queue_splk_.lock();
-    active->DEBUG_wait_state = false;
-
     if (waiter.IsLinked()) {
       wait_queue_.Unlink(&waiter);
 
@@ -568,10 +562,6 @@ inline bool EventCount::wait(uint32_t epoch) noexcept {
     wait_queue_.Link(&waiter);
     lk.unlock();
     active->Suspend();
-
-    lk.lock();
-    active->DEBUG_wait_state = false;
-    lk.unlock();
 
     return true;
   }


### PR DESCRIPTION
Before, we could get "no element" response, when in fact the queue is not empty. This can happen when `tail_` is being in the middle of the update but its "next" field has not been updated yet (inside Push).

Before the change, we treated this state as "Empty", while the queue could have multiple entries (probably 1 or 2). After this change: we retry the pop operation in scheduler until we reach the true depletion of the remote queue.