### PR TITLE
chore: tls cleanups + remove spurious socket error

### DIFF
--- a/util/fibers/epoll_socket.cc
+++ b/util/fibers/epoll_socket.cc
@@ -355,7 +355,7 @@ auto EpollSocket::RecvMsg(const msghdr& msg, int flags) -> Result<size_t> {
 
   // ETIMEDOUT can happen if a socket does not have keepalive enabled or for some reason
   // TCP connection did indeed stopped getting tcp keep alive packets.
-  if (!base::_in(res, {ECONNABORTED, EPIPE, ECONNRESET})) {
+  if (!base::_in(res, {ECONNABORTED, EPIPE, ECONNRESET, ETIMEDOUT})) {
     LOG(ERROR) << "sock[" << fd << "] Unexpected error " << res << "/" << strerror(res) << " "
                << RemoteEndpoint();
   }

--- a/util/fibers/listener_interface.cc
+++ b/util/fibers/listener_interface.cc
@@ -227,6 +227,9 @@ void ListenerInterface::RunSingleConnection(Connection* conn) {
   CHECK(conn->socket() != nullptr);
 
   VSOCK(1, *conn) << "Closing connection";
+
+  // Shut down connections in orderly fashion by telling the peer that we are done.
+  conn->socket()->Shutdown(SHUT_RDWR);
   LOG_IF(ERROR, conn->socket()->Close());
 
   // Our connection could migrate, hence we should find it again


### PR DESCRIPTION
1. Fixes https://github.com/dragonflydb/dragonfly/issues/2736
2. Make sure we call `Shutdown` when a connection is being closed.
3. Fix tls logic - if we have SSL errors, to continue writing the outgoing ssl stream to the underlying ssl socket