### PR TITLE
fix: a better fix to sleeping fibers starvation

### DIFF
--- a/util/accept_server_test.cc
+++ b/util/accept_server_test.cc
@@ -276,8 +276,11 @@ TEST_F(AcceptServerTest, Shutdown) {
   constexpr auto kHupMask = POLLHUP;
 #endif
 
-    vector<unique_ptr<FiberSocketBase>> socks;
     constexpr unsigned kNumSocks = 2000;
+
+    vector<unique_ptr<FiberSocketBase>> socks;
+    vector<bool> error_notification(kNumSocks, false);
+
     unsigned called = 0;
     fb2::CondVarAny cond;
 
@@ -286,9 +289,14 @@ TEST_F(AcceptServerTest, Shutdown) {
       error_code ec = socks.back()->Connect(ep_);
       EXPECT_FALSE(ec);
 
-      socks.back()->RegisterOnErrorCb([&](int err) {
+      socks.back()->RegisterOnErrorCb([&, i](int err) {
         EXPECT_EQ(err, kHupMask);
-        ++called;
+
+        // MacOs can send multiple notifications per socket.
+        if (!error_notification[i]) {
+          ++called;
+          error_notification[i] = true;
+        }
         cond.notify_one();
       });
     }
@@ -297,7 +305,7 @@ TEST_F(AcceptServerTest, Shutdown) {
       std::ignore = socks[i]->Shutdown(SHUT_RDWR);
     }
     fb2::NoOpLock lock;
-    ASSERT_TRUE(cond.wait_for(lock, 1s, [&] {return called == kNumSocks;}));
+    ASSERT_TRUE(cond.wait_for(lock, 1s, [&] {return called == kNumSocks;})) << called;
 
     // Please note that in perfect conditions like with this unit test,
     // we will get ErrorCb trigerred for every socket because both the server and the client

--- a/util/fibers/detail/wait_queue.h
+++ b/util/fibers/detail/wait_queue.h
@@ -19,6 +19,13 @@ class Waiter {
   }
 
  public:
+  // For some boost versions/distributions, the default move c'tor does not work well,
+  // so we implement it explicitly.
+  Waiter(Waiter&& o) : cntx_(o.cntx_) {
+    o.wait_hook.swap_nodes(wait_hook);
+    o.cntx_ = nullptr;
+  }
+
   using ListHookType =
       boost::intrusive::slist_member_hook<boost::intrusive::link_mode<boost::intrusive::safe_link>>;
 

--- a/util/fibers/proactor_base.h
+++ b/util/fibers/proactor_base.h
@@ -240,6 +240,9 @@ class ProactorBase {
     return absl::GetCurrentTimeNanos();
   }
 
+  // Returns true if we have not processed sleep fibers for too long.
+  bool HasSleepFibersStarved() const;
+
   // Returns number of sleeping fibers being activated.
   unsigned ProcessSleepFibers(detail::Scheduler* scheduler);
 
@@ -250,8 +253,8 @@ class ProactorBase {
   bool is_stopped_ = true;
 
   std::atomic_uint32_t tq_seq_{0};
-  std::atomic_uint32_t tq_full_ev_{0};   // task queue full events.
-  std::atomic_uint32_t tq_wakeup_ev_{0};  // task queue wakeup events.
+  std::atomic_uint32_t tq_full_ev_{0};            // task queue full events.
+  std::atomic_uint32_t tq_wakeup_ev_{0};          // task queue wakeup events.
   std::atomic_uint32_t tq_wakeup_skipped_ev_{0};  // task queue wakeup prevented events.
 
   Stats stats_;

--- a/util/fibers/synchronization.h
+++ b/util/fibers/synchronization.h
@@ -588,7 +588,7 @@ std::cv_status CondVarAny::wait_until(LockType& lt, std::chrono::steady_clock::t
   // lock back.
   lt.lock();
   std::cv_status status = PostWaitTimeout(std::move(waiter), timed_out, active);
-
+  assert(!waiter.IsLinked());
   return status;
 }
 


### PR DESCRIPTION
Before we used a counter which allowed inner loops to shortcut and rarely reach ProcessSleepFibers call in high I/O situations.

Now, we also call ProcessSleepFibers when we process I/O completions that provides a good balance between responsiveness and the maintenance cost of checking for starvation.

## Results:

Before I could observe delays reaching 2seconds between Heartbeat runs that where scheduled to run every 10ms (on highly loaded server in debug mode).

After: the delays have not crossed 40ms under the same conditions.