### PR TITLE
chore: add DEBUG_Count() to barrier

### DIFF
--- a/util/fibers/synchronization.cc
+++ b/util/fibers/synchronization.cc
@@ -168,6 +168,10 @@ void EmbeddedBlockingCounter::Cancel() {
   ec_.notifyAll();
 }
 
+uint64_t EmbeddedBlockingCounter::DEBUG_Count() const {
+  return count_.load(memory_order_relaxed);
+}
+
 BlockingCounter::BlockingCounter(unsigned start_count)
     : counter_{std::make_shared<EmbeddedBlockingCounter>(start_count)} {
 }

--- a/util/fibers/synchronization.h
+++ b/util/fibers/synchronization.h
@@ -393,7 +393,7 @@ class EmbeddedBlockingCounter {
   // Same as Wait(), but with timeout
   bool WaitFor(const std::chrono::steady_clock::duration& duration);
 
-  // Start with specified count. Current value must be zero or cancelled
+  // Start with specified count. Current value must be strictly zero (not cancelled).
   void Start(unsigned cnt);
 
   // Add to blocking counter
@@ -404,6 +404,8 @@ class EmbeddedBlockingCounter {
 
   // Cancel blocking counter, unblock wait. Release semantics.
   void Cancel();
+
+  uint64_t DEBUG_Count() const;
 
  private:
   EventCount ec_;


### PR DESCRIPTION
Forgot to add this one 😅 Need it for DCHECKs. DEBUG prefix is used mainly in DF to indicate it's better not used in real code