### PR TITLE
fix: livelock fix with http connections in epoll mode

### DIFF
--- a/util/accept_server_test.cc
+++ b/util/accept_server_test.cc
@@ -51,7 +51,9 @@ void TestConnection::HandleRequests() {
 
   while (true) {
     size_t res = asa.read_some(boost::asio::buffer(buf), ec);
-    if (ec == std::errc::connection_aborted)  // TODO: still holds for macos.
+
+    // holds for macos or epoll.
+    if (ec == std::errc::connection_aborted || ec == boost::asio::error::eof)
       break;
 
     CHECK(!ec) << ec << "/" << ec.message();

--- a/util/asio_stream_adapter.h
+++ b/util/asio_stream_adapter.h
@@ -46,8 +46,12 @@ size_t AsioStreamAdapter<Socket>::read_some(const MBS& bufs, error_code& ec) {
   badapter bsa(bufs);
 
   auto res = s_.Recv(bsa.buffers(), bsa.count());
-  if (res)
-    return res.value();
+  if (res) {
+    if (*res == 0) {
+      ec = boost::asio::error::eof;
+    }
+    return *res;
+  }
   ec = error_code(std::move(res.error()).value(), boost::system::system_category());
 
   return 0;

--- a/util/http/http_handler.cc
+++ b/util/http/http_handler.cc
@@ -274,7 +274,6 @@ bool HttpListenerBase::HandleRoot(const RequestType& request, HttpContext* cntx)
 }
 
 bool HttpListenerBase::RegisterCb(std::string_view path, RequestCb cb) {
-
   auto res = cb_map_.emplace(path, std::move(cb));
   return res.second;
 }
@@ -366,7 +365,8 @@ void HttpConnection::HandleRequests() {
   }
 
   VLOG(1) << "HttpConnection exit " << ec.message();
-  LOG_IF(INFO, !FiberSocketBase::IsConnClosed(ec)) << "Http error " << ec.message();
+  LOG_IF(INFO, ec != h2::error::end_of_stream && !FiberSocketBase::IsConnClosed(ec))
+      << "Http error " << ec.message();
 }
 
 bool HttpConnection::CheckRequestAuthorization(const RequestType& req, HttpContext* cntx,


### PR DESCRIPTION
Boost beast expects the socket to return eof error upon socket shutdown.