### PR TITLE
chore: more customizations of iouring behavior

### DIFF
--- a/util/fibers/uring_proactor.h
+++ b/util/fibers/uring_proactor.h
@@ -103,6 +103,20 @@ class UringProactor : public ProactorBase {
     return IOURING;
   }
 
+  void ConfigureSubmitWakeup(bool enable) {
+    submit_on_wake_ = uint8_t(enable);
+  }
+
+  void ConfigureMsgRing(bool enable) {
+    msgring_f_ = uint8_t(enable);
+  }
+
+  void SetSubmitQueueThreshold(uint32_t threshold) {
+    submit_q_threshold_ = threshold;
+  }
+
+  bool FlushSubmitQueueIfNeeded();
+
   // Register buffer with given size and allocate backing storage, calls io_uring_register_buffers.
   // Returns 0 on success, errno on error.
   unsigned RegisterBuffers(size_t size);
@@ -195,7 +209,8 @@ class UringProactor : public ProactorBase {
   uint8_t poll_first_ : 1;
   uint8_t buf_ring_f_ : 1;
   uint8_t bundle_f_ : 1;
-  uint8_t : 4;
+  uint8_t submit_on_wake_ : 1;
+  uint8_t : 3;
 
   EventCount sqe_avail_;
 
@@ -235,6 +250,7 @@ class UringProactor : public ProactorBase {
     base::SegmentPool segments;
   } buf_pool_;
 
+  uint32_t submit_q_threshold_ = UINT32_MAX;
   int32_t next_free_ce_ = -1;
   uint32_t pending_cb_cnt_ = 0;
   uint32_t next_free_index_ = 0;  // next available fd for register files.

--- a/util/fibers/uring_proactor.h
+++ b/util/fibers/uring_proactor.h
@@ -115,6 +115,10 @@ class UringProactor : public ProactorBase {
     submit_q_threshold_ = threshold;
   }
 
+  /**
+   * Flushes the submit queue if the number of pending submissions reaches the configured threshold.
+   * Returns true if the queue was flushed, false otherwise.
+   */
   bool FlushSubmitQueueIfNeeded();
 
   // Register buffer with given size and allocate backing storage, calls io_uring_register_buffers.


### PR DESCRIPTION
1. Optionally flush sqs on writes if the pending sq count is higher than the threshold.
2. Optionally flush sqs when waking up another thread.
3. Allow switching from msgring to event_fd wake configurations programatically.