### PR TITLE
chore: add IORING_OP_MADVISE support to iouring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          brew update && brew install ninja boost openssl automake gcc
+          brew uninstall --formula node kotlin harfbuzz sbt selenium-server imagemagick \
+              gradle maven openjdk postgresql r ant mongodb-community@5.0 mongosh \
+              node@18 php composer
+          brew update && brew install  --force ninja boost openssl automake gcc
           cmake --version
           gcc-13 --version
           uname -a

--- a/base/malloc_test.cc
+++ b/base/malloc_test.cc
@@ -322,4 +322,28 @@ static void BM_MimallocHeapVisit(benchmark::State& state) {
 }
 BENCHMARK(BM_MimallocHeapVisit);
 
+constexpr size_t kMmapSz = 1 << 16;
+static void BM_Madvise(benchmark::State& state) {
+  void* ptr = mmap(NULL, kMmapSz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  CHECK(ptr != MAP_FAILED);
+
+  while (state.KeepRunning()) {
+    madvise(ptr, kMmapSz, MADV_DONTNEED);
+    madvise(ptr, kMmapSz, MADV_SEQUENTIAL);
+  }
+  munmap(ptr, kMmapSz);
+}
+BENCHMARK(BM_Madvise);
+
+static void BM_Mmap(benchmark::State& state) {
+  while (state.KeepRunning()) {
+    char* ptr =
+        (char*)mmap(NULL, kMmapSz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (ptr != MAP_FAILED) {
+      munmap(ptr, kMmapSz);
+    }
+  }
+}
+BENCHMARK(BM_Mmap);
+
 }  // namespace base

--- a/util/fibers/detail/fiber_interface.cc
+++ b/util/fibers/detail/fiber_interface.cc
@@ -45,6 +45,9 @@ uint64_t g_tsc_cycles_per_ms = 0;
 
 }  // namespace
 
+PMR_NS::memory_resource* default_stack_resource = nullptr;
+size_t default_stack_size = 64 * 1024;
+
 // Per thread initialization structure.
 struct TL_FiberInitializer {
   TL_FiberInitializer* next = nullptr;

--- a/util/fibers/detail/fiber_interface.h
+++ b/util/fibers/detail/fiber_interface.h
@@ -336,6 +336,9 @@ inline void ActivateSameThread(FiberInterface* active, FiberInterface* other) {
   active->ActivateOther(other);
 }
 
+extern PMR_NS::memory_resource* default_stack_resource;
+extern size_t default_stack_size;
+
 }  // namespace detail
 }  // namespace fb2
 }  // namespace util

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -54,7 +54,7 @@ class DispatcherImpl final : public FiberInterface {
 };
 
 DispatcherImpl* MakeDispatcher(Scheduler* sched) {
-  ctx::fixedsize_stack salloc;
+  ctx::fixedsize_stack salloc(1024 * 32);  // 32K stack.
   ctx::stack_context sctx = salloc.allocate();
   ctx::preallocated palloc = MakePreallocated<DispatcherImpl>(sctx);
 

--- a/util/fibers/fibers.cc
+++ b/util/fibers/fibers.cc
@@ -42,5 +42,12 @@ void Fiber::JoinIfNeeded() {
     Join();
 }
 
+void SetDefaultStackResource(PMR_NS::memory_resource* mr, size_t default_size) {
+  CHECK(detail::default_stack_resource == nullptr);
+  detail::default_stack_resource = mr;
+  detail::default_stack_size = default_size;
+  std::atomic_thread_fence(std::memory_order_seq_cst);
+}
+
 }  // namespace fb2
 }  // namespace util

