### PR TITLE
chore: Introduce TryRecv method for helio sockets

### DIFF
--- a/util/fiber_socket_base.h
+++ b/util/fiber_socket_base.h
@@ -159,6 +159,10 @@ class FiberSocketBase : public io::Sink,
   // Try sending without blocking the calling fiber in case EAGAIN was encountered.
   virtual io::Result<size_t> TrySend(io::Bytes buf) = 0;
   virtual io::Result<size_t> TrySend(const iovec* v, uint32_t len) = 0;
+
+  // Try receiving without blocking the calling fiber in case EAGAIN was encountered.
+  virtual io::Result<size_t> TryRecv(io::MutableBytes buf) = 0;
+
  protected:
   virtual void OnSetProactor() {
   }
@@ -230,6 +234,7 @@ class LinuxSocketBase : public FiberSocketBase {
 
   io::Result<size_t> TrySend(io::Bytes buf) override;
   io::Result<size_t> TrySend(const iovec* v, uint32_t len) override;
+  io::Result<size_t> TryRecv(io::MutableBytes buf) override;
 
  protected:
   constexpr static unsigned kFdShift = 4;

--- a/util/tls/tls_socket.h
+++ b/util/tls/tls_socket.h
@@ -94,7 +94,7 @@ class TlsSocket final : public FiberSocketBase {
 
   io::Result<size_t> TrySend(io::Bytes buf) override;
   io::Result<size_t> TrySend(const iovec* v, uint32_t len) override;
-
+  io::Result<size_t> TryRecv(io::MutableBytes buf) override;
 
   // * NOT PART OF THE API -- USED FOR TESTING PURPOSES ONLY *
   // This function is used to simulate a corner case of AsyncReadSome. In particular,
@@ -156,12 +156,12 @@ class TlsSocket final : public FiberSocketBase {
     enum Role : std::uint8_t { READER, WRITER };
 
     AsyncReq(TlsSocket* owner, io::AsyncProgressCb cb, const iovec* v, uint32_t len,
-             Engine::OpResult op_val, Role role)
-        : owner_(owner), caller_completion_cb_(std::move(cb)), vec_(v), len_(len), op_val_(op_val),
+             Role role)
+        : owner_(owner), caller_completion_cb_(std::move(cb)), vec_(v), len_(len),
           role_(role) {
     }
 
-    void HandleOpAsync();
+    void HandleOpAsync(int op_val);
     void StartUpstreamWrite();
     void SetEngineWritten(size_t written) {
       engine_written_ = written;
@@ -174,7 +174,6 @@ class TlsSocket final : public FiberSocketBase {
 
     const iovec* vec_;
     uint32_t len_;
-    Engine::OpResult op_val_;
 
     Role role_;
 


### PR DESCRIPTION
When using OnRecv interface, one may need to read data from the socket. a posix `recv` call works for regular sockets but not for tls socket that needs to delegate to SSL_read.

Also, simplify a little the async state in tls socket.