### PR TITLE
chore: socket improvements

### DIFF
--- a/util/accept_server_test.cc
+++ b/util/accept_server_test.cc
@@ -333,6 +333,7 @@ TEST_P(AcceptServerTest, Shutdown) {
     // See https://man7.org/linux/man-pages/man2/poll.2.html for more details.
     EXPECT_GE(called, socks.size());
     for (unsigned i = 0; i < socks.size(); ++i) {
+      socks[i]->CancelOnErrorCb();
       std::ignore = socks[i]->Close();
     }
   });

--- a/util/fiber_socket_base.h
+++ b/util/fiber_socket_base.h
@@ -143,6 +143,9 @@ class FiberSocketBase : public io::Sink,
   virtual ABSL_MUST_USE_RESULT error_code ListenUDS(const char* path, mode_t permissions,
                                                     unsigned backlog) = 0;
 
+  // Direct send just calls send(2) syscall without any wrapping by helio.
+  ssize_t RawSend(io::Bytes buf);
+  ssize_t RawSend(const iovec* v, uint32_t len);
  protected:
   virtual void OnSetProactor() {
   }

--- a/util/fibers/epoll_socket.h
+++ b/util/fibers/epoll_socket.h
@@ -57,6 +57,7 @@ class EpollSocket : public LinuxSocketBase {
     }
 
     // Caller is responsible for *calling* cb.
+    // Returns true if the callback has run.
     std::pair<bool, Result<size_t>> Run(int fd, bool is_send);
   };
 
@@ -86,8 +87,13 @@ class EpollSocket : public LinuxSocketBase {
   static constexpr uint32_t kMaxBufSize = 1 << 16;
   static constexpr uint32_t kMinBufSize = 1 << 4;
   uint32_t bufreq_sz_ = kMinBufSize;
-  uint8_t async_write_pending_ : 1;
-  uint8_t async_read_pending_ : 1;
+  union {
+    struct {
+      uint8_t async_write_pending_ : 1;
+      uint8_t async_read_pending_ : 1;
+    };
+    uint8_t flags_;
+  };
   std::function<void(uint32_t)> error_cb_;
 };
 

--- a/util/fibers/fiber_socket_base.cc
+++ b/util/fibers/fiber_socket_base.cc
@@ -57,6 +57,22 @@ Result<size_t> FiberSocketBase::Recv(const iovec* ptr, size_t len) {
   return RecvMsg(msg, 0);
 }
 
+ssize_t FiberSocketBase::RawSend(io::Bytes buf) {
+  int fd = native_handle();
+  return send(fd, buf.data(), buf.size(), MSG_NOSIGNAL);
+}
+
+ssize_t FiberSocketBase::RawSend(const iovec* v, uint32_t len) {
+  int fd = native_handle();
+
+  msghdr msg;
+  memset(&msg, 0, sizeof(msg));
+  msg.msg_iov = const_cast<iovec*>(v);
+  msg.msg_iovlen = len;
+
+  return sendmsg(fd, &msg, MSG_NOSIGNAL);
+}
+
 LinuxSocketBase::~LinuxSocketBase() {
   int fd = native_handle();
 


### PR DESCRIPTION
1. Remove memory leak in uring_socket when ErrorCb was registered but have not been unregistered upon close.
2. Disable iouring bundles as it has buggy implementation at the moment.
3. Remove code duplication in tls_socket_test.
4. Add RawSend posix methods that allow potentially sending data without blocking a caller (for non-blocking sockets). Currently, broken for tls sockets.