### PR TITLE
fix: improve EpollDel and use a synchronose API on newer kernels

### DIFF
--- a/util/fibers/uring_proactor.h
+++ b/util/fibers/uring_proactor.h
@@ -103,8 +103,8 @@ class UringProactor : public ProactorBase {
     return IOURING;
   }
 
-  void ConfigureSubmitWakeup(bool enable) {
-    submit_on_wake_ = uint8_t(enable);
+  // Deprecated: not needed.
+  void ConfigureSubmitWakeup(bool) {
   }
 
   void ConfigureMsgRing(bool enable) {
@@ -203,8 +203,8 @@ class UringProactor : public ProactorBase {
   uint8_t poll_first_ : 1;
   uint8_t buf_ring_f_ : 1;
   uint8_t bundle_f_ : 1;
-  uint8_t submit_on_wake_ : 1;
   uint8_t msgring_enabled_f_ : 1;
+  uint8_t sync_cancel_f_ : 1;
   uint8_t : 2;
 
   EventCount sqe_avail_;


### PR DESCRIPTION
Before: I saw that PrepPollRemove was failing sometimes with error EALREADY. Retrying fixed the issue. Also, the synchronous (newer) API did not have such problem.

This PR: uses the newer API if possible, and fallbacks to the async API for older kernels.