### PR TITLE
chore: support onrecv hook for tcp sockets

### DIFF
--- a/util/fiber_socket_base.h
+++ b/util/fiber_socket_base.h
@@ -123,6 +123,14 @@ class FiberSocketBase : public io::Sink,
   //! Cancels a callback that was registered with RegisterOnErrorCb. Must be reentrant.
   virtual void CancelOnErrorCb() = 0;
 
+  struct RecvNotification {
+    // TODO: move ProvidedBuffer functionality here and remove RecvProvided interface.
+  };
+
+  using OnRecvCb = std::function<void (const RecvNotification&)>;
+  virtual void RegisterOnRecv(OnRecvCb cb) = 0;
+  virtual void ResetOnRecvHook() = 0;
+
   virtual bool IsUDS() const = 0;
 
   using native_handle_type = int;

--- a/util/fibers/epoll_socket.h
+++ b/util/fibers/epoll_socket.h
@@ -44,6 +44,8 @@ class EpollSocket : public LinuxSocketBase {
   void CancelOnErrorCb() final;
 
   using FiberSocketBase::IsConnClosed;
+  void RegisterOnRecv(std::function<void (const RecvNotification&)> cb) final;
+  void ResetOnRecvHook() final;
 
  private:
   class PendingReq;
@@ -77,9 +79,15 @@ class EpollSocket : public LinuxSocketBase {
     AsyncReq* async_write_req_;
   };
 
+  // Read path
+  struct OnRecvRecord {
+    std::function<void (const RecvNotification&)> cb;
+  };
+
   union {
     PendingReq* read_req_;
     AsyncReq* async_read_req_;
+    OnRecvRecord* on_recv_;
   };
 
   int32_t arm_index_ = -1;
@@ -91,6 +99,7 @@ class EpollSocket : public LinuxSocketBase {
     struct {
       uint8_t async_write_pending_ : 1;
       uint8_t async_read_pending_ : 1;
+      uint8_t recv_hook_registered_ : 1;
     };
     uint8_t flags_;
   };

--- a/util/fibers/uring_socket.h
+++ b/util/fibers/uring_socket.h
@@ -47,6 +47,8 @@ class UringSocket : public LinuxSocketBase {
 
   void RegisterOnErrorCb(std::function<void(uint32_t)> cb) final;
   void CancelOnErrorCb() final;
+  void RegisterOnRecv(OnRecvCb cb) final;
+  void ResetOnRecvHook() final;
 
   // Returns the native linux fd even for direct-fd iouring mode.
   native_handle_type native_handle() const final;
@@ -113,6 +115,7 @@ class UringSocket : public LinuxSocketBase {
   };
 
   ErrorCbRefWrapper* error_cb_wrapper_ = nullptr;
+  UringProactor::EpollIndex recv_poll_id_ = 0;
 
   // A multishot state object. Manages the multishot completions in the shared completion array
   // of proactor. The socket must drain all its completions before it can be destroyed.

--- a/util/tls/tls_socket.cc
+++ b/util/tls/tls_socket.cc
@@ -468,6 +468,14 @@ void TlsSocket::CancelOnErrorCb() {
   return next_sock_->CancelOnErrorCb();
 }
 
+void TlsSocket::RegisterOnRecv(OnRecvCb cb) {
+  LOG(FATAL) << "Not implemented";
+}
+
+void TlsSocket::ResetOnRecvHook() {
+  LOG(FATAL) << "Not implemented";
+}
+
 unsigned TlsSocket::RecvProvided(unsigned buf_len, ProvidedBuffer* dest) {
   LOG(DFATAL) << "Not implemented";
 

--- a/util/tls/tls_socket.h
+++ b/util/tls/tls_socket.h
@@ -89,6 +89,9 @@ class TlsSocket final : public FiberSocketBase {
 
   virtual void SetProactor(ProactorBase* p) override;
 
+  virtual void RegisterOnRecv(OnRecvCb cb) final;
+  virtual void ResetOnRecvHook() final;
+
   // * NOT PART OF THE API -- USED FOR TESTING PURPOSES ONLY *
   // This function is used to simulate a corner case of AsyncReadSome. In particular,
   // when engine_->Read(...) returns NEED_WRITE. According to chatgpt and google


### PR DESCRIPTION
Asynchronous interface with fiber blockage is not flexibile enough for use-cases, where we want a fiber to block on multiple events, not just socket recv or socket send.

This is wjere OnRecv comes in but will require a separation of polling notification and socket reads for iouring mode. However, starting from kernel 6.11, iouring supports multi-shot receives with provided buffers where it can notify and provide already filled buffer from a registered buffer pool.

This PR exposes only basic epoll-like mechanism for both epoll and iouring sockets without multi-shot recv support in iouring. Tls sockets are also not part of the scope.