### PR TITLE
chore: remove code duplication on sockets

### DIFF
--- a/util/fiber_socket_base.h
+++ b/util/fiber_socket_base.h
@@ -262,4 +262,9 @@ void SetNonBlocking(int fd);
 
 void SetCloexec(int fd);
 
+bool posix_err_wrap(ssize_t res, FiberSocketBase::error_code* ec);
+
+nonstd::unexpected<std::error_code> MakeUnexpected(std::errc code);
+
+
 }  // namespace util

--- a/util/fibers/epoll_socket.cc
+++ b/util/fibers/epoll_socket.cc
@@ -33,19 +33,6 @@ inline EpollSocket::error_code from_errno() {
   return EpollSocket::error_code(errno, system_category());
 }
 
-inline ssize_t posix_err_wrap(ssize_t res, EpollSocket::error_code* ec) {
-  if (res == -1) {
-    *ec = from_errno();
-  } else if (res < 0) {
-    LOG(WARNING) << "Bad posix error " << res;
-  }
-  return res;
-}
-
-nonstd::unexpected<error_code> MakeUnexpected(std::errc code) {
-  return make_unexpected(make_error_code(code));
-}
-
 #ifdef __linux__
 constexpr int kEventMask = EPOLLIN | EPOLLOUT | EPOLLET | EPOLLRDHUP;
 
@@ -267,7 +254,7 @@ error_code EpollSocket::Connect(const endpoint_type& ep, std::function<void(int)
   error_code ec;
 
   int fd = CreateSockFd(ep.address().is_v4() ? AF_INET : AF_INET6);
-  if (posix_err_wrap(fd, &ec) < 0)
+  if (posix_err_wrap(fd, &ec))
     return ec;
 
   CHECK(read_req_ == NULL);

--- a/util/fibers/fiber_socket_base.cc
+++ b/util/fibers/fiber_socket_base.cc
@@ -20,19 +20,21 @@ namespace util {
 using namespace std;
 using io::Result;
 using nonstd::make_unexpected;
-namespace {
 
 // Return true if error occurred and ec is set, false otherwise.
-inline bool posix_err_wrap(ssize_t res, FiberSocketBase::error_code* ec) {
+bool posix_err_wrap(ssize_t res, FiberSocketBase::error_code* ec) {
   if (res == -1) {
     *ec = FiberSocketBase::error_code(errno, std::system_category());
     return true;
+  } else if (res < 0) {
+    LOG(WARNING) << "Bad posix error " << res;
   }
-
   return false;
 }
 
-}  // namespace
+nonstd::unexpected<error_code> MakeUnexpected(std::errc code) {
+  return make_unexpected(make_error_code(code));
+}
 
 void FiberSocketBase::SetProactor(ProactorBase* p) {
   if (p == proactor_)


### PR DESCRIPTION
Notice that we implement the same functions`posix_err_wrap` and `MakeUnexpected` in 3 places (fiber_socket_base, epoll_socket and uring_socket). Furthermore, use a consistent API (return bool instead of size_t).