### PR TITLE
chore: refactor azure/gcp code

### DIFF
--- a/util/cloud/azure/azure.cc
+++ b/util/cloud/azure/azure.cc
@@ -117,7 +117,7 @@ error_code Credentials::Init(unsigned) {
   return {};
 }
 
-string Credentials::GetEndpoint() const {
+string Credentials::ServiceEndpoint() const {
   return absl::StrCat(account_name_, ".blob.core.windows.net");
 }
 

--- a/util/cloud/azure/creds_provider.h
+++ b/util/cloud/azure/creds_provider.h
@@ -22,7 +22,7 @@ class Credentials : public CredentialsProvider {
     return account_key_;
   }
 
-  std::string GetEndpoint() const;
+  std::string ServiceEndpoint() const;
 
   void Sign(detail::HttpRequestBase* req) const final;
   std::error_code RefreshToken() final;

--- a/util/cloud/azure/storage.h
+++ b/util/cloud/azure/storage.h
@@ -19,7 +19,7 @@ class Credentials;
 
 class Storage {
  public:
-  Storage(Credentials* creds) : creds_(creds) {
+  explicit Storage(CredentialsProvider* creds) : creds_(creds) {
   }
 
   using ContainerItem = std::string_view;
@@ -30,18 +30,17 @@ class Storage {
                        unsigned max_results, std::function<void(const ListItem&)> cb);
 
  private:
-  Credentials* creds_;
+  CredentialsProvider* creds_;
 };
 
 struct ReadFileOptions {
-  Credentials* creds_provider = nullptr;
+  CredentialsProvider* creds_provider = nullptr;
   SSL_CTX* ssl_cntx;
 };
 
 using WriteFileOptions = ReadFileOptions;
 
-io::Result<io::ReadonlyFile*> OpenReadFile(const std::string& container,
-                                           const std::string& key,
+io::Result<io::ReadonlyFile*> OpenReadFile(const std::string& container, const std::string& key,
                                            const ReadFileOptions& opts);
 
 io::Result<io::WriteFile*> OpenWriteFile(const std::string& container, const std::string& key,

--- a/util/cloud/gcp/gcp_creds_provider.h
+++ b/util/cloud/gcp/gcp_creds_provider.h
@@ -30,6 +30,8 @@ class GCPCredsProvider : public CredentialsProvider {
   // TODO: to use expire_time_ to skip the refresh if expire time is far away.
   std::error_code RefreshToken();
 
+  std::string ServiceEndpoint() const final;
+
   const std::string& project_id() const {
     return project_id_;
   }

--- a/util/cloud/gcp/gcp_utils.cc
+++ b/util/cloud/gcp/gcp_utils.cc
@@ -5,7 +5,6 @@
 
 #include <absl/strings/str_cat.h>
 
-
 #include "base/logging.h"
 #include "util/cloud/gcp/gcp_creds_provider.h"
 #include "util/http/http_client.h"
@@ -14,18 +13,18 @@ namespace util::cloud {
 using namespace std;
 
 namespace h2 = boost::beast::http;
-const char GCS_API_DOMAIN[] = "storage.googleapis.com";
+
+namespace detail {
+
 
 string AuthHeader(string_view access_token) {
   return absl::StrCat("Bearer ", access_token);
 }
 
-namespace detail {
-
-EmptyRequestImpl CreateGCPEmptyRequest(boost::beast::http::verb req_verb, std::string_view url,
-                                       const std::string_view access_token) {
+EmptyRequestImpl CreateGCPEmptyRequest(boost::beast::http::verb req_verb, std::string_view endpoint,
+                                       std::string_view url, const std::string_view access_token) {
   EmptyRequestImpl res(req_verb, url);
-  res.SetHeader(h2::field::host, GCS_API_DOMAIN);
+  res.SetHeader(h2::field::host, endpoint);
   res.SetHeader(h2::field::authorization, AuthHeader(access_token));
   return res;
 }

--- a/util/cloud/gcp/gcp_utils.h
+++ b/util/cloud/gcp/gcp_utils.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <boost/beast/http/empty_body.hpp>
 #include <boost/beast/http/dynamic_body.hpp>
+#include <boost/beast/http/empty_body.hpp>
 #include <boost/beast/http/parser.hpp>
 #include <memory>
 
@@ -12,16 +12,13 @@
 #include "util/http/https_client_pool.h"
 
 namespace util::cloud {
-class GCPCredsProvider;
-extern const char GCS_API_DOMAIN[];
 
 namespace detail {
-  EmptyRequestImpl CreateGCPEmptyRequest(boost::beast::http::verb req_verb, std::string_view url,
-                                         const std::string_view access_token);
-
-} // namespace detail
-
+EmptyRequestImpl CreateGCPEmptyRequest(boost::beast::http::verb req_verb, std::string_view endpoint,
+                                       std::string_view url, const std::string_view access_token);
 
 std::string AuthHeader(std::string_view access_token);
+
+}  // namespace detail
 
 }  // namespace util::cloud

--- a/util/cloud/gcp/gcs_file.cc
+++ b/util/cloud/gcp/gcs_file.cc
@@ -254,8 +254,8 @@ io::SizeOrError GcsReadFile::Read(size_t offset, const iovec* v, uint32_t len) {
   // the "offset" argument is ignored as this file only reads sequentially.
   if (!client_handle_) {
     string token = opts_.creds_provider->access_token();
-    detail::EmptyRequestImpl empty_req =
-        detail::CreateGCPEmptyRequest(h2::verb::get, read_obj_url_, token);
+    detail::EmptyRequestImpl empty_req = detail::CreateGCPEmptyRequest(
+        h2::verb::get, opts_.creds_provider->ServiceEndpoint(), read_obj_url_, token);
 
     RobustSender sender(opts_.pool, opts_.creds_provider);
     RobustSender::SenderResult send_res;
@@ -312,7 +312,8 @@ io::Result<io::WriteFile*> OpenWriteGcsFile(const string& bucket, const string& 
   absl::StrAppend(&url, bucket, "/o?uploadType=resumable&name=");
   strings::AppendUrlEncoded(key, &url);
   string token = opts.creds_provider->access_token();
-  detail::EmptyRequestImpl empty_req = detail::CreateGCPEmptyRequest(h2::verb::post, url, token);
+  detail::EmptyRequestImpl empty_req = detail::CreateGCPEmptyRequest(
+      h2::verb::post, opts.creds_provider->ServiceEndpoint(), url, token);
   empty_req.Finalize();  // it's post request so it's required.
 
   RobustSender sender(opts.pool, opts.creds_provider);

--- a/util/cloud/utils.h
+++ b/util/cloud/utils.h
@@ -158,6 +158,8 @@ class CredentialsProvider {
 
   virtual std::error_code Init(unsigned connect_ms) = 0;
 
+  virtual std::string ServiceEndpoint() const = 0;
+
   virtual void Sign(detail::HttpRequestBase* req) const = 0;
   virtual std::error_code RefreshToken() = 0;
 };


### PR DESCRIPTION
Small refactoring around cloud::CredentialsProvider so now Azure can rely on an abstract interface instead of using the concrete one.