### PR TITLE
chore: add SimpleChannel::NotifyProducer function

### DIFF
--- a/util/fibers/simple_channel.h
+++ b/util/fibers/simple_channel.h
@@ -81,6 +81,10 @@ template <typename T, typename Queue = folly::ProducerConsumerQueue<T>> class Si
     return q_.capacity();
   }
 
+  // Advanced control - tries to wake up the producer, blocked on a full queue.
+  void NotifyProducer() {
+    push_ec_.notify();
+  }
  private:
   Queue q_;
   unsigned throttled_pushes_ = 0;


### PR DESCRIPTION
Currently SimpleChannel wakes up producer only when the queue has been depleted. This can be suboptimal in some situations, specifically in Dragonfly, consumer can pop an element and block on writing it into disk, an meanwhile producer can not progress. This function provides more advanced control, allowing to wake up producer earlier