### PR TITLE
chore: fix epoll leaks

### DIFF
--- a/util/fibers/epoll_socket.cc
+++ b/util/fibers/epoll_socket.cc
@@ -192,12 +192,16 @@ auto EpollSocket::Close() -> error_code {
 
     // Cleanup pending requests
     if (async_write_pending_) {
+      DCHECK(async_write_req_);
+      async_write_req_->cb(MakeUnexpected(errc::operation_canceled));
       delete async_write_req_;
       async_write_req_ = nullptr;
       async_write_pending_ = 0;
     }
 
     if (async_read_pending_) {
+      DCHECK(async_read_req_);
+      async_read_req_->cb(MakeUnexpected(errc::operation_canceled));
       delete async_read_req_;
       async_read_req_ = nullptr;
       async_read_pending_ = 0;

--- a/util/fibers/submit_entry.h
+++ b/util/fibers/submit_entry.h
@@ -183,7 +183,7 @@ class SubmitEntry {
   void PrepTimeoutRemove(unsigned long long userdata) {
     PrepFd(IORING_OP_TIMEOUT_REMOVE, -1);
     sqe_->addr = userdata;
-    sqe_->len = 1;
+    sqe_->timeout_flags = 0;
   }
 
   // Sets up link timeout with relative timespec.


### PR DESCRIPTION
Before: epoll socket would leak memory if closed in the middle of request.
Also, we had a bug in PrepTimeoutRemove that caused periodic callback leakage.

Now: EpollSocket deletes its resources as long as Close is called.
PrepTimeoutRemove correctly removes the periodic callback.