### PR TITLE
chore: busy polling specific per proactor

### DIFF
--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -498,6 +498,8 @@ auto Scheduler::RunWorkerFibersStepImpl() -> RunFiberResult {
   const unsigned q_indx = unsigned(FiberPriority::NORMAL);
   DCHECK(HasReady(q_indx));
 
+  ProactorBase::UpdateMonotonicTime();
+
   constexpr uint64_t kMaxTimeSpentNs = 1000'000U;  // 1 ms.
   const uint64_t deadline_ns = ProactorBase::GetMonotonicTimeNs() + kMaxTimeSpentNs;
 

--- a/util/fibers/proactor_base.cc
+++ b/util/fibers/proactor_base.cc
@@ -24,7 +24,7 @@ constexpr int kNumSig = _NSIG;
 
 #else
 constexpr int kNumSig = NSIG;
-#endif // __linux__
+#endif  // __linux__
 
 #include <mutex>  // once_flag
 
@@ -73,11 +73,9 @@ static inline void arm_arch_pause(void) {
 
   if (use_spin_delay_sb == 1) {
     asm volatile(".inst 0xd50330ff");  // SB instruction encoding
-  }
-  else if (use_spin_delay_sb == 0) {
+  } else if (use_spin_delay_sb == 0) {
     asm volatile("isb");
-  }
-  else {
+  } else {
     // Initialize variable and check if SB is supported
     if (getauxval(AT_HWCAP) & HWCAP_SB)
       use_spin_delay_sb = 1;
@@ -86,9 +84,9 @@ static inline void arm_arch_pause(void) {
   }
 #else
   asm volatile("isb");
-#endif // __linux__
+#endif  // __linux__
 }
-#endif // __aarch64__
+#endif  // __aarch64__
 
 unsigned pause_amplifier = 50;
 uint64_t cycles_per_10us = 1000000;  // correctly defined inside ModuleInit.
@@ -102,6 +100,8 @@ __thread ProactorBase::TLInfo ProactorBase::tl_info_;
 
 ProactorBase::ProactorBase() : task_queue_(kTaskQueueLen) {
   call_once(module_init, &ModuleInit);
+
+  SetBusyPollUsec(20);
 
 #ifdef __linux__
   wake_fd_ = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
@@ -196,7 +196,7 @@ bool ProactorBase::RunOnIdleTasks() {
           on_idle_next_ = 0;
           break;  // do/while loop
         }
-      } else {   // level >= 0
+      } else {  // level >= 0
         curr_ts = GetClockNanos();
 
         if (unsigned(level) >= kOnIdleMaxLevel) {
@@ -323,7 +323,11 @@ void ProactorBase::ClearSignal(std::initializer_list<uint16_t> signals, bool ins
 }
 
 uint64_t ProactorBase::GetCurrentBusyCycles() const {
-  return base::CycleClock::Now() - idle_end_cycle_;
+  return base::CycleClock::Now() - busy_poll_start_cycle_;
+}
+
+void ProactorBase::SetBusyPollUsec(uint32_t usec) {
+  busy_poll_cycle_limit_ = base::CycleClock::FromUsec(usec);
 }
 
 // The threshold is set to ~2.5ms.
@@ -356,18 +360,23 @@ bool ProactorBase::RunL2Tasks(detail::Scheduler* scheduler) {
 }
 
 void ProactorBase::IdleEnd(uint64_t start) {
-  idle_end_cycle_ = base::CycleClock::Now();
+  auto end_cycles = base::CycleClock::Now();
+  busy_poll_start_cycle_ = end_cycles;
 
   // Assuming that cpu clock frequency is
   uint64_t kMinCyclePeriod = cycles_per_10us * 500'000ULL;
-  cpu_idle_cycles_ += (idle_end_cycle_ - start);
+  cpu_idle_cycles_ += (end_cycles - start);
 
-  if (idle_end_cycle_ > cpu_measure_cycle_start_ + kMinCyclePeriod) {
+  if (end_cycles > cpu_measure_cycle_start_ + kMinCyclePeriod) {
     load_numerator_ = cpu_idle_cycles_;
-    load_denominator_ = idle_end_cycle_ - cpu_measure_cycle_start_;
+    load_denominator_ = end_cycles - cpu_measure_cycle_start_;
     cpu_idle_cycles_ = 0;
-    cpu_measure_cycle_start_ = idle_end_cycle_;
+    cpu_measure_cycle_start_ = end_cycles;
   }
+}
+
+void ProactorBase::ResetBusyPoll() {
+  busy_poll_start_cycle_ = base::CycleClock::Now();
 }
 
 void ProactorBase::Pause(unsigned count) {

--- a/util/fibers/uring_proactor.h
+++ b/util/fibers/uring_proactor.h
@@ -241,7 +241,7 @@ class UringProactor : public ProactorBase {
   uint32_t direct_fds_cnt_ = 0;
   uint32_t get_entry_sq_full_ = 0, get_entry_await_ = 0;
   uint64_t reaped_cqe_cnt_ = 0;
-  std::atomic_uint64_t last_wake_ts_{0};
+  std::atomic_int64_t last_wake_ts_{0};
 
   struct EpollEntry {
     EpollCB cb;


### PR DESCRIPTION
Beforehand we had a flag that was common to all proactors. Now the responsibility to override goes to caller and each proactor can have its own setting.