### PR TITLE
chore: allow injection of memory_resource into accept server

### DIFF
--- a/util/accept_server.h
+++ b/util/accept_server.h
@@ -8,8 +8,10 @@
 #include <memory>
 #include <vector>
 
+#include "base/pmr/memory_resource.h"
 #include "util/connection.h"
 #include "util/fibers/synchronization.h"
+
 namespace util {
 
 class ListenerInterface;
@@ -20,7 +22,12 @@ class AcceptServer {
   void operator=(const AcceptServer&) = delete;
 
  public:
-  explicit AcceptServer(ProactorPool* pool, bool break_on_int = true);
+  explicit AcceptServer(ProactorPool* pool, bool break_on_int = true)
+      : AcceptServer(pool, nullptr, break_on_int) {
+  }
+
+  AcceptServer(ProactorPool* pool, PMR_NS::memory_resource* mr, bool break_on_int);
+
   ~AcceptServer();
 
   void Run();
@@ -55,6 +62,7 @@ class AcceptServer {
   void BreakListeners();
 
   ProactorPool* pool_;
+  PMR_NS::memory_resource* mr_;
 
   // Called if a termination signal has been caught (SIGTERM/SIGINT).
   std::function<void()> on_break_hook_;

--- a/util/fibers/accept_server.cc
+++ b/util/fibers/accept_server.cc
@@ -16,7 +16,8 @@ namespace util {
 using namespace boost;
 using namespace std;
 
-AcceptServer::AcceptServer(ProactorPool* pool, bool break_on_int) : pool_(pool), ref_bc_(0) {
+AcceptServer::AcceptServer(ProactorPool* pool, PMR_NS::memory_resource* mr, bool break_on_int)
+    : pool_(pool), mr_(mr), ref_bc_(0) {
   if (break_on_int) {
     ProactorBase* proactor = pool_->GetNextProactor();
     proactor->RegisterSignal({SIGINT, SIGTERM}, [this](int signal) {
@@ -150,7 +151,7 @@ error_code AcceptServer::AddListener(const char* bind_addr, uint16_t port,
   if (success) {
     DCHECK(fs->IsOpen());
 
-    listener->RegisterPool(pool_);
+    listener->InitByAcceptServer(pool_, mr_);
     listener->sock_ = std::move(fs);
     list_interface_.emplace_back(listener);
   }
@@ -179,7 +180,7 @@ error_code AcceptServer::AddUDSListener(const char* path, mode_t permissions,
   });
 
   if (!ec) {
-    listener->RegisterPool(pool_);
+    listener->InitByAcceptServer(pool_, mr_);
     listener->sock_ = std::move(fs);
     list_interface_.emplace_back(listener);
   }

--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -458,7 +458,7 @@ TEST_F(FiberTest, SwitchAndExecute) {
 }
 
 TEST_F(FiberTest, StackSize) {
-  Fiber fb1(Launch::dispatch, boost::context::fixedsize_stack{4096}, "fb1", [] {
+  Fiber fb1(Launch::dispatch, boost::context::fixedsize_stack{6144}, "fb1", [] {
     LOG(INFO) << "fb1 started";
     detail::FiberInterface* active = detail::FiberActive();
 

--- a/util/listener_interface.h
+++ b/util/listener_interface.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <unordered_map>
 
+#include "base/pmr/memory_resource.h"
 #include "util/fiber_socket_base.h"
 
 namespace util {
@@ -26,7 +27,7 @@ class ListenerInterface {
 
   virtual ~ListenerInterface();
 
-  void RegisterPool(ProactorPool* pool);
+  void InitByAcceptServer(ProactorPool* pool, PMR_NS::memory_resource* mr);
 
   //! Creates a dedicated handler for a new connection.
   //! Called per new accepted connection
@@ -122,6 +123,7 @@ class ListenerInterface {
   std::atomic_uint32_t open_connections_{0};
 
   ProactorPool* pool_ = nullptr;
+  PMR_NS::memory_resource* mr_;
   friend class AcceptServer;
 };
 

--- a/util/tls/tls_engine_test.cc
+++ b/util/tls/tls_engine_test.cc
@@ -48,6 +48,22 @@ SSL_CTX* CreateSslCntx() {
 
   return ctx;
 }
+
+static void* TestMalloc(size_t num, const char* file, int line) {
+  VLOG(1) << "MyTestMalloc " << num << " " << file << ":" << line;
+  return malloc(num);
+}
+
+static void* TestRealloc(void* addr, size_t num, const char* file, int line) {
+  VLOG(1) << "MyTestRealloc " << num << " " << file << ":" << line;
+  return realloc(addr, num);
+}
+
+static void TestFree(void* addr, const char* file, int line) {
+  VLOG(1) << "TestFree " << file << ":" << line << " " << addr;
+  free(addr);
+}
+
 class SslStreamTest : public testing::Test {
  public:
   struct Options {
@@ -65,8 +81,11 @@ class SslStreamTest : public testing::Test {
 
  protected:
   static void SetUpTestSuite() {
+    CRYPTO_set_mem_functions(&TestMalloc, &TestRealloc, &TestFree);
   }
-
+  static void TearDownTestSuite() {
+    OPENSSL_cleanup();
+  }
   void SetUp() override;
 
   void TearDown() override {


### PR DESCRIPTION
By default we preserve the current behavior and fallback with a memory resource that allocates using std::malloc/std::free.

Also, provide an example of how to customize memory functions for OpenSSL.