### PR TITLE
chore: introduce worker fiber stack size tracking

### DIFF
--- a/util/fibers/detail/fiber_interface.cc
+++ b/util/fibers/detail/fiber_interface.cc
@@ -136,7 +136,7 @@ FiberInterface::FiberInterface(Type type, uint32_t cnt, string_view nm)
 FiberInterface::~FiberInterface() {
   DVLOG(2) << "Destroying " << name_;
   DCHECK_EQ(use_count_.load(), 0u);
-  DCHECK(wait_queue_.empty());
+  DCHECK(join_q_.empty());
   DCHECK(!list_hook.is_linked());
 }
 
@@ -170,7 +170,7 @@ ctx::fiber_context FiberInterface::Terminate() {
     CpuPause();
   }
   trace_ = TRACE_TERMINATE;
-  wait_queue_.NotifyAll(this);
+  join_q_.NotifyAll(this);
 
   flags_.fetch_and(~kBusyBit, memory_order_release);
 
@@ -221,7 +221,7 @@ void FiberInterface::Join() {
   }
 
   Waiter waiter{active->CreateWaiter()};
-  wait_queue_.Link(&waiter);
+  join_q_.Link(&waiter);
   flags_.fetch_and(~kBusyBit, memory_order_release);  // release the lock
   DVLOG(2) << "Joining on " << name_;
 
@@ -405,6 +405,14 @@ uint64_t FiberLongRunCnt() noexcept {
 
 uint64_t FiberLongRunSumUsec() noexcept {
   return detail::FbInitializer().long_runtime_usec;
+}
+
+size_t WorkerStackSize() {
+  return detail::FbInitializer().sched->worker_stack_size();
+}
+
+size_t WorkerFibersCount() {
+  return detail::FbInitializer().sched->num_worker_fibers();
 }
 
 }  // namespace fb2

--- a/util/fibers/detail/scheduler.h
+++ b/util/fibers/detail/scheduler.h
@@ -95,6 +95,10 @@ class Scheduler {
   bool RemoteEmpty() const {
     return remote_ready_queue_.Empty();
   }
+
+  size_t worker_stack_size() const {
+    return worker_stack_size_;
+  }
  private:
   // We use intrusive::list and not slist because slist has O(N) complexity for some operations
   // which may be time consuming for long lists.
@@ -134,6 +138,7 @@ class Scheduler {
 
   bool shutdown_ = false;
   uint32_t num_worker_fibers_ = 0;
+  size_t worker_stack_size_ = 0;
 };
 
 }  // namespace detail

--- a/util/fibers/fiber2.h
+++ b/util/fibers/fiber2.h
@@ -109,7 +109,9 @@ uint64_t FiberLongRunSumUsec() noexcept;
 // It is advised to call this function when a program starts.
 void SetDefaultStackResource(PMR_NS::memory_resource* mr, size_t default_size = 64 * 1024);
 
-// Returns the total size for worker fibers for the current thread.
+// Returns the total stack size (virtual memory) for worker fibers for the current thread.
+// Please note that RSS memory usage is usually smaller, depending on the actuall stack usage
+// of the fibers.
 size_t WorkerStackSize();
 
 // Returns number of worker fibers for the current thread.

--- a/util/fibers/fiber2.h
+++ b/util/fibers/fiber2.h
@@ -109,6 +109,12 @@ uint64_t FiberLongRunSumUsec() noexcept;
 // It is advised to call this function when a program starts.
 void SetDefaultStackResource(PMR_NS::memory_resource* mr, size_t default_size = 64 * 1024);
 
+// Returns the total size for worker fibers for the current thread.
+size_t WorkerStackSize();
+
+// Returns number of worker fibers for the current thread.
+size_t WorkerFibersCount();
+
 }  // namespace fb2
 
 template <typename Fn, typename... Arg> fb2::Fiber MakeFiber(Fn&& fn, Arg&&... arg) {

--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -184,9 +184,14 @@ TEST_F(FiberTest, Basic) {
   Fiber fb1("test1", [&] { ++run; });
   Fiber fb2("test2", [&] { ++run; });
   EXPECT_EQ(epoch, FiberSwitchEpoch());
+  EXPECT_EQ(128 * 1024 * 2, WorkerStackSize());
+  EXPECT_EQ(2, WorkerFibersCount());
 
   fb1.Join();
   fb2.Join();
+
+  EXPECT_EQ(0, WorkerFibersCount());
+  EXPECT_EQ(0, WorkerStackSize());
 
   EXPECT_EQ(2, run);
   EXPECT_LT(epoch, FiberSwitchEpoch());


### PR DESCRIPTION
I used the following script to track RSS usage vs VM usage for fibers:
https://github.com/ARM-software/CSAL/blob/master/coresight-tools/cskern/pagemap.py
