### PR TITLE
chore: Fix the crash in tls shutdown

### DIFF
--- a/util/tls/tls_engine.cc
+++ b/util/tls/tls_engine.cc
@@ -134,7 +134,6 @@ auto Engine::PeekOutputBuf() -> BufResult {
 }
 
 void Engine::ConsumeOutputBuf(unsigned sz) {
-  CHECK(external_bio_);
   int res = BIO_nread(external_bio_, NULL, sz);
 
   if (res <= 0) {

--- a/util/tls/tls_socket.cc
+++ b/util/tls/tls_socket.cc
@@ -68,7 +68,7 @@ TlsSocket::TlsSocket(FiberSocketBase* next) : TlsSocket(std::unique_ptr<FiberSoc
 
 TlsSocket::~TlsSocket() {
   // sanity check that all pending ops are done.
-  DCHECK_EQ(state_ & 7, 0);
+  DCHECK_EQ(state_ & (WRITE_IN_PROGRESS | READ_IN_PROGRESS | SHUTDOWN_IN_PROGRESS), 0);
 }
 
 void TlsSocket::InitSSL(SSL_CTX* context, Buffer prefix) {

--- a/util/tls/tls_socket.cc
+++ b/util/tls/tls_socket.cc
@@ -10,6 +10,7 @@
 
 #include "base/logging.h"
 #include "util/tls/tls_engine.h"
+#include "util/fibers/fibers.h"
 
 namespace util {
 namespace tls {
@@ -66,6 +67,8 @@ TlsSocket::TlsSocket(FiberSocketBase* next) : TlsSocket(std::unique_ptr<FiberSoc
 }
 
 TlsSocket::~TlsSocket() {
+  // sanity check that all pending ops are done.
+  DCHECK_EQ(state_ & 7, 0);
 }
 
 void TlsSocket::InitSSL(SSL_CTX* context, Buffer prefix) {
@@ -80,6 +83,11 @@ void TlsSocket::InitSSL(SSL_CTX* context, Buffer prefix) {
 
 auto TlsSocket::Shutdown(int how) -> error_code {
   DCHECK(engine_);
+  if (state_ & (SHUTDOWN_DONE | SHUTDOWN_IN_PROGRESS)) {
+    return {};
+  }
+
+  state_ |= SHUTDOWN_IN_PROGRESS;
   Engine::OpResult op_result = engine_->Shutdown();
   if (op_result) {
     // engine_ could send notification messages to the peer.
@@ -87,8 +95,19 @@ auto TlsSocket::Shutdown(int how) -> error_code {
   }
 
   // In any case we should also shutdown the underlying TCP socket without relying on the
-  // the peer.
-  return next_sock_->Shutdown(how);
+  // the peer. It could be that when we are in the middle of MaybeSendOutput, and
+  // the other fiber calls Close() on this socket. In this case next_sock_ will be closed
+  // by the time we reach this line, so we omit calling Shutdown().
+  // It's not the best behavior, but it's also not disastrous either, because
+  // such interaction happens only during the server shutdown.
+  error_code res;
+  if (next_sock_->IsOpen()) {
+    res = next_sock_->Shutdown(how);
+  }
+  state_ |= SHUTDOWN_DONE;
+  state_ &= ~SHUTDOWN_IN_PROGRESS;
+
+  return res;
 }
 
 auto TlsSocket::Accept() -> AcceptResult {
@@ -324,7 +343,7 @@ auto TlsSocket::MaybeSendOutput() -> error_code {
 
     // Safe to clear here since the code below is atomic fiber-wise.
     state_ &= ~WRITE_IN_PROGRESS;
-
+    DCHECK(engine_);
     if (!write_result) {
       return write_result.error();
     }

--- a/util/tls/tls_socket.h
+++ b/util/tls/tls_socket.h
@@ -21,7 +21,6 @@ class TlsSocket : public FiberSocketBase {
   using Buffer = Engine::Buffer;
   using FiberSocketBase::endpoint_type;
 
-
   TlsSocket(std::unique_ptr<FiberSocketBase> next);
 
   // Takes ownership of next
@@ -57,7 +56,7 @@ class TlsSocket : public FiberSocketBase {
   endpoint_type LocalEndpoint() const override;
   endpoint_type RemoteEndpoint() const override;
 
-  void RegisterOnErrorCb(std::function<void (uint32_t)> cb) override;
+  void RegisterOnErrorCb(std::function<void(uint32_t)> cb) override;
   void CancelOnErrorCb() override;
 
   bool IsUDS() const override;
@@ -90,7 +89,12 @@ class TlsSocket : public FiberSocketBase {
   std::unique_ptr<FiberSocketBase> next_sock_;
   std::unique_ptr<Engine> engine_;
 
-  enum { WRITE_IN_PROGRESS = 1, READ_IN_PROGRESS = 2};
+  enum {
+    WRITE_IN_PROGRESS = 1,
+    READ_IN_PROGRESS = 2,
+    SHUTDOWN_IN_PROGRESS = 4,
+    SHUTDOWN_DONE = 8
+  };
   uint8_t state_{0};
 };
 


### PR DESCRIPTION
The root cause was due to a socket being closed and destroyed inside ListenerInterface::RunSingleConnection
and in parallel the listener was performing the shutdown sequence inside ListenerInterface::RunAcceptLoop().

In fact we had a comment saying it's working because socket.Shutdown did not preempt.
In one of my recent PRs I implemented the logic where TlsSocket informs the peer about the shutdown
which made the call preemptible. As a result the whole management code around this became unsafe.

1. I introduced an intrusive refcnt so that a connection would not be destroyed inside RunSingleConnection
   when RunAcceptLoop still uses it.
2. Changed the iteration loop in the latter tu support preemption.
3. Fixed the Shutdown code to support the case where the tcp socket is closed in the middle of shutdown.
4. Found unrelated migration bug that where we failed to Unlink a connection because the listener was destroyed.
   Now we try to unlink only if the connection indeed is linked inside a connection list.