--- a/util/fibers/submit_entry.h
+++ b/util/fibers/submit_entry.h
@@ -27,7 +27,7 @@ class SubmitEntry {
 
   void PrepOpenAt(int dfd, const char* path, int flags, mode_t mode) {
     PrepFd(IORING_OP_OPENAT, dfd);
-    sqe_->addr = (unsigned long)path;
+    sqe_->addr = (__u64)path;
     sqe_->open_flags = flags;
     sqe_->len = mode;
   }
@@ -49,35 +49,35 @@ class SubmitEntry {
 
   void PrepAccept(int listen_fd, struct sockaddr* addr, unsigned addrlen, unsigned flags) {
     PrepFd(IORING_OP_ACCEPT, listen_fd);
-    sqe_->addr = (unsigned long)addr;
+    sqe_->addr = (__u64)addr;
     sqe_->len = addrlen;
     sqe_->accept_flags = flags;
   }
 
   void PrepRecv(int fd, void* buf, size_t len, unsigned flags) {
     PrepFd(IORING_OP_RECV, fd);
-    sqe_->addr = (unsigned long)buf;
+    sqe_->addr = (__u64)buf;
     sqe_->len = len;
     sqe_->msg_flags = flags;
   }
 
   void PrepRecvMsg(int fd, const struct msghdr* msg, unsigned flags) {
     PrepFd(IORING_OP_RECVMSG, fd);
-    sqe_->addr = (unsigned long)msg;
+    sqe_->addr = (__u64)msg;
     sqe_->len = 1;
     sqe_->msg_flags = flags;
   }
 
   void PrepRead(int fd, void* buf, unsigned size, size_t offset) {
     PrepFd(IORING_OP_READ, fd);
-    sqe_->addr = (unsigned long)buf;
+    sqe_->addr = (__u64)buf;
     sqe_->len = size;
     sqe_->off = offset;
   }
 
   void PrepReadFixed(int fd, void* buf, unsigned size, size_t offset, uint16_t buf_index) {
     PrepFd(IORING_OP_READ_FIXED, fd);
-    sqe_->addr = (unsigned long)buf;
+    sqe_->addr = (__u64)buf;
     sqe_->len = size;
     sqe_->off = offset;
     sqe_->buf_index = buf_index;
@@ -86,7 +86,7 @@ class SubmitEntry {
   void PrepReadV(int fd, const struct iovec* vec, unsigned nr_vecs, size_t offset,
                  unsigned flags = 0) {
     PrepFd(IORING_OP_READV, fd);
-    sqe_->addr = (unsigned long)vec;
+    sqe_->addr = (__u64)vec;
     sqe_->len = nr_vecs;
     sqe_->off = offset;
     sqe_->rw_flags = flags;
@@ -94,14 +94,14 @@ class SubmitEntry {
 
   void PrepWrite(int fd, const void* buf, unsigned size, size_t offset) {
     PrepFd(IORING_OP_WRITE, fd);
-    sqe_->addr = (unsigned long)buf;
+    sqe_->addr = (__u64)buf;
     sqe_->len = size;
     sqe_->off = offset;
   }
 
   void PrepWriteFixed(int fd, void* buf, unsigned size, size_t offset, uint16_t buf_index) {
     PrepFd(IORING_OP_WRITE_FIXED, fd);
-    sqe_->addr = (unsigned long)buf;
+    sqe_->addr = (__u64)buf;
     sqe_->len = size;
     sqe_->off = offset;
     sqe_->buf_index = buf_index;
@@ -110,7 +110,7 @@ class SubmitEntry {
   void PrepWriteV(int fd, const struct iovec* vec, unsigned nr_vecs, size_t offset,
                   unsigned flags = 0) {
     PrepFd(IORING_OP_WRITEV, fd);
-    sqe_->addr = (unsigned long)vec;
+    sqe_->addr = (__u64)vec;
     sqe_->len = nr_vecs;
     sqe_->off = offset;
     sqe_->rw_flags = flags;
@@ -132,21 +132,21 @@ class SubmitEntry {
 
   void PrepSend(int fd, const void* buf, size_t len, unsigned flags) {
     PrepFd(IORING_OP_SEND, fd);
-    sqe_->addr = (unsigned long)buf;
+    sqe_->addr = (__u64)buf;
     sqe_->len = len;
     sqe_->msg_flags = flags;
   }
 
   void PrepSendMsg(int fd, const struct msghdr* msg, unsigned flags) {
     PrepFd(IORING_OP_SENDMSG, fd);
-    sqe_->addr = (unsigned long)msg;
+    sqe_->addr = (__u64)msg;
     sqe_->len = 1;
     sqe_->msg_flags = flags;
   }
 
   void PrepConnect(int fd, const struct sockaddr* addr, socklen_t addrlen) {
     PrepFd(IORING_OP_CONNECT, fd);
-    sqe_->addr = (unsigned long)addr;
+    sqe_->addr = (__u64)addr;
     sqe_->len = 0;
     sqe_->off = addrlen;
   }
@@ -157,7 +157,7 @@ class SubmitEntry {
 
   void PrepTimeout(const timespec* ts, bool is_abs = true) {
     PrepFd(IORING_OP_TIMEOUT, -1);
-    sqe_->addr = (unsigned long)ts;
+    sqe_->addr = (__u64)ts;
     sqe_->len = 1;
     sqe_->timeout_flags = (is_abs ? IORING_TIMEOUT_ABS : 0);
   }
@@ -171,7 +171,7 @@ class SubmitEntry {
   // Sets up link timeout with relative timespec.
   void PrepLinkTimeout(const timespec* ts) {
     PrepFd(IORING_OP_LINK_TIMEOUT, -1);
-    sqe_->addr = (unsigned long)ts;
+    sqe_->addr = (__u64)ts;
     sqe_->len = 1;
     sqe_->timeout_flags = 0;
   }
@@ -194,13 +194,21 @@ class SubmitEntry {
     sqe_->cancel_flags = flags;
   }
 
-  io_uring_sqe* sqe() {
-    return sqe_;
+  void PrepMadvise(void* addr, off_t len, int advice) {
+    PrepFd(IORING_OP_MADVISE, -1);
+    sqe_->addr = (__u64)addr;
+    sqe_->len = len;
+    sqe_->fadvise_advice = advice;
   }
 
   void PrepNOP() {
     PrepFd(IORING_OP_NOP, -1);
   }
+
+  io_uring_sqe* sqe() {
+    return sqe_;
+  }
+
 
   // Used only by Proactor.
   explicit SubmitEntry(io_uring_sqe* sqe) : sqe_(sqe) {


### PR DESCRIPTION
Also add a microbenchmark measuring mmap and madvise calls.

a single madvise call takes around 100ns while mmap is x3 more expensive.