### PR TITLE
chore: improve signal handling code

### DIFF
--- a/util/fibers/accept_server.cc
+++ b/util/fibers/accept_server.cc
@@ -33,7 +33,7 @@ AcceptServer::AcceptServer(ProactorPool* pool, PMR_NS::memory_resource* mr, bool
 
 AcceptServer::~AcceptServer() {
   if (break_on_int_) {
-    ProactorBase::ClearSignal({SIGINT, SIGTERM});
+    ProactorBase::ClearSignal({SIGINT, SIGTERM}, true);
   }
   list_interface_.clear();
 }

--- a/util/fibers/proactor_base.h
+++ b/util/fibers/proactor_base.h
@@ -91,12 +91,12 @@ class ProactorBase {
     return tl_info_.owner;
   }
 
-  static void RegisterSignal(std::initializer_list<uint16_t> l, ProactorBase* proactor,
+  static void RegisterSignal(std::initializer_list<uint16_t> signals, ProactorBase* proactor,
                              std::function<void(int)> cb);
 
-  static void ClearSignal(std::initializer_list<uint16_t> l) {
-    RegisterSignal(l, nullptr, nullptr);
-  }
+  // Unregisters any callbacks assigned the the signals.
+  // If ignore is true, installs SIG_IGN handler for the signals, otherwise SIG_DFL.
+  static void ClearSignal(std::initializer_list<uint16_t> signals, bool install_ignore);
 
   // Returns an approximate (cached) time with nano-sec granularity.
   // The caller must run in the same thread as the proactor.
@@ -265,12 +265,12 @@ class ProactorBase {
   static uint64_t GetCPUCycleCount() {
 #if defined(__x86_64__)
     uint64_t low, high;
-    __asm__ volatile("rdtsc" : "=a"(low), "=d"(high));
-    return static_cast<int64_t>((high << 32) | low);
+  __asm__ volatile("rdtsc" : "=a"(low), "=d"(high));
+  return static_cast<int64_t>((high << 32) | low);
 #elif defined(__aarch64__)
-    int64_t tv;
-    asm volatile("mrs %0, cntvct_el0" : "=r"(tv));
-    return tv;
+  int64_t tv;
+  asm volatile("mrs %0, cntvct_el0" : "=r"(tv));
+  return tv;
 #else
     return absl::base_internal::CycleClock::Now();
 #endif


### PR DESCRIPTION
1. Relax ClearSignal function - now it can be called on unregistered signals (before it check-failed)
2. Now it is possible to install the ignore handler,
   which is what we really want to use when we clear the signal handlers via AcceptServer.
   Indeed, if accept server is shut down, the process will usually exit right after.
   There will be some clean up code but that's it. So we do not want to interrupt due sigterm/sigint signals because
   we are already in the process of shutting down anyway. Before this change - if we got the signal during the
   critical section after the accept server handlers were cleared, and default handlers were installed,
   the process would exit with -15 for SIGTERM and -2 for SIGINT just because it would catch these signals
   during the shutdown.