### PR TITLE
fix(cmake): add boost >= 1.89 compatibility for boost::system

### DIFF
--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -241,38 +241,18 @@ endif()
 find_package(Boost CONFIG REQUIRED)
 Message(STATUS "Found Boost ${Boost_LIBRARY_DIRS} ${Boost_LIB_VERSION} ${Boost_VERSION}")
 
-# For Boost < 1.89 keep the original behavior
-if(Boost_VERSION VERSION_LESS 1.89)
+if(Boost_VERSION_MAJOR EQUAL 1 AND Boost_VERSION_MINOR LESS 89)
   find_package(Boost CONFIG REQUIRED COMPONENTS context system)
 else()
-  # For Boost >= 1.89: do not request system via CONFIG (it may not provide boost_systemConfig)
-  # 1) Still request context via CONFIG (it should exist)
   find_package(Boost CONFIG QUIET COMPONENTS context)
-
-  # 2) Resolve Boost::system differently
+  find_package(Boost MODULE QUIET COMPONENTS system)
   if(NOT TARGET Boost::system)
-    # Try FindBoost (module) first
-    set(Boost_NO_BOOST_CMAKE ON)
-    find_package(Boost MODULE QUIET COMPONENTS system)
-  endif()
-
-  if(NOT TARGET Boost::system)
-    # If FindBoost exposed the library path, wrap it into an imported target
-    if(DEFINED Boost_SYSTEM_LIBRARY AND EXISTS "${Boost_SYSTEM_LIBRARY}")
-      add_library(Boost::system UNKNOWN IMPORTED)
-      set_target_properties(Boost::system PROPERTIES
-        IMPORTED_LOCATION "${Boost_SYSTEM_LIBRARY}"
-        INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}")
-      Message(STATUS "Using Boost_SYSTEM_LIBRARY at ${Boost_SYSTEM_LIBRARY}")
-    else()
-      # Final fallback: header-only
-      add_library(Boost::system INTERFACE IMPORTED)
-      target_compile_definitions(Boost::system INTERFACE BOOST_ERROR_CODE_HEADER_ONLY)
-      if(Boost_INCLUDE_DIRS)
-        target_include_directories(Boost::system INTERFACE "${Boost_INCLUDE_DIRS}")
-      endif()
-      Message(STATUS "Using header-only Boost::system (BOOST_ERROR_CODE_HEADER_ONLY)")
+    add_library(Boost::system INTERFACE IMPORTED)
+    if(Boost_INCLUDE_DIRS)
+      target_include_directories(Boost::system INTERFACE "${Boost_INCLUDE_DIRS}")
     endif()
+    target_compile_definitions(Boost::system INTERFACE BOOST_ERROR_CODE_HEADER_ONLY)
+    message(STATUS "Using header-only Boost::system (BOOST_ERROR_CODE_HEADER_ONLY)")
   endif()
 endif()
 


### PR DESCRIPTION
Problem:
With Boost 1.89+, BoostConfig no longer provides boost_systemConfig.cmake, so find_package(Boost CONFIG REQUIRED COMPONENTS system) fails.

Fixes: https://github.com/dragonflydb/dragonfly/actions/runs/17061127671/job/48370365579
