### PR TITLE
fix(listener): Check if sock_ is not null

### DIFF
--- a/util/fibers/listener_interface.cc
+++ b/util/fibers/listener_interface.cc
@@ -225,7 +225,7 @@ void ListenerInterface::RunAcceptLoop() {
 }
 
 ListenerInterface::~ListenerInterface() {
-  if (sock_->IsOpen()) {
+  if (sock_ && sock_->IsOpen()) {
     sock_->proactor()->Await([this] {
       std::ignore = this->sock_->Close();
     });


### PR DESCRIPTION
Listener object can be created but `sock_` variable is not initialized. Destructor should check if sock_ is initialized before using it.