### PR TITLE
feat: add SendProvided call

### DIFF
--- a/util/fibers/uring_proactor.h
+++ b/util/fibers/uring_proactor.h
@@ -44,8 +44,6 @@ class UringProactor : public ProactorBase {
   // IoResult is the I/O result of the completion event.
   // uint32_t - epoll flags.
   // uint32_t - the user tag supplied during event submission. See GetSubmitEntry below.
-  // int64_t is the payload supplied during event submission. See GetSubmitEntry below.
-  // using CbType = std::function<void(IoResult, uint32_t)>;
   using CbType =
       fu2::function_base<true /*owns*/, false /*non-copyable*/, fu2::capacity_fixed<16, 8>,
                          false /* non-throwing*/, false /* strong exceptions guarantees*/,

--- a/util/fibers/uring_socket.h
+++ b/util/fibers/uring_socket.h
@@ -62,6 +62,9 @@ class UringSocket : public LinuxSocketBase {
   unsigned RecvProvided(unsigned buf_len, ProvidedBuffer* dest) final;
   void ReturnProvided(const ProvidedBuffer& pbuf) final;
 
+  // Sends provided buffers from the group. Not sure yet how to use this API.
+  void SendProvided(uint16_t buf_gid, io::AsyncProgressCb cb);
+
   void EnableRecvMultishot();
   void set_bufring_id(uint16_t id) {
     bufring_id_ = id;


### PR DESCRIPTION
Given its restrictive api, where we need to allocate a buffer group per socket, I doubt it will be useful any time soon. Also, it's not supported on 6.8.