### PR TITLE
chore: refactor scheduling code

### DIFF
--- a/util/fibers/detail/fiber_interface.cc
+++ b/util/fibers/detail/fiber_interface.cc
@@ -268,11 +268,6 @@ void FiberInterface::Join() {
   DCHECK(!waiter.IsLinked());
 }
 
-void FiberInterface::Yield() {
-  scheduler_->AddReady(this);
-  scheduler_->Preempt();
-}
-
 void FiberInterface::ActivateOther(FiberInterface* other) {
   DCHECK(other->scheduler_);
 

--- a/util/fibers/detail/fiber_interface_impl.h
+++ b/util/fibers/detail/fiber_interface_impl.h
@@ -19,6 +19,10 @@ inline void FiberInterface::Suspend() {
   assert(!IsScheduledRemotely());
 }
 
+inline void FiberInterface::Yield() {
+  scheduler_->Yield(this);
+}
+
 }  // namespace detail
 }  // namespace fb2
 }  // namespace util

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -11,6 +11,7 @@
 
 #include "base/logging.h"
 #include "util/fibers/detail/utils.h"
+#include "util/fibers/proactor_base.h"
 #include "util/fibers/stacktrace.h"
 
 namespace util {
@@ -199,6 +200,12 @@ Scheduler::~Scheduler() {
   DestroyTerminated();
 }
 
+void Scheduler::Yield(FiberInterface* me) {
+  AddReady(me);
+  was_yield_ = true;
+  Preempt();
+}
+
 ctx::fiber_context Scheduler::Preempt() {
   if (FiberActive() == dispatch_cntx_.get()) {
     LOG(DFATAL) << "Should not preempt dispatcher: " << GetStacktrace();
@@ -210,7 +217,8 @@ ctx::fiber_context Scheduler::Preempt() {
     if (now != last_ts) {  //   once a second at most.
       last_ts = now;
       LOG(DFATAL) << "Preempting inside of atomic section, fiber: " << FiberActive()->name()
-                << ", stacktrace:\n" << GetStacktrace();
+                  << ", stacktrace:\n"
+                  << GetStacktrace();
     }
   }
 
@@ -482,6 +490,24 @@ void Scheduler::PrintAllFiberStackTraces() {
   };
 
   ExecuteOnAllFiberStacks(print_fn);
+}
+
+bool Scheduler::RunWorkerFibersStepImpl() {
+  DCHECK(!ready_queue_.empty());
+
+  FiberInterface* fi = PopReady();
+  DCHECK(!fi->list_hook.is_linked());
+  DCHECK(!fi->sleep_hook.is_linked());
+  AddReady(dispatch_cntx_.get());
+
+  DVLOG(2) << "Switching to " << fi->name();
+  ProactorBase::UpdateMonotonicTime();
+  fi->SwitchTo();
+
+  was_yield_ = false;
+
+  // We are back to the dispatcher, return true if there are no ready fibers.
+  return !HasReady();
 }
 
 }  // namespace detail

--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -571,7 +571,7 @@ TEST_P(ProactorTest, AsyncCall) {
   EXPECT_EQ(std::cv_status::no_timeout, ec.await_until([&] { return signal; }, next));
 }
 
-TEST_P(ProactorTest, Await) {
+TEST_P(ProactorTest, AwaitBrief) {
   thread_local int val = 5;
 
   proactor()->AwaitBrief([] { val = 15; });
@@ -613,7 +613,7 @@ TEST_P(ProactorTest, Sleep) {
     LOG(INFO) << "Before Sleep";
     ThisFiber::SleepFor(20ms);
     LOG(INFO) << "After Sleep";
-  });
+  }, Fiber::Opts{.name = "test_sleep"});
 }
 
 TEST_P(ProactorTest, LocalCond) {


### PR DESCRIPTION
1. Move scheduling step into Scheduler::RunWorkerFibersStep from Epoll/Uring proactors.
2. Extend ProactorBase::Await to support Fiber::Opts