### PR TITLE
chore: partial support of absl::log library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ option (HELIO_USE_SANITIZER "Use asan and usan sanitizers" OFF)
 option (BUILD_DOCS "Generate documentation " ON)
 option (BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option (USE_MOLD "whether to use mold linker" OFF)
+option (LEGACY_GLOG "whether to use legacy glog library" ON)
 set    (HELIO_MIMALLOC_OPTS "" CACHE STRING "additional mimalloc compile options")
 set    (HELIO_MIMALLOC_LIBNAME "libmimalloc.a" CACHE STRING "name of mimalloc library")
 

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -1,9 +1,16 @@
 add_library(base hash.cc histogram.cc init.cc logging.cc proc_util.cc
     pthread_utils.cc varz_node.cc cuckoo_map.cc io_buf.cc segment_pool.cc)
 
-# atomic is not present on Fedora. I suspect it's not needed on ubuntu as well
-# removing it for now.
-cxx_link(base glog::glog absl::flags_parse
+if (LEGACY_GLOG) 
+  set(LOG_LIBS glog::glog)
+else()
+
+  target_compile_definitions(base PUBLIC -DUSE_ABSL_LOG=1)
+  set(LOG_LIBS absl::check absl::log -Wl,--whole-archive absl::log_flags
+      absl::log_initialize)
+endif()
+
+cxx_link(base ${LOG_LIBS} absl::flags_parse 
     absl::strings absl::symbolize absl::time absl::failure_signal_handler TRDP::xxhash)
 
 # Define default gtest_main for tests.

--- a/base/init.cc
+++ b/base/init.cc
@@ -4,6 +4,10 @@
 
 #include "base/init.h"
 
+#ifdef USE_ABSL_LOG
+#include <absl/log/initialize.h>
+#endif
+
 #include <atomic>
 #include <exception>
 
@@ -57,9 +61,13 @@ MainInitGuard::MainInitGuard(int* argc, char*** argv, uint32_t flags) {
     return;
 
   absl::ParseCommandLine(*argc, *argv);
+#ifdef USE_ABSL_LOG
+  absl::InitializeLog();
+#else
   if (!google::IsGoogleLoggingInitialized()) {
     google::InitGoogleLogging((*argv)[0]);
   }
+#endif
   absl::InitializeSymbolizer((*argv)[0]);
   absl::FailureSignalHandlerOptions options;
   absl::InstallFailureSignalHandler(options);
@@ -96,5 +104,7 @@ MainInitGuard::~MainInitGuard() {
     return;
 
   __internal__::ModuleInitializer::RunFtors(false);
+#ifndef USE_ABSL_LOG
   google::ShutdownGoogleLogging();
+#endif
 }

--- a/base/logging.cc
+++ b/base/logging.cc
@@ -70,6 +70,8 @@ string MyUserName() {
   return str ? str : string("unknown-user");
 }
 
+#if USE_ABSL_LOG
+#else
 void ConsoleLogSink::send(google::LogSeverity severity, const char* full_filename,
                           const char* base_filename, int line, const struct ::tm* tm_time,
                           const char* message, size_t message_len) {
@@ -81,6 +83,7 @@ ConsoleLogSink* ConsoleLogSink::instance() {
   static ConsoleLogSink sink;
   return &sink;
 }
+#endif
 
 const char* kProgramName = "";
 

--- a/base/logging.h
+++ b/base/logging.h
@@ -4,7 +4,49 @@
 
 #pragma once
 
+#ifdef USE_ABSL_LOG
+#include <absl/log/absl_log.h>
+#include <absl/log/absl_check.h>
+#include <absl/log/globals.h>
+#include <absl/log/vlog_is_on.h>
+#include <absl/log/log_sink_registry.h>
+
+#define CHECK ABSL_CHECK
+#define CHECK_GT ABSL_CHECK_GT
+#define CHECK_LT ABSL_CHECK_LT
+#define CHECK_EQ ABSL_CHECK_EQ
+#define CHECK_NE ABSL_CHECK_NE
+#define CHECK_GE ABSL_CHECK_GE
+#define CHECK_LE ABSL_CHECK_LE
+
+#define DCHECK ABSL_DCHECK
+#define DCHECK_GT ABSL_DCHECK_GT
+#define DCHECK_LT ABSL_DCHECK_LT
+#define DCHECK_EQ ABSL_DCHECK_EQ
+#define DCHECK_NE ABSL_DCHECK_NE
+#define DCHECK_GE ABSL_DCHECK_GE
+#define DCHECK_LE ABSL_DCHECK_LE
+
+#define DVLOG ABSL_DVLOG
+#define VLOG ABSL_VLOG
+#define LOG ABSL_LOG
+#define LOG_IF ABSL_LOG_IF
+#define LOG_FIRST_N ABSL_LOG_FIRST_N
+#define VLOG_IF(verboselevel, condition) \
+  ABSL_LOG_IF(INFO, (condition) && ABSL_VLOG_IS_ON(verboselevel))
+
+
+template <typename T> T* CHECK_NOTNULL(T* t) {
+  CHECK(t);
+  return t;
+}
+
+#else
 #include <glog/logging.h>
+
+#define CONSOLE_INFO LOG_TO_SINK(base::ConsoleLogSink::instance(), INFO)
+
+#endif
 
 #include <string>
 
@@ -15,6 +57,26 @@ std::string ProgramBaseName();
 
 std::string MyUserName();
 
+#ifdef USE_ABSL_LOG
+
+inline void FlushLogs() {
+  absl::FlushLogSinks();
+}
+
+inline int SetVLogLevel(std::string_view module_pattern, int log_level) {
+  return absl::SetVLogLevel(module_pattern, log_level);
+}
+
+#else
+
+inline void FlushLogs() {
+  google::FlushLogFiles(google::INFO);
+}
+
+inline int SetVLogLevel(std::string_view module_pattern, int log_level) {
+  return google::SetVLOGLevel(module_pattern.data(), log_level);
+}
+
 class ConsoleLogSink : public google::LogSink {
  public:
   virtual void send(google::LogSeverity severity, const char* full_filename,
@@ -23,9 +85,7 @@ class ConsoleLogSink : public google::LogSink {
 
   static ConsoleLogSink* instance();
 };
-
+#endif
 extern const char* kProgramName;
 
 }  // namespace base
-
-#define CONSOLE_INFO LOG_TO_SINK(base::ConsoleLogSink::instance(), INFO)

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -7,6 +7,8 @@ if(POLICY CMP0144)
   cmake_policy(SET CMP0144 NEW) # find_package() uses upper-case <PACKAGENAME>_ROOT variables
 endif()
 
+cmake_policy (SET CMP0079 NEW)
+
 set(THIRD_PARTY_DIR "${CMAKE_CURRENT_BINARY_DIR}/third_party")
 
 SET_DIRECTORY_PROPERTIES(PROPERTIES EP_PREFIX ${THIRD_PARTY_DIR})
@@ -203,41 +205,44 @@ if(NOT abseil_cpp_POPULATED)
   set(CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE_OLD})
 endif()
 
-set(FETCHCONTENT_UPDATES_DISCONNECTED_GLOG ON CACHE BOOL "")
+if (LEGACY_GLOG)
+  set(FETCHCONTENT_UPDATES_DISCONNECTED_GLOG ON CACHE BOOL "")
 
-FetchContent_Declare(
-  glog
-  GIT_REPOSITORY https://github.com/romange/glog
-  GIT_TAG Absl
+  FetchContent_Declare(
+    glog
+    GIT_REPOSITORY https://github.com/romange/glog
+    GIT_TAG Absl
 
-  GIT_PROGRESS    TRUE
-  GIT_SHALLOW     TRUE
-)
+    GIT_PROGRESS    TRUE
+    GIT_SHALLOW     TRUE
+  )
 
-FetchContent_GetProperties(glog)
-if (NOT glog_POPULATED)
-    FetchContent_Populate(glog)
+  FetchContent_GetProperties(glog)
+  if (NOT glog_POPULATED)
+      FetchContent_Populate(glog)
 
-  # There are bugs with libunwind on aarch64
-  # Also there is something fishy with pthread_rw_lock on aarch64 - glog sproadically fails
-  # inside pthreads code.
-  if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
-    set(WITH_UNWIND OFF  CACHE BOOL "")
-    set(HAVE_RWLOCK OFF  CACHE BOOL "")
+    # There are bugs with libunwind on aarch64
+    # Also there is something fishy with pthread_rw_lock on aarch64 - glog sproadically fails
+    # inside pthreads code.
+    if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
+      set(WITH_UNWIND OFF  CACHE BOOL "")
+      set(HAVE_RWLOCK OFF  CACHE BOOL "")
+    endif()
+
+      set(WITH_GTEST OFF CACHE BOOL "")
+      set(BUILD_TESTING OFF CACHE BOOL "")
+
+      set(HAVE_LIB_GFLAGS OFF CACHE BOOL "")
+      set(WITH_GFLAGS OFF CACHE BOOL "")
+      set(WITH_ABSL ON  BOOL "")
+      add_subdirectory(${glog_SOURCE_DIR} ${glog_BINARY_DIR})
+
+      set_property(TARGET glog APPEND PROPERTY
+                  INCLUDE_DIRECTORIES $<TARGET_PROPERTY:absl::flags,INTERFACE_INCLUDE_DIRECTORIES>)
   endif()
 
-    set(WITH_GTEST OFF CACHE BOOL "")
-    set(BUILD_TESTING OFF CACHE BOOL "")
-
-    set(HAVE_LIB_GFLAGS OFF CACHE BOOL "")
-    set(WITH_GFLAGS OFF CACHE BOOL "")
-    set(WITH_ABSL ON  BOOL "")
-    add_subdirectory(${glog_SOURCE_DIR} ${glog_BINARY_DIR})
-
-    set_property(TARGET glog APPEND PROPERTY
-                 INCLUDE_DIRECTORIES $<TARGET_PROPERTY:absl::flags,INTERFACE_INCLUDE_DIRECTORIES>)
+  target_link_libraries(glog PRIVATE $<BUILD_INTERFACE:absl::flags>)
 endif()
-
 
 # 1.71 comes with ubuntu 20.04 so that's what we require.
 find_package(Boost 1.71.0 REQUIRED COMPONENTS context system)
@@ -376,8 +381,6 @@ if (WITH_UNWIND AND (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64"))
   set_target_properties(TRDP::gperf PROPERTIES IMPORTED_LINK_INTERFACE_LIBRARIES unwind)
 endif()
 
-cmake_policy (SET CMP0079 NEW)
-target_link_libraries(glog PRIVATE $<BUILD_INTERFACE:absl::flags>)
 target_compile_definitions(TRDP::pugixml INTERFACE PUGIXML_NO_EXCEPTIONS=1 PUGIXML_NO_XPATH=1)
 
 if (APPLE)

--- a/examples/echo_server.cc
+++ b/examples/echo_server.cc
@@ -392,7 +392,7 @@ void TLocalClient::Connect(tcp::endpoint ep) {
   for (auto& fb : fbs)
     fb.Join();
   LOG(INFO) << "TLocalClient::Connect-End";
-  google::FlushLogFiles(google::INFO);
+  base::FlushLogs();
 }
 
 size_t TLocalClient::Run() {

--- a/util/fibers/listener_interface.cc
+++ b/util/fibers/listener_interface.cc
@@ -418,7 +418,8 @@ uint32_t ListenerInterface::GetMaxClients() const {
 }
 
 void Connection::Shutdown() {
-  auto ec = CHECK_NOTNULL(socket_)->Shutdown(SHUT_RDWR);
+  CHECK(socket_);
+  auto ec = socket_->Shutdown(SHUT_RDWR);
   VLOG_IF(1, ec) << "Error during shutdown " << ec.message();
 
   OnShutdown();

--- a/util/fibers/uring_socket.cc
+++ b/util/fibers/uring_socket.cc
@@ -79,7 +79,8 @@ auto UringSocket::Close() -> error_code {
   error_code ec;
   if (fd_ < 0)
     return ec;
-  DCHECK(DCHECK_NOTNULL(proactor())->InMyThread());
+  DCHECK(proactor());
+  DCHECK(proactor()->InMyThread());
   DVSOCK(1) << "Closing socket";
 
   int fd;

--- a/util/http/http_handler.cc
+++ b/util/http/http_handler.cc
@@ -66,7 +66,7 @@ void HandleVModule(std::string_view str) {
     int32_t level = 0;
     if (sep != std::string_view::npos && absl::SimpleAtoi(p.substr(sep + 1), &level)) {
       string module_expr = string(p.substr(0, sep));
-      int prev = google::SetVLOGLevel(module_expr.c_str(), level);
+      int prev = base::SetVLogLevel(module_expr, level);
       LOG(INFO) << "Setting module " << module_expr << " to loglevel " << level
                 << ", prev: " << prev;
     }

--- a/util/http/profilez_handler.cc
+++ b/util/http/profilez_handler.cc
@@ -93,7 +93,7 @@ static void HandleCpuProfile(bool enable, StringResponse* response) {
   string url("filez?file=");
   url.append(profile_name);
   LOG(INFO) << "Redirecting to " << url;
-  google::FlushLogFiles(google::INFO);
+  base::FlushLogs();
 
   response->set(h2::field::location, url);
   response->result(h2::status::moved_permanently);


### PR DESCRIPTION
Keep the default with the old glog library. The absl log library is missing a LOT of features, like logging into files, file rotation etc. Basically it provides only the low-level api to serialize log messes into sink and a stderr sink. This is not enough for prod use. Still, this PR provides a common ground to use both libraries in neutral way. If I have bandwidth I will fill in the functionality inside helio to be able to get rid of old glog