### PR TITLE
chore: add ability to print custom data during PrintAllFiberStackTraces

### DIFF
--- a/util/fibers/detail/fiber_interface.h
+++ b/util/fibers/detail/fiber_interface.h
@@ -206,6 +206,15 @@ class FiberInterface {
     return stack_size_;
   }
 
+  // Assigns a print callback that is called by Scheduler::PrintAllFiberStackTraces.
+  // Please note that there can be at most one callback at any time during the lifetime of fiber.
+  void SetPrintStacktraceCb(std::function<std::string()> cb) {
+    (void)cb;
+#ifndef NDEBUG
+    stacktrace_print_cb_ = std::move(cb);
+#endif
+  }
+
   uint64_t DEBUG_remote_epoch = 0;
 
  protected:
@@ -245,6 +254,9 @@ class FiberInterface {
   char name_[24];
   uint32_t stack_size_ = 0;
  private:
+#ifndef NDEBUG
+  std::function<std::string()> stacktrace_print_cb_;
+#endif
   // Handles all the stats and also updates the involved data structure before actually switching
   // the fiber context. Returns the active fiber before the context switch.
   FiberInterface* SwitchSetup();

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -454,8 +454,12 @@ void Scheduler::PrintAllFiberStackTraces() {
                            chrono::steady_clock::now().time_since_epoch().count());
     }
 
+    string print_cb_str;
+#ifndef NDEBUG
+    print_cb_str = fb->stacktrace_print_cb_ ? fb->stacktrace_print_cb_() : string{};
+#endif
     LOG(INFO) << "------------ Fiber " << fb->name_ << " (" << state << ") ------------\n"
-              << GetStacktrace();
+              << print_cb_str << GetStacktrace();
   };
 
   ExecuteOnAllFiberStacks(print_fn);

--- a/util/fibers/fibers.h
+++ b/util/fibers/fibers.h
@@ -170,6 +170,18 @@ inline std::string_view GetName() {
   return fb2::detail::FiberActive()->name();
 }
 
+class PrintLocalsCallback {
+public:
+  template<typename Fn>
+  PrintLocalsCallback(Fn&& fn) {
+    fb2::detail::FiberActive()->SetPrintStacktraceCb(std::forward<Fn>(fn));
+  }
+
+  ~PrintLocalsCallback() {
+    fb2::detail::FiberActive()->SetPrintStacktraceCb(nullptr);
+  }
+};
+
 };  // namespace ThisFiber
 
 class FiberAtomicGuard {

--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -875,6 +875,11 @@ TEST_P(ProactorTest, DumpFiberStacks) {
 
   Fiber fb = proactor()->LaunchFiber([&] {
     ThisFiber::SetName("migrated");
+    int i = 42;
+    ThisFiber::PrintLocalsCallback locals([&] {
+      return absl::StrCat("i=", i, "\n");
+    });
+
     proactor()->Migrate(pth.get());
     ThisFiber::SleepFor(30ms);
   });


### PR DESCRIPTION
This can be used to debug deadlock states when the state is kept within the fiber stack.