### PR TITLE
fix visibility of LEGACY_GLOG in cmake/third_party

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ option (HELIO_USE_SANITIZER "Use asan and usan sanitizers" OFF)
 option (BUILD_DOCS "Generate documentation " ON)
 option (BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option (USE_MOLD "whether to use mold linker" OFF)
-option (LEGACY_GLOG "whether to use legacy glog library" ON)
 set    (HELIO_MIMALLOC_OPTS "" CACHE STRING "additional mimalloc compile options")
 set    (HELIO_MIMALLOC_LIBNAME "libmimalloc.a" CACHE STRING "name of mimalloc library")
 

--- a/base/logging.cc
+++ b/base/logging.cc
@@ -28,7 +28,7 @@ string ProgramAbsoluteFileName() {
 #ifdef __APPLE__
   uint32_t sz = res.size();
 
-  if (_NSGetExecutablePath( &res.front(), &sz) != 0) {
+  if (_NSGetExecutablePath(&res.front(), &sz) != 0) {
     // Buffer size is too small.
     return res;
   }
@@ -41,7 +41,7 @@ string ProgramAbsoluteFileName() {
     }
   }
 
-#else // not __APPLE__
+#else  // not __APPLE__
   ssize_t sz = readlink(kProcSelf, &res.front(), res.size());
   CHECK_GT(sz, 0);
   if (sz > kDeletedSuffixLen) {
@@ -70,8 +70,7 @@ string MyUserName() {
   return str ? str : string("unknown-user");
 }
 
-#if USE_ABSL_LOG
-#else
+#ifndef USE_ABSL_LOG
 void ConsoleLogSink::send(google::LogSeverity severity, const char* full_filename,
                           const char* base_filename, int line, const struct ::tm* tm_time,
                           const char* message, size_t message_len) {

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -17,6 +17,7 @@ Include(ExternalProject)
 Include(FetchContent)
 
 option (WITH_UNWIND "Enable libunwind support" ON)
+option (LEGACY_GLOG "whether to use legacy glog library" ON)
 
 set(THIRD_PARTY_LIB_DIR "${THIRD_PARTY_DIR}/libs")
 file(MAKE_DIRECTORY ${THIRD_PARTY_LIB_DIR})
@@ -222,7 +223,7 @@ if (LEGACY_GLOG)
       FetchContent_Populate(glog)
 
     # There are bugs with libunwind on aarch64
-    # Also there is something fishy with pthread_rw_lock on aarch64 - glog sproadically fails
+    # Also there is something fishy with pthread_rw_lock on aarch64 - glog sporadically fails
     # inside pthreads code.
     if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
       set(WITH_UNWIND OFF  CACHE BOOL "")


### PR DESCRIPTION
The problem was the visibility of option `LEGACY_GLOG` which was not available when `included` the thirdparty cmake.