### PR TITLE
chore: stop yielding inside tls socket

### DIFF
--- a/util/tls/tls_socket.h
+++ b/util/tls/tls_socket.h
@@ -10,6 +10,7 @@
 
 #include "util/fiber_socket_base.h"
 #include "util/tls/tls_engine.h"
+#include "util/fibers/synchronization.h"
 
 namespace util {
 namespace tls {
@@ -210,6 +211,7 @@ class TlsSocket final : public FiberSocketBase {
   // preempt in function context, we simply subscribe the async request to the one in-flight and
   // once that completes it will also continue the one pending/blocked.
   AsyncReq* blocked_async_req_ = nullptr;
+  fb2::CondVarAny block_concurrent_cv_;
 };
 
 }  // namespace tls


### PR DESCRIPTION
Before: we yielded in tls socket in case both read and write path are stuch on the same I/O operation. This is problematic, when this I/O op does not progress. Imagine a case where a client does not read data, and the server is stuck on writing to the socket. If the read path asks to write to the socket, and it yields, it will just constantly yield spiking to 100% CPU on that thread as long as the write path does not progress.

This PR removes yields and replaces them with simple blocking condition.