### PR TITLE
chore: do not miss notifications in Epoll::RegisterOnRecv

### DIFF
--- a/examples/echo_server.cc
+++ b/examples/echo_server.cc
@@ -174,7 +174,9 @@ void EchoConnection::HandleRequests() {
         string blob(req_len_ * 8, 0);
         int res = recv(socket_->native_handle(), blob.data(), blob.size(), 0);
         if (res < 0) {
-          LOG(FATAL) << "Recv error: " << strerror(-res);
+          VLOG(1) << "Recv error: " << strerror(-res);
+          ec_ = make_error_code(errc::connection_aborted);
+          recv_notify_.notify_one();
           return;
         } else if (res == 0) {
           // connection closed.

--- a/util/fibers/epoll_socket.h
+++ b/util/fibers/epoll_socket.h
@@ -69,7 +69,7 @@ class EpollSocket : public LinuxSocketBase {
   // kevent pass error code together with completion event.
   void Wakey(uint32_t event_flags, int error, EpollProactor* cntr);
 
-  void HandleAsyncRequest(error_code ec, bool is_send);
+  void HandleAsyncRequest(unsigned epoll_mask);
 
   union {
     PendingReq* write_req_;
@@ -94,6 +94,7 @@ class EpollSocket : public LinuxSocketBase {
       uint8_t async_write_pending_ : 1;
       uint8_t async_read_pending_ : 1;
       uint8_t recv_hook_registered_ : 1;
+      uint8_t read_notified_ : 1;
     };
     uint8_t flags_;
   };

--- a/util/fibers/proactor_base.h
+++ b/util/fibers/proactor_base.h
@@ -38,7 +38,7 @@ class ProactorBase {
   enum { kTaskQueueLen = 256 };
 
   enum Kind { EPOLL = 1, IOURING = 2 };
-  enum EpollFlags { EPOLL_IN = 1, EPOLL_OUT = 4 };
+  enum EpollFlags : uint8_t { EPOLL_IN = 1, EPOLL_OUT = 4 };
 
   // Corresponds to level 0.
   // Idle tasks will rest at least kIdleCycleMaxMicros / (2^level) time between runs.


### PR DESCRIPTION
It could be that we get a notification and call RegisterOnRecv afterwards. Before this PR the notification would get lost.
Now it is cached so that RegisterOnRecv can call the hook.

Also, simplify error propagation in EpollSocket::Wakey.