### PR TITLE
fix: SSL_shutdown on incomplete handshake

### DIFF
--- a/util/tls/tls_engine.cc
+++ b/util/tls/tls_engine.cc
@@ -143,7 +143,7 @@ auto Engine::Shutdown() -> OpResult {
   int result = SSL_shutdown(ssl_);
   // See https://www.openssl.org/docs/man1.1.1/man3/SSL_shutdown.html
 
-  if (result == 0) { // First step of Shutdown (close_notify) returns 0.
+  if (result == 0) {              // First step of Shutdown (close_notify) returns 0.
     result = SSL_shutdown(ssl_);  // Initiate the second step.
   }
 
@@ -216,15 +216,14 @@ int SslProbeSetDefaultCALocation(SSL_CTX* ctx) {
   return -1;
 }
 
-
 auto Engine::ToOpResult(int result, const char* location) -> OpResult {
   DCHECK_LE(result, 0);
 
   int ssl_error = SSL_get_error(ssl_, result);
   unsigned long queue_error = 0;
 
-#define ERROR_DETAILS errno << ":" << queue_error << " "  \
-                   << ERR_reason_error_string(queue_error) << " " << location
+#define ERROR_DETAILS \
+  errno << ":" << queue_error << " " << ERR_reason_error_string(queue_error) << " " << location
 
   switch (ssl_error) {
     case SSL_ERROR_ZERO_RETURN:  // graceful shutdown of TLS connection.
@@ -237,15 +236,16 @@ auto Engine::ToOpResult(int result, const char* location) -> OpResult {
       queue_error = ERR_get_error();
       VLOG(1) << "SSL syscall error " << ERROR_DETAILS;
       break;
-    case SSL_ERROR_SSL:
+    case SSL_ERROR_SSL: {
       state_ |= FATAL_ERROR;
       queue_error = ERR_get_error();
-      LOG(WARNING) << "SSL protocol error " << ERROR_DETAILS;
+      LOG_EVERY_T(WARNING, 30) << "SSL protocol error " << ERROR_DETAILS;
       break;
+    }
     default:
       queue_error = ERR_get_error();
       state_ |= FATAL_ERROR;
-      LOG(WARNING) << "Unexpected SSL error " << ssl_error << " " << ERROR_DETAILS;
+      LOG_EVERY_T(WARNING, 30) << "Unexpected SSL error " << ssl_error << " " << ERROR_DETAILS;
       break;
   }
 

--- a/util/tls/tls_engine.cc
+++ b/util/tls/tls_engine.cc
@@ -140,6 +140,9 @@ auto Engine::Shutdown() -> OpResult {
   if (state_ & FATAL_ERROR)
     return 1;
 
+  if (!SSL_is_init_finished(ssl_))
+    return 0;
+
   int result = SSL_shutdown(ssl_);
   // See https://www.openssl.org/docs/man1.1.1/man3/SSL_shutdown.html
 
@@ -239,13 +242,13 @@ auto Engine::ToOpResult(int result, const char* location) -> OpResult {
     case SSL_ERROR_SSL: {
       state_ |= FATAL_ERROR;
       queue_error = ERR_get_error();
-      LOG_EVERY_T(WARNING, 30) << "SSL protocol error " << ERROR_DETAILS;
+      LOG_EVERY_T(WARNING, 1) << "SSL protocol error " << ERROR_DETAILS;
       break;
     }
     default:
       queue_error = ERR_get_error();
       state_ |= FATAL_ERROR;
-      LOG_EVERY_T(WARNING, 30) << "Unexpected SSL error " << ssl_error << " " << ERROR_DETAILS;
+      LOG_EVERY_T(WARNING, 1) << "Unexpected SSL error " << ssl_error << " " << ERROR_DETAILS;
       break;
   }
 

--- a/util/tls/tls_socket.cc
+++ b/util/tls/tls_socket.cc
@@ -62,14 +62,7 @@ auto TlsSocket::Shutdown(int how) -> error_code {
   }
 
   state_ |= SHUTDOWN_IN_PROGRESS;
-  // We must call SSL_shutdown only the handshake is complete.
-  // if handshake is not complete we cannot send or receive the TLS close_notify alert so
-  // op result should be zero such that we don't call MaybeSendOutput() below.
-  Engine::OpResult op_result = 0;
-  if (state_ & HANDSHAKE_COMPLETE) {
-    state_ &= HANDSHAKE_COMPLETE;
-    op_result = engine_->Shutdown();
-  }
+  Engine::OpResult op_result = engine_->Shutdown();
   if (op_result) {
     // engine_ could send notification messages to the peer.
     std::ignore = MaybeSendOutput();
@@ -102,7 +95,6 @@ auto TlsSocket::Accept() -> AcceptResult {
     }
 
     if (op_result == 1) {  // Success.
-      state_ |= HANDSHAKE_COMPLETE;
       if (VLOG_IS_ON(1)) {
         const SSL_CIPHER* cipher = SSL_get_current_cipher(engine_->native_handle());
         string_view proto_version = SSL_get_version(engine_->native_handle());
@@ -137,7 +129,6 @@ error_code TlsSocket::Connect(const endpoint_type& endpoint,
   while (true) {
     Engine::OpResult op_result = engine_->Handshake(Engine::HandshakeType::CLIENT);
     if (op_result == 1) {
-      state_ &= HANDSHAKE_COMPLETE;
       break;
     }
 
@@ -170,7 +161,6 @@ error_code TlsSocket::Connect(const endpoint_type& endpoint,
 
 auto TlsSocket::Close() -> error_code {
   DCHECK(engine_);
-  state_ &= HANDSHAKE_COMPLETE;
   return next_sock_->Close();
 }
 

--- a/util/tls/tls_socket.h
+++ b/util/tls/tls_socket.h
@@ -113,7 +113,13 @@ class TlsSocket final : public FiberSocketBase {
   std::unique_ptr<Engine> engine_;
   size_t upstream_write_ = 0;
 
-  enum { WRITE_IN_PROGRESS = 1, READ_IN_PROGRESS = 2, SHUTDOWN_IN_PROGRESS = 4, SHUTDOWN_DONE = 8 };
+  enum {
+    WRITE_IN_PROGRESS = 1,
+    READ_IN_PROGRESS = 2,
+    SHUTDOWN_IN_PROGRESS = 4,
+    SHUTDOWN_DONE = 8,
+    HANDSHAKE_COMPLETE = 16
+  };
   uint8_t state_{0};
 
   // TODO turn this into a class with proper access specifiers

--- a/util/tls/tls_socket.h
+++ b/util/tls/tls_socket.h
@@ -118,7 +118,6 @@ class TlsSocket final : public FiberSocketBase {
     READ_IN_PROGRESS = 2,
     SHUTDOWN_IN_PROGRESS = 4,
     SHUTDOWN_DONE = 8,
-    HANDSHAKE_COMPLETE = 16
   };
   uint8_t state_{0};
 


### PR DESCRIPTION
We should not call `SSL_shutdown` if the handshake is not complete.

Furthermore reduce the `LOG(INFO)` because they can flood and steal cpu time.

Fixes: #430
