### PR TITLE
fix: fibers/socket bugs

### DIFF
--- a/util/fibers/uring_proactor.h
+++ b/util/fibers/uring_proactor.h
@@ -195,12 +195,7 @@ class FiberCall {
     return &se_;
   }
 
-  IoResult Get() {
-    me_->Suspend();
-    me_ = nullptr;
-
-    return io_res_;
-  }
+  IoResult Get();
 
   uint32_t flags() const {
     return res_flags_;
@@ -208,12 +203,12 @@ class FiberCall {
 
  private:
   SubmitEntry se_;
-  SubmitEntry tm_;
 
   detail::FiberInterface* me_;
   UringProactor::IoResult io_res_ = 0;
-  timespec ts_;             // in case of timeout.
   uint32_t res_flags_ = 0;  // set by waker upon completion.
+  bool was_run_ = false;
+  timespec ts_;             // in case of timeout.
 };
 
 }  // namespace fb2

--- a/util/http/http_client.cc
+++ b/util/http/http_client.cc
@@ -46,6 +46,9 @@ Client::Client(ProactorBase* proactor) : proactor_(proactor) {
 }
 
 Client::~Client() {
+  if (socket_) {
+    socket_->Close();
+  }
 }
 
 std::error_code Client::Connect(string_view host, string_view service) {
@@ -120,7 +123,6 @@ void Client::Shutdown() {
   if (socket_) {
     std::error_code ec = socket_->Shutdown(SHUT_RDWR);
     LOG_IF(WARNING, !ec) << "Socket Shutdown failed: " << ec.message();
-    socket_.reset();
   }
 }
 

--- a/util/http/http_client.h
+++ b/util/http/http_client.h
@@ -38,11 +38,6 @@ class Client {
   std::error_code Connect(std::string_view host, std::string_view service);
   std::error_code Reconnect();
 
-  /*BoostError Send(Verb verb, std::string_view url, std::string_view body, Response* response);
-  BoostError Send(Verb verb, std::string_view url, Response* response) {
-    return Send(verb, url, std::string_view{}, response);
-  }*/
-
   /*! @brief Sends http request but does not read response back.
    *
    *  Possibly retries and reconnects if there are problems with connection.


### PR DESCRIPTION
1. Prevent from FiberCall to wake up before its waker actually has been called.
2. Fix DnsResolve code to prevent notifying the wrong FiberCall on epoll event.