### PR TITLE
chore: add more logs around ProcessRemoteReady

### DIFF
--- a/util/fibers/detail/fiber_interface.h
+++ b/util/fibers/detail/fiber_interface.h
@@ -206,6 +206,8 @@ class FiberInterface {
     return stack_size_;
   }
 
+  uint64_t DEBUG_remote_epoch = 0;
+
  protected:
   static constexpr uint16_t kTerminatedBit = 0x1;
   static constexpr uint16_t kBusyBit = 0x2;

--- a/util/fibers/detail/scheduler.h
+++ b/util/fibers/detail/scheduler.h
@@ -132,6 +132,7 @@ class Scheduler {
   FI_Queue ready_queue_, terminate_queue_;
   SleepQueue sleep_queue_;
   base::MPSCIntrusiveQueue<FiberInterface> remote_ready_queue_;
+  std::atomic_uint64_t remote_epoch_{0};
 
   // A list of all fibers in the thread.
   FI_List fibers_;

--- a/util/fibers/synchronization.h
+++ b/util/fibers/synchronization.h
@@ -8,7 +8,7 @@
 #include <condition_variable>  // for cv_status
 
 #include "base/spinlock.h"
-#include "util/fibers/detail/scheduler.h"
+#include "util/fibers/detail/fiber_interface.h"
 
 namespace util {
 namespace fb2 {


### PR DESCRIPTION
In order to progress around ProcessRemoteReady added epoch counter to show how far events are between pushing the fiber to the queue and trying to pull it.