### PR TITLE
chore: more debug assertions coverage

### DIFF
--- a/util/fibers/detail/fiber_interface.cc
+++ b/util/fibers/detail/fiber_interface.cc
@@ -46,12 +46,12 @@ class MainFiberImpl final : public FiberInterface {
 mutex g_scheduler_lock;
 
 TL_FiberInitializer* g_fiber_thread_list = nullptr;
-uint64_t g_tsc_cycles_per_ms = 0;
 
 }  // namespace
 
 PMR_NS::memory_resource* default_stack_resource = nullptr;
 size_t default_stack_size = 64 * 1024;
+uint64_t g_tsc_cycles_per_ms = 0;
 
 // Per thread initialization structure.
 struct TL_FiberInitializer {
@@ -368,10 +368,11 @@ void FiberInterface::ExecuteOnFiberStack(PrintFn fn) {
 }
 
 FiberInterface* FiberInterface::SwitchSetup() {
-  FiberInterface* prev = this;
-
   auto& fb_initializer = FbInitializer();
-  std::swap(fb_initializer.active, prev);
+
+  // switch the active fiber and set to_suspend to the previously active fiber.
+  FiberInterface* to_suspend = fb_initializer.active;
+  fb_initializer.active = this;
 
   uint64_t tsc = CycleClock::Now();
 
@@ -379,21 +380,23 @@ FiberInterface* FiberInterface::SwitchSetup() {
   // We ignore such cases (and they are very rare).
   if (tsc > cpu_tsc_) {
     ++fb_initializer.epoch;
-    DCHECK_GE(tsc, prev->cpu_tsc_);
+    DCHECK_GE(tsc, to_suspend->cpu_tsc_);
     fb_initializer.switch_delay_cycles += (tsc - cpu_tsc_);
 
-    // prev tsc points to the fiber that was active before this call.
-    uint64_t delta_cycles = tsc - prev->cpu_tsc_;
+    // to_suspend points to the fiber that is active and is going to be to_suspend.
+    uint64_t delta_cycles = tsc - to_suspend->cpu_tsc_;
     if (delta_cycles > g_tsc_cycles_per_ms) {
       fb_initializer.long_runtime_cnt++;
 
       // improve precision, instead of "delta_cycles / (g_tsc_cycles_per_ms / 1000)"
       fb_initializer.long_runtime_usec += (delta_cycles * 1000) / g_tsc_cycles_per_ms;
     }
+
+    to_suspend->cpu_tsc_ = tsc;  // mark when the fiber was suspended.
   }
 
   cpu_tsc_ = tsc;
-  return prev;
+  return to_suspend;
 }
 
 void FiberInterface::PrintAllFiberStackTraces() {

--- a/util/fibers/detail/fiber_interface.h
+++ b/util/fibers/detail/fiber_interface.h
@@ -256,7 +256,7 @@ class FiberInterface {
   // used for sleeping with a timeout. Specifies the time when this fiber should be woken up.
   std::chrono::steady_clock::time_point tp_;
 
-  // A tsc of when this fiber becames ready or becomes active (in cycles).
+  // A timestamp counter when this fiber became ready,active or got suspended (in cycles).
   uint64_t cpu_tsc_ = 0;
   char name_[24];
   uint32_t stack_size_ = 0;

--- a/util/fibers/uring_socket.cc
+++ b/util/fibers/uring_socket.cc
@@ -250,9 +250,8 @@ auto UringSocket::Connect(const endpoint_type& ep,
 }
 
 auto UringSocket::WriteSome(const iovec* ptr, uint32_t len) -> Result<size_t> {
-  CHECK(proactor());
-  CHECK_GT(len, 0U);
-  CHECK_GE(fd_, 0);
+  DCHECK_GT(len, 0U);
+  DCHECK_GE(fd_, 0);
 
   if (fd_ & IS_SHUTDOWN) {
     return Unexpected(errc::connection_aborted);
@@ -260,6 +259,8 @@ auto UringSocket::WriteSome(const iovec* ptr, uint32_t len) -> Result<size_t> {
 
   int fd = ShiftedFd();
   Proactor* p = GetProactor();
+  DCHECK(ProactorBase::me() == p);
+
   ssize_t res = 0;
   VSOCK(2) << "WriteSome [" << fd << "] " << len;
 
@@ -327,6 +328,8 @@ void UringSocket::AsyncWriteSome(const iovec* v, uint32_t len, io::AsyncProgress
 
   int fd = native_handle();
   Proactor* proactor = GetProactor();
+  DCHECK(ProactorBase::me() == proactor);
+
   auto mycb = [msg, cb = std::move(cb)](detail::FiberInterface*, Proactor::IoResult res,
                                         uint32_t flags, uint32_t) {
     delete msg;
@@ -357,6 +360,8 @@ void UringSocket::AsyncReadSome(const iovec* v, uint32_t len, io::AsyncProgressC
 
   int fd = ShiftedFd();
   Proactor* proactor = GetProactor();
+  DCHECK(ProactorBase::me() == proactor);
+
   auto mycb = [msg, cb = std::move(cb)](detail::FiberInterface*, Proactor::IoResult res,
                                         uint32_t flags, uint32_t) {
     delete msg;
@@ -375,8 +380,7 @@ void UringSocket::AsyncReadSome(const iovec* v, uint32_t len, io::AsyncProgressC
 }
 
 auto UringSocket::RecvMsg(const msghdr& msg, int flags) -> Result<size_t> {
-  CHECK(proactor());
-  CHECK_GE(fd_, 0);
+  DCHECK_GE(fd_, 0);
 
   if (fd_ & IS_SHUTDOWN) {
     return Unexpected(errc::connection_aborted);


### PR DESCRIPTION
Also, add a timestamp tracking when a fiber becomes suspended. This is handy when we print stacktraces.