### PR TITLE
feat: introduce FiberPriority

### DIFF
--- a/util/accept_server_test.cc
+++ b/util/accept_server_test.cc
@@ -129,9 +129,9 @@ void AcceptServerTest::SetUp() {
 
   as_.reset(new AcceptServer{up});
   listener_ = new TestListener();
-  
+
   // Add appropriate listener based on the parameter
-  auto ec = UseIPv6() 
+  auto ec = UseIPv6()
       ? as_->AddListener("::1", kPort, listener_)  // IPv6
       : as_->AddListener("localhost", kPort, listener_);  // IPv4
   CHECK(!ec) << ec;
@@ -139,7 +139,7 @@ void AcceptServerTest::SetUp() {
 
   ProactorBase* pb = pp_->GetNextProactor();
   client_sock_.reset(pb->CreateSocket());
-  
+
   // Use IPv4 or IPv6 address based on the parameter
   boost::asio::ip::address address;
   if (UseIPv6()) {
@@ -165,7 +165,7 @@ void AcceptServerTest::SetUp() {
       pp_->AwaitFiberOnAll([&m](unsigned index, ProactorBase* base) {
         std::unique_lock lk(m);
         LOG(ERROR) << "Proactor ------------------------" << index << " ---------------:\n";
-        fb2::detail::FiberInterface::PrintAllFiberStackTraces();
+        fb2::PrintFiberStackTracesInThread();
         LOG(ERROR) << "Proactor ------------------------" << index << " end---------------\n";
       });
       LOG(FATAL) << "Deadlock detected!!!!";

--- a/util/fibers/detail/fiber_interface.cc
+++ b/util/fibers/detail/fiber_interface.cc
@@ -27,11 +27,13 @@ struct TL_FiberInitializer;
 
 namespace {
 
+[[maybe_unused]] size_t kSzFiberInterface = sizeof(FiberInterface);
+
 // Serves as a stub Fiber since it does not allocate any stack.
 // It's used as a main fiber of the thread.
 class MainFiberImpl final : public FiberInterface {
  public:
-  MainFiberImpl() noexcept : FiberInterface{MAIN, 1, "main"} {
+  MainFiberImpl() noexcept : FiberInterface{MAIN, FiberPriority::NORMAL, 1, "main"} {
   }
 
   ~MainFiberImpl() {
@@ -128,8 +130,8 @@ FiberInterface* FiberActive() noexcept {
   return FbInitializer().active;
 }
 
-FiberInterface::FiberInterface(Type type, uint32_t cnt, string_view nm)
-    : use_count_(cnt), type_(type) {
+FiberInterface::FiberInterface(Type type, FiberPriority prio, uint32_t cnt, string_view nm)
+    : use_count_(cnt), type_(type), prio_(prio) {
   remote_next_.store((FiberInterface*)kRemoteFree, memory_order_relaxed);
   size_t len = std::min(nm.size(), sizeof(name_) - 1);
   name_[len] = 0;
@@ -457,6 +459,10 @@ size_t WorkerFibersStackSize() {
 
 size_t WorkerFibersCount() {
   return detail::FbInitializer().sched->num_worker_fibers();
+}
+
+void PrintFiberStackTracesInThread() {
+  detail::PrintAllFiberStackTraces();
 }
 
 }  // namespace fb2

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -65,11 +65,11 @@ DispatcherImpl* MakeDispatcher(Scheduler* sched) {
 }
 
 // DispatcherImpl implementation.
-DispatcherImpl::DispatcherImpl(ctx::preallocated const& palloc, ctx::fixedsize_stack&& salloc,
+DispatcherImpl::DispatcherImpl(const ctx::preallocated& palloc, ctx::fixedsize_stack&& salloc,
                                detail::Scheduler* sched) noexcept
-    : FiberInterface{DISPATCH, 0, "_dispatch"} {
+    : FiberInterface{DISPATCH, FiberPriority::NORMAL, 0, "_dispatch"} {
   stack_size_ = palloc.sctx.size;
-  entry_ = ctx::fiber(std::allocator_arg, palloc, salloc,
+  entry_ = ctx::fiber(std::allocator_arg, palloc, std::move(salloc),
                       [this](ctx::fiber&& caller) { return Run(std::move(caller)); });
   scheduler_ = sched;
 #if defined(BOOST_USE_UCONTEXT)

--- a/util/tls/tls_socket_test.cc
+++ b/util/tls/tls_socket_test.cc
@@ -136,7 +136,7 @@ void TlsSocketTest::SetUp() {
     VLOG(1) << "Accepted connection " << sock->native_handle();
 
     sock->SetProactor(proactor_.get());
-    sock->RegisterOnErrorCb([this](uint32_t mask) {
+    sock->RegisterOnErrorCb([](uint32_t mask) {
       LOG(ERROR) << "Error mask: " << mask;
     });
     server_socket_ = std::make_unique<tls::TlsSocket>(sock);


### PR DESCRIPTION
Also, perform some clean-up in the code i touched. FiberPriority is not used yet, it is only stored in FiberInterface. The only functional change is that it fibers use boost fixedsize_stack, we now pass the stack size through the Opts struct, which is 64KB, while default boost fixedsize_stack size was 128KB, hence the change in fibers_test.cc.

First step for #399 