### PR TITLE
chore: add high priority to the scheduler

### DIFF
--- a/util/fibers/detail/fiber_interface.cc
+++ b/util/fibers/detail/fiber_interface.cc
@@ -282,7 +282,7 @@ void FiberInterface::Start(Launch launch) {
   switch (launch) {
     case Launch::post:
       // Activate but do not switch to it.
-      fb_init.sched->AddReady(this);
+      fb_init.sched->AddReady(this, prio_ == FiberPriority::HIGH /* to_front */);
       break;
     case Launch::dispatch:
       // Add the active fiber to the ready queue and switch to the new fiber.
@@ -336,7 +336,7 @@ void FiberInterface::ActivateOther(FiberInterface* other) {
     // In case `other` times out on wait, it could be added to the ready queue already by
     // ProcessSleep.
     if (!other->list_hook.is_linked())
-      scheduler_->AddReady(other);
+      scheduler_->AddReady(other, other->prio_ == FiberPriority::HIGH /* to_front */);
   } else {
     // The fiber belongs to another thread. We need to schedule it on that thread.
     // Note, that in this case it is assumed that ActivateOther was called by WaitQueue

--- a/util/fibers/detail/fiber_interface.h
+++ b/util/fibers/detail/fiber_interface.h
@@ -25,6 +25,7 @@ enum class Launch {
 enum class FiberPriority : uint8_t {
   NORMAL = 0,      // default priority
   BACKGROUND = 1,  // background priority, runs when no NORMAL fibers are ready.
+  HIGH = 2,       // High priority, activated earlier than other fibers.
 };
 
 // based on boost::context::fixedsize_stack but uses pmr::memory_resource for allocation.


### PR DESCRIPTION
High priority share the NORMAL queue with NORMAL fibers.

If a high priority fiber is activated, it is pushed to the front of the queue. If it yields, however, it is still pushed to back.

Also added support for priorities for default, main thread that does not run an I/O polling loop. It is mainly added for being able to test fibers without proactors.