### PR TITLE
feat(fibers): Add GetStackMargin method

### DIFF
--- a/util/fibers/detail/fiber_interface.cc
+++ b/util/fibers/detail/fiber_interface.cc
@@ -185,6 +185,10 @@ ctx::fiber_context FiberInterface::Terminate() {
   return scheduler_->Preempt();
 }
 
+size_t FiberInterface::GetStackMargin(const void* stack_address) const {
+  return static_cast<const uint8_t*>(stack_address) - stack_bottom_;
+}
+
 void FiberInterface::CheckStackMargin() {
   uint32_t check_margin = absl::GetFlag(FLAGS_fiber_safety_margin);
   if (check_margin == 0)

--- a/util/fibers/detail/fiber_interface.h
+++ b/util/fibers/detail/fiber_interface.h
@@ -59,7 +59,6 @@ using FI_SleepHook =
 
 class Scheduler;
 
-
 class FiberInterface {
   friend class Scheduler;
 
@@ -222,6 +221,8 @@ class FiberInterface {
 
   void CheckStackMargin();
 
+  size_t GetStackMargin(const void* stack_address) const;
+
  protected:
   static constexpr uint16_t kTerminatedBit = 0x1;
   static constexpr uint16_t kBusyBit = 0x2;
@@ -260,6 +261,7 @@ class FiberInterface {
   char name_[24];
   uint32_t stack_size_ = 0;
   uint8_t* stack_bottom_ = nullptr;
+
  private:
 #ifndef NDEBUG
   std::function<std::string()> stacktrace_print_cb_;

--- a/util/fibers/fibers.h
+++ b/util/fibers/fibers.h
@@ -175,14 +175,19 @@ inline std::string_view GetName() {
   return fb2::detail::FiberActive()->name();
 }
 
+/* Returns the margin between the provided stack address
+   and the bottom of the fiber's stack. */
+inline uint32_t GetStackMargin(const void* stack_address) {
+  return fb2::detail::FiberActive()->GetStackMargin(stack_address);
+}
+
 inline void CheckSafetyMargin() {
   fb2::detail::FiberActive()->CheckStackMargin();
 }
 
 class PrintLocalsCallback {
-public:
-  template<typename Fn>
-  PrintLocalsCallback(Fn&& fn) {
+ public:
+  template <typename Fn> PrintLocalsCallback(Fn&& fn) {
     fb2::detail::FiberActive()->SetPrintStacktraceCb(std::forward<Fn>(fn));
   }
 


### PR DESCRIPTION
During debugging, it is sometimes useful to check how much stack space is left before calling a method. To do this, we can use `GetStackMargin`.