### PR TITLE
fix: data race for for Barrier::Wait()

### DIFF
--- a/util/fibers/synchronization.cc
+++ b/util/fibers/synchronization.cc
@@ -161,7 +161,6 @@ bool Barrier::Wait() {
   if (0 == --current_) {
     ++cycle_;
     current_ = initial_;
-    lk.unlock();  // no pessimization
     cond_.notify_all();
     return true;
   }

--- a/util/fibers/synchronization.h
+++ b/util/fibers/synchronization.h
@@ -155,11 +155,13 @@ class CondVarAny {
   CondVarAny(CondVarAny const&) = delete;
   CondVarAny& operator=(CondVarAny const&) = delete;
 
+  // in contrast to std::condition_variable::notify_one() isn't thread-safe and should be called under the mutex
   void notify_one() noexcept {
     if (!wait_queue_.empty())
       wait_queue_.NotifyOne(detail::FiberActive());
   }
 
+  // in contrast to std::condition_variable::notify_all() isn't thread-safe and should be called under the mutex
   void notify_all() noexcept {
     if (!wait_queue_.empty())
       wait_queue_.NotifyAll(detail::FiberActive());
@@ -207,10 +209,12 @@ class CondVar {
   CondVar(CondVar const&) = delete;
   CondVar& operator=(CondVar const&) = delete;
 
+  // in contrast to std::condition_variable::notify_one() isn't thread-safe and should be called under the mutex
   void notify_one() noexcept {
     cnd_.notify_one();
   }
 
+  // in contrast to std::condition_variable::notify_all() isn't thread-safe and should be called under the mutex
   void notify_all() noexcept {
     cnd_.notify_all();
   }


### PR DESCRIPTION
cond_.notify_all() accesses unprotected wait_queue, therefore it must be under lock.
The problem was found in https://github.com/dragonflydb/dragonfly/actions/runs/11343555702/job/31546353995?pr=3924#step:12:818