### PR TITLE
chore: enable -Wthread-safety and add LockGuard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,10 @@ else()
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=undefined")
   endif()
 
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      set(CMAKE_CXX_FLAGS "-Wthread-safety ${CMAKE_CXX_FLAGS}")
+  endif()
+
   include(third_party)
   include(internal)
 endif()

--- a/util/fibers/synchronization.h
+++ b/util/fibers/synchronization.h
@@ -99,6 +99,21 @@ class EventCount {
 
 class CondVar;
 
+// Replacement of std::LockGuard that allows -Wthread-safety
+template <typename Mutex> class ABSL_SCOPED_LOCKABLE LockGuard {
+ public:
+  explicit LockGuard(Mutex& m) ABSL_EXCLUSIVE_LOCK_FUNCTION(m) : m_(m) {
+    m_.lock();
+  }
+
+  ~LockGuard() ABSL_UNLOCK_FUNCTION() {
+    m_.unlock();
+  }
+
+ private:
+  Mutex& m_;
+};
+
 class ABSL_LOCKABLE Mutex {
  private:
   friend class CondVar;


### PR DESCRIPTION
`std::lock_guard` and `std::unique_lock` do not work with `ABSL_GUARD_XXX` variants and for that we need our own wrappers. Furthermore, even if helio doesn't use those guards right now, they might be useful in the future so I add them here and enable `-Wthread-safety` for clang

* enable -Wthread-safety
* add LockGuard as replacement of std::LockGuard