### PR TITLE
feat: allow a listener to stop accepting new connections

### DIFF
--- a/util/fibers/accept_server.cc
+++ b/util/fibers/accept_server.cc
@@ -43,7 +43,7 @@ void AcceptServer::Run() {
     for (auto& lw : list_interface_) {
       ProactorBase* proactor = lw->socket()->proactor();
 
-      // We must capture ref_bc_ by value because once it is decremented AcceptServer
+      // We must capture ref_bc_ by value because once it is decremented, AcceptServer
       // instance can be destroyed before Dec returnes.
       proactor->Dispatch([li = lw.get(), bc = ref_bc_]() mutable {
         li->RunAcceptLoop();

--- a/util/fibers/uring_socket.cc
+++ b/util/fibers/uring_socket.cc
@@ -79,8 +79,7 @@ auto UringSocket::Close() -> error_code {
   error_code ec;
   if (fd_ < 0)
     return ec;
-
-  DCHECK(proactor()->InMyThread());
+  DCHECK(DCHECK_NOTNULL(proactor())->InMyThread());
   DVSOCK(1) << "Closing socket";
 
   int fd;

--- a/util/listener_interface.h
+++ b/util/listener_interface.h
@@ -84,6 +84,16 @@ class ListenerInterface {
     conn_fiber_stack_size_ = size;
   }
 
+  // Stops accepting the new sockets. Any incomming connection is immediately closed.
+  // The listener continues runnning.
+  void pause_accepting() {
+    pause_accepting_ = true;
+  }
+
+  void resume_accepting() {
+    pause_accepting_ = false;
+  }
+
  protected:
   ProactorPool* pool() {
     return pool_;
@@ -124,6 +134,8 @@ class ListenerInterface {
 
   ProactorPool* pool_ = nullptr;
   PMR_NS::memory_resource* mr_;
+  bool pause_accepting_ = false;
+
   friend class AcceptServer;
 };
 


### PR DESCRIPTION
There are two ways to stop accepting:
1. stop pulling a connection from the accept queue. This leads to a back pressure on a client side
2. Pull and immediately close. This usually leads to retries on the client side

This PR implements the second option, which seems like a bad idea, but in some cases is necessary. For example, when we failover to a differrent host, we want a client to retry until its DNS cache is updated with the new host ip and it reconnects to a differrent node. This mode essentially simulates the behavior of a closed port.