### PR TITLE
chore: return 0 result from Socket::Recv on socket shutdown.

### DIFF
--- a/io/io.cc
+++ b/io/io.cc
@@ -149,7 +149,7 @@ Result<size_t> Source::ReadAtLeast(const MutableBytes& dest, size_t min_size) {
     if (!res)
       return res;
 
-    if (*res == 0)
+    if (*res == 0)  // EOF
       break;
 
     to_read += *res;

--- a/util/accept_server_test.cc
+++ b/util/accept_server_test.cc
@@ -51,10 +51,13 @@ void TestConnection::HandleRequests() {
 
   while (true) {
     size_t res = asa.read_some(boost::asio::buffer(buf), ec);
-    if (ec == std::errc::connection_aborted)
+    if (ec == std::errc::connection_aborted)  // TODO: still holds for macos.
       break;
 
     CHECK(!ec) << ec << "/" << ec.message();
+    if (res == 0)
+      break;
+
     string_view sv(buf, res);
     if (sv == "migrate") {
       ++migrations;

--- a/util/fiber_socket_base.h
+++ b/util/fiber_socket_base.h
@@ -118,11 +118,12 @@ class FiberSocketBase : public io::Sink,
   virtual void CancelOnErrorCb() = 0;
 
   struct RecvNotification {
-    // For pure epoll notifications, this contains a monostate.
+    // For classic recv notifications, this contains RecvCompletion (false on close, true on data).
     // For iouring/bufring notifications, it contains either the positive error code,
     // or the received data buffer. In latter case, the callback must consume the data before
     // returning.
-    std::variant<std::monostate, std::error_code, io::MutableBytes> read_result;
+    using RecvCompletion = bool;
+    std::variant<RecvCompletion, std::error_code, io::MutableBytes> read_result;
   };
 
   using OnRecvCb = std::function<void (const RecvNotification&)>;


### PR DESCRIPTION
Before - we returned ECONNABORTED which is fine but it makes it harder to distinguish between orderly shutdown and irregular states.