### PR TITLE
fix: EpollSocket::WriteSome early return on EAGAIN

### DIFF
--- a/util/fibers/epoll_socket.cc
+++ b/util/fibers/epoll_socket.cc
@@ -4,6 +4,7 @@
 
 #include "util/fibers/epoll_socket.h"
 
+#include <errno.h>
 #include <netinet/in.h>
 
 #include "absl/cleanup/cleanup.h"
@@ -134,7 +135,6 @@ class EpollSocket::PendingReq {
 
   void Activate(error_code ec);
 };
-
 
 error_code EpollSocket::PendingReq::Suspend(uint32_t timeout) {
   bool timed_out = false;
@@ -352,7 +352,7 @@ auto EpollSocket::WriteSome(const iovec* ptr, uint32_t len) -> Result<size_t> {
 
     DCHECK_EQ(res, -1);
 
-    if (res != EAGAIN) {
+    if (errno != EAGAIN) {
       ec = from_errno();
       break;
     }

--- a/util/fibers/fiber_socket_test.cc
+++ b/util/fibers/fiber_socket_test.cc
@@ -167,12 +167,6 @@ TEST_P(FiberSocketTest, Basic) {
 }
 
 TEST_P(FiberSocketTest, Bug363) {
-  const bool use_epoll = GetParam() == "epoll";
-  // We test only epoll proactor
-  if (!use_epoll) {
-    return;
-  }
-
   unique_ptr<FiberSocketBase> sock(proactor_->CreateSocket());
   sock->set_timeout(3);
 
@@ -187,7 +181,7 @@ TEST_P(FiberSocketTest, Bug363) {
       uint8_t buf[1024 * 100] = {0};
       auto res = sock->WriteSome(io::Bytes(buf));
       if (!res) {
-        ASSERT_TRUE(res.error().value() != EAGAIN);
+        EXPECT_EQ(res.error().value(), ECANCELED);
       }
     }
 


### PR DESCRIPTION
`sendmsg` returns the bytes written and `-1` if it failed. For the later, we need to poll ERNO, and for `EAGAIN` we need to block and retry later when we get notified. What this means is that the calling fiber must block on EAGAIN when we call WriteSome. However this is not the case as we improperly check: `if (res != EAGAIN)` which can't be true because we are on the path of `sendmsg` that returned `< 0`. We should check `ERRNO` and not `res`.