### PR TITLE
fix: crash-bug if we deregister onrecv hook too quickly

### DIFF
--- a/util/fibers/uring_proactor.cc
+++ b/util/fibers/uring_proactor.cc
@@ -544,6 +544,8 @@ UringProactor::EpollIndex UringProactor::EpollAdd(int fd, EpollCB cb, uint32_t e
   entry->index = se.sqe()->user_data;
   se.sqe()->len = IORING_POLL_ADD_MULTI;
 
+  // flush SQEs. Important to avoid data-race with subsequent calls to EpollDel.
+  io_uring_submit(&ring_);
   return reinterpret_cast<EpollIndex>(entry);
 }
 


### PR DESCRIPTION
EpollAdd was asynchronous while EpollDel is synchronous. It is possible that we ask to register EpollAdd but before it actually happenned we try to deregister in the kernel but kernel does not know this id yet.

This PR calls io_submit inside EpollAdd which flashes the SQEs and ensures they are executed immediately.