### PR TITLE
fix: Do not crash if connection is not found in list

### DIFF
--- a/util/fibers/listener_interface.cc
+++ b/util/fibers/listener_interface.cc
@@ -277,8 +277,12 @@ void ListenerInterface::TraverseConnectionsOnThread(TraverseCB cb) {
   DCHECK(ProactorBase::IsProactorThread());
   unsigned index = ProactorBase::me()->GetPoolIndex();
 
-  FiberAtomicGuard fg;
   auto it = conn_list.find(this);
+  if (it == conn_list.end()) {
+    return;
+  }
+
+  FiberAtomicGuard fg;
   for (auto& conn : it->second->list) {
     cb(index, &conn);
   }


### PR DESCRIPTION
This happens in Dragonfly if we kill the server immediately after starting replication.

Fixes https://github.com/dragonflydb/dragonfly/issues/2737