### PR TITLE
fix: non constant expression in array size

### DIFF
--- a/util/fibers/proactor_pool.cc
+++ b/util/fibers/proactor_pool.cc
@@ -4,6 +4,8 @@
 
 #include "util/proactor_pool.h"
 
+#include <vector>
+
 #include "base/flags.h"
 #include "base/logging.h"
 #include "base/pthread_utils.h"
@@ -229,7 +231,7 @@ void ProactorPool::SetupProactors() {
 
   cpu_set_t online_cpus = OnlineCpus();
   unsigned num_online_cpus = CPU_COUNT(&online_cpus);
-  unsigned rel_to_abs_cpu[num_online_cpus];
+  std::vector<unsigned> rel_to_abs_cpu(num_online_cpus, 0);
   unsigned rel_cpu_index = 0, abs_cpu_index = 0;
 
   for (; abs_cpu_index < kTotalCpus; abs_cpu_index++) {


### PR DESCRIPTION
Expression of the form `int arr[SOME_NON_CONSTANT]` are illegal by the C++ standard yet compilers support it as an extension. Let's not use that and use `vector` instead. On the bonus side we also now don't have a warning.