### PR TITLE
chore: flush data in TlsSocket::Connect

### DIFF
--- a/util/tls/tls_engine.cc
+++ b/util/tls/tls_engine.cc
@@ -90,16 +90,6 @@ auto Engine::PeekOutputBuf() -> Buffer {
 
 void Engine::ConsumeOutputBuf(unsigned sz) {
   int res = BIO_nread(external_bio_, NULL, sz);
-
-  if (res <= 0) {
-    unsigned long error = ::ERR_get_error();
-    char buf[256];
-    ERR_error_string_n(error, buf, sizeof(buf));
-    int retry = BIO_should_retry(external_bio_);
-    LOG(FATAL) << "Unexpected error " << buf << " " << error << " when consuming " << sz
-               << " bytes from BIO, retry is " << retry;
-  }
-  CHECK_GT(res, 0);
   CHECK_EQ(unsigned(res), sz);
 }
 

--- a/util/tls/tls_socket.h
+++ b/util/tls/tls_socket.h
@@ -120,6 +120,7 @@ class TlsSocket final : public FiberSocketBase {
   void __DebugForceNeedWriteOnAsyncWrite(const iovec* v, uint32_t len, io::AsyncProgressCb cb);
 
  private:
+  // Both opcode and written can be set.
   struct PushResult {
     size_t written = 0;
     int engine_opcode = 0;  // Engine::OpCode


### PR DESCRIPTION
Before: TlsSocket::Connect returned with pending data in its buffer, which was obviously a bug that can potentially cause starvation. It usually does not happen as client sockets follow up with writes that flush previous data as well.