### PR TITLE
chore: thread safety annotations on synchronization primitives

### DIFF
--- a/base/spinlock.h
+++ b/base/spinlock.h
@@ -8,21 +8,21 @@
 
 namespace base {
 
-class SpinLock {
+class ABSL_LOCKABLE SpinLock {
  public:
   SpinLock() = default;
   SpinLock(const SpinLock&) = delete;
   SpinLock& operator=(const SpinLock&) = delete;
 
-  void lock() {
+  void lock() ABSL_EXCLUSIVE_LOCK_FUNCTION() {
     lock_.Lock();
   }
 
-  void unlock() {
+  void unlock() ABSL_UNLOCK_FUNCTION() {
     lock_.Unlock();
   }
 
-  bool try_lock() {
+  bool try_lock() ABSL_EXCLUSIVE_TRYLOCK_FUNCTION(true) {
     return lock_.TryLock();
   }
 


### PR DESCRIPTION
In order for our mutex classes to work with [clang's ThreadSafety analysis](https://clang.llvm.org/docs/ThreadSafetyAnalysis.html#thread-safety-analysis) (used by ABSL_GUARD_XXX functions) we need to properly annotate them. This PR adds the missing annotations.

 