### PR TITLE
chore: add debug printing for the Unlink bug

### DIFF
--- a/util/fibers/synchronization.cc
+++ b/util/fibers/synchronization.cc
@@ -5,6 +5,7 @@
 #include "util/fibers/synchronization.h"
 
 #include "base/logging.h"
+#include "util/fibers/stacktrace.h"
 
 namespace util {
 namespace fb2 {
@@ -118,6 +119,10 @@ std::cv_status CondVarAny::PostWaitTimeout(detail::Waiter waiter, bool timed_out
     CHECK(!active->IsScheduledRemotely());
   }
   return status;
+}
+
+void CondVarAny::PrintFailState() {
+  LOG(DFATAL) << "Failed to unlink waiter from the queue. This is a bug:\n" << GetStacktrace();
 }
 
 bool EmbeddedBlockingCounter::WaitUntil(const std::chrono::steady_clock::time_point tp) {

--- a/util/fibers/synchronization.h
+++ b/util/fibers/synchronization.h
@@ -144,7 +144,7 @@ class CondVarAny {
 
   std::cv_status PostWaitTimeout(detail::Waiter waiter, bool clean_remote,
                                  detail::FiberInterface* active);
-
+  void PrintFailState();
  public:
   CondVarAny() = default;
 
@@ -585,6 +585,11 @@ template <typename LockType> void CondVarAny::wait(LockType& lt) {
   // relock external again before returning
   try {
     lt.lock();
+    if (waiter.IsLinked()) {
+      wait_queue_.Unlink(&waiter);
+      PrintFailState();
+    }
+
   } catch (...) {
     std::terminate();
   }


### PR DESCRIPTION
If for some reasone a fiber was resumed not via wait_list_, we identify this and print the error message. We also attempt to do the self-healing fix by unlinking the waiter manually.