### PR TITLE
feat(tls): implement async TrySend/TryRecv and event-driven API

### DIFF
--- a/util/tls/tls_socket.cc
+++ b/util/tls/tls_socket.cc
@@ -87,6 +87,7 @@ auto TlsSocket::Shutdown(int how) -> error_code {
   // such interaction happens only during the server shutdown.
   error_code res;
   if (next_sock_->IsOpen()) {
+    next_sock_->ResetOnRecvHook();
     res = next_sock_->Shutdown(how);
   }
   state_ |= SHUTDOWN_DONE;
@@ -222,6 +223,8 @@ io::Result<size_t> TlsSocket::RecvMsg(const msghdr& msg, int flags) {
     }
 
     if (op_val == Engine::NEED_READ_AND_MAYBE_WRITE) {
+      // Flush pending protocol output without attempting another upstream read to avoid blocking
+      // the caller after we already have application data ready.
       error_code flush_ec = MaybeSendOutput();
       if (flush_ec) {
         return make_unexpected(flush_ec);
@@ -358,6 +361,18 @@ auto TlsSocket::MaybeSendOutput() -> error_code {
   return WriteToUpstreamSocket();
 }
 
+auto TlsSocket::MaybeSendOutputAsync() -> error_code {
+  if (engine_->OutputPending() == 0)
+    return {};
+
+  if (state_ & WRITE_IN_PROGRESS) {
+    return make_error_code(errc::resource_unavailable_try_again);
+  }
+
+  StartPendingTrySend();
+  return {};
+}
+
 auto TlsSocket::ReadFromUpstreamSocket() -> error_code {
   if (engine_->OutputPending() != 0) {
     // All TLS operations should make sure that output is flushed before finishing.
@@ -403,6 +418,34 @@ auto TlsSocket::ReadFromUpstreamSocket() -> error_code {
   return error_code{};
 }
 
+error_code TlsSocket::ReadFromUpstreamSocketAsync() {
+  if ((engine_->OutputPending() != 0) && ((state_ & WRITE_IN_PROGRESS) == 0)) {
+    // All TLS operations should make sure that output is flushed before finishing.
+    // If the state machine requested reading, then the output has been flushed,
+    // or there is a concurrent write in progress.
+    RETURN_ON_ERROR(MaybeSendOutputAsync());
+  }
+
+  if (state_ & READ_IN_PROGRESS) {
+    return make_error_code(errc::resource_unavailable_try_again);
+  }
+
+  auto mut_buf{engine_->PeekInputBuf()};
+  state_ |= READ_IN_PROGRESS;
+  io::Result<size_t> esz{next_sock_->TryRecv(mut_buf)};
+  state_ &= ~READ_IN_PROGRESS;
+  block_concurrent_cv_.notify_one();
+  if (!esz) {
+    return esz.error();
+  }
+  if ((*esz) == 0) {
+    return make_error_code(errc::connection_aborted);
+  }
+
+  engine_->CommitInput(*esz);
+  return error_code{};
+}
+
 error_code TlsSocket::WriteToUpstreamSocket() {
   Engine::Buffer buffer = engine_->PeekOutputBuf();
   DCHECK(!buffer.empty());
@@ -441,6 +484,39 @@ error_code TlsSocket::WriteToUpstreamSocket() {
   return ec;
 }
 
+// Low-level function, Try once only, higher level caller maybe loop to retry.
+error_code TlsSocket::WriteToUpstreamSocketAsync() {
+  DCHECK(engine_);
+  error_code ec;
+  Engine::Buffer buffer{engine_->PeekOutputBuf()};
+  DCHECK(!buffer.empty());
+
+  if (buffer.empty())
+    return {};
+
+  // we do not allow concurrent writes from multiple fibers.
+  state_ |= WRITE_IN_PROGRESS;
+  io::Result<size_t> write_result{next_sock_->TrySend(buffer)};
+
+  if (!write_result) {
+    ec = write_result.error();
+    VLOG(1) << "WriteToUpstreamSocketAsync failed: " << ec.message();
+  } else {
+    if ((*write_result) > 0) {
+      upstream_write_ += (*write_result);
+      engine_->ConsumeOutputBuf(*write_result);
+    } else {
+      // No data was written, treat as would_block.
+      ec = make_error_code(std::errc::resource_unavailable_try_again);
+    }
+  }
+
+  state_ &= ~WRITE_IN_PROGRESS;
+  block_concurrent_cv_.notify_one();
+
+  return ec;
+}
+
 error_code TlsSocket::HandleOp(int op_val) {
   switch (op_val) {
     case Engine::EOF_STREAM:
@@ -465,6 +541,29 @@ error_code TlsSocket::HandleOp(int op_val) {
   return {};
 }
 
+error_code TlsSocket::HandleOpAsync(int op_val) {
+  switch (op_val) {
+    case Engine::EOF_STREAM:
+      return make_error_code(errc::connection_aborted);
+    case Engine::NEED_READ_AND_MAYBE_WRITE: {
+      // The TLS engine has generated protocol output (e.g., handshake messages, alerts, or
+      // encrypted data), so we need to flush any pending output to the underlying socket
+      // asynchronously. This ensures protocol progress and prevents stalling or deadlocks,
+      // regardless of the specific operation that triggered this state.
+      auto ec = MaybeSendOutputAsync();
+      if (ec) {
+        return ec;
+      }
+      return ReadFromUpstreamSocketAsync();
+    }
+    case Engine::NEED_WRITE:
+      return MaybeSendOutputAsync();
+    default:
+      LOG(DFATAL) << "Unsupported " << op_val;
+  }
+  return {};
+}
+
 TlsSocket::endpoint_type TlsSocket::LocalEndpoint() const {
   return next_sock_->LocalEndpoint();
 }
@@ -482,26 +581,191 @@ void TlsSocket::CancelOnErrorCb() {
 }
 
 void TlsSocket::RegisterOnRecv(OnRecvCb cb) {
-  LOG(FATAL) << "Not implemented";
+  next_sock_->RegisterOnRecv(
+      [recv_cb = std::move(cb), this](const RecvNotification& rn) { RecvAsync(rn, recv_cb); });
 }
 
-void TlsSocket::ResetOnRecvHook() {
-  LOG(FATAL) << "Not implemented";
+void TlsSocket::RecvAsync(const RecvNotification& rn, const OnRecvCb& recv_cb) {
+  if (std::holds_alternative<FiberSocketBase::RecvNotification::RecvCompletion>(rn.read_result) ||
+      std::holds_alternative<std::error_code>(rn.read_result)) {
+    if (recv_cb) {
+      recv_cb(rn);
+    }
+    return;
+  }
+
+  if (std::holds_alternative<io::MutableBytes>(rn.read_result)) {
+    auto& buf{std::get<io::MutableBytes>(rn.read_result)};
+    auto input_buf{engine_->PeekInputBuf()};
+    CHECK_GE(input_buf.size(), buf.size())
+        << "input_buf too small for memcpy: " << input_buf.size() << " < " << buf.size();
+    std::memcpy(input_buf.data(), buf.data(), buf.size());
+    engine_->CommitInput(buf.size());
+
+    // Loop to read and deliver all available decrypted application data.
+    // Note: app_buf is stack-allocated and only valid during this function's scope.
+    // RecvNotification's buffer must not be accessed after the callback returns.
+    // See fiber_socket_base.h, the comments after struct RecvNotification, for buffer lifetime
+    // contract.
+    static constexpr size_t kAppBufSize = 4096;
+    std::array<uint8_t, kAppBufSize> app_buf{};
+    while (true) {
+      int read_result = engine_->Read(app_buf.data(), app_buf.size());
+      if (read_result > 0) {
+        RecvNotification internal_rn;
+        internal_rn.read_result =
+            io::MutableBytes{app_buf.data(), static_cast<size_t>(read_result)};
+        recv_cb(internal_rn);
+        // Continue looping to deliver all buffered decrypted data to the user-provided callback.
+        continue;
+      } else if ((read_result == Engine::NEED_READ_AND_MAYBE_WRITE) ||
+                 (read_result == Engine::NEED_WRITE)) {
+        auto ec = HandleOpAsync(read_result);
+        if (ec) {
+          // TODO: returning error also for errc::resource_unavailable_try_again.
+          // A future optimization could be to add a subscription mechanism to get notified from the TLS engine
+          // when more decrypted data is available, or from other fibers when READ/WRITE operations complete.
+          // As of now, we expect caller to handle (pre-optimization) errc::resource_unavailable_try_again as well.
+          RecvNotification err_rn;
+          err_rn.read_result = ec;
+          recv_cb(err_rn);
+          break;
+        }
+        // After handling, check if more decrypted data is available and continue loop.
+        continue;
+      } else {
+        // EOF_STREAM (connection closed), 0 (no data read), or unexpected error.
+        if ((read_result != Engine::EOF_STREAM) && (read_result != 0)) {
+          LOG(ERROR) << "RecvAsync: unexpected error from engine_->Read: " << read_result;
+        }
+        break;
+      }
+    }
+  }
 }
 
 io::Result<size_t> TlsSocket::TrySend(io::Bytes buf) {
-  LOG(DFATAL) << "Not implemented";
-  return 0;
+  iovec iov{const_cast<uint8_t*>(buf.data()), buf.size()};
+  return TrySend(&iov, 1);
 }
 
 io::Result<size_t> TlsSocket::TrySend(const iovec* v, uint32_t len) {
-  LOG(DFATAL) << "Not implemented";
-  return 0;
+  size_t total_written = 0;
+  size_t iov_idx = 0;
+  size_t iov_offset = 0;
+
+  // Returns a pair: if the first is true, return immediately with the second.
+  auto should_return_early = [&](error_code ec,
+                                 const char* caller) -> std::pair<bool, io::Result<size_t>> {
+    if (!ec) {
+      return {false, {}};
+    }
+    if (ec == errc::resource_unavailable_try_again) {
+      if (total_written > 0) {
+        return {true, total_written};
+      }
+      return {true, make_unexpected(ec)};
+    }
+    VLOG(1) << caller << " failed " << ec.message();
+    return {true, make_unexpected(ec)};
+  };
+
+  while (iov_idx < len) {
+    // Flush any pending output from previous iterations or previous calls.
+    if (engine_->OutputPending() > 0) {
+      auto ec = MaybeSendOutputAsync();
+      auto [should_return, result] = should_return_early(ec, "MaybeSendOutputAsync");
+      if (should_return)
+        return result;
+    }
+
+    //  Create a temporary iovec (view) representing the unsent portion of the current buffer.
+    //  This allows us to handle partial writes and retries without modifying the original
+    //  iovec array.
+    iovec remaining_iov;
+    remaining_iov.iov_base = static_cast<uint8_t*>(v[iov_idx].iov_base) + iov_offset;
+    remaining_iov.iov_len = v[iov_idx].iov_len - iov_offset;
+    PushResult push_res{PushToEngine(&remaining_iov, 1)};
+    if (push_res.engine_opcode < 0) {
+      auto ec = HandleOpAsync(push_res.engine_opcode);
+      auto [should_return, result] = should_return_early(ec, "HandleOpAsync");
+      if (should_return)
+        return result;
+    }
+
+    if (push_res.written > 0) {
+      size_t written = push_res.written;
+      total_written += written;
+      if (written < remaining_iov.iov_len) {
+        iov_offset += written;
+      } else {
+        ++iov_idx;
+        iov_offset = 0;
+      }
+      // We pushed data, so we likely have output.
+      // The next iteration of the loop will handle flushing it.
+      continue;
+    } else {
+      // No progress made, and no error or special opcode to handle.
+      // Avoid infinite loop: return EAGAIN or partial progress.
+      if (total_written > 0) {
+        return total_written;
+      } else {
+        return make_unexpected(make_error_code(errc::resource_unavailable_try_again));
+      }
+    }
+  }  // while
+
+  // Perform a final attempt to flush any remaining TLS engine output. In async mode, we cannot
+  // enter a loop here - repeatedly flushing would block the fiber and violate async I/O principles.
+  // If the output buffer is still not empty after this call, further flushes must be triggered by
+  // the event loop when the socket becomes writable.
+  error_code ec = MaybeSendOutputAsync();
+  if (ec) {
+    VLOG(1) << "MaybeSendOutputAsync returned error: " << ec.message();
+  }
+
+  return total_written;
 }
 
 io::Result<size_t> TlsSocket::TryRecv(io::MutableBytes buf) {
-  LOG(DFATAL) << "Not implemented";
-  return 0;
+  static constexpr size_t kMaxIterations = 100;  // To prevent infinite loops in edge cases.
+  size_t total_read{}, max_iterations{kMaxIterations};
+  unsigned cnt = 0;
+  while (!buf.empty()) {
+    auto read_result = engine_->Read(buf.data(), buf.size());
+    if (read_result > 0) {
+      buf.remove_prefix(read_result);
+      total_read += read_result;
+      cnt = 0;
+      continue;
+    } else if ((read_result == Engine::NEED_READ_AND_MAYBE_WRITE) ||
+               (read_result == Engine::NEED_WRITE)) {
+      // Prevent infinite loop if the engine is stuck in NEED_READ/WRITE state.
+      if (++cnt > max_iterations) {
+        if (total_read == 0) {
+          return make_unexpected(make_error_code(errc::resource_unavailable_try_again));
+        }
+        break;
+      }
+      auto ec{HandleOpAsync(read_result)};
+      if (ec) {
+        if (ec == errc::resource_unavailable_try_again) {
+          if (total_read == 0) {
+            return make_unexpected(ec);
+          }
+          break;
+        }
+        return make_unexpected(ec);
+      }
+      continue;
+    } else {
+      return make_unexpected(read_result == Engine::EOF_STREAM
+                                 ? make_error_code(std::errc::connection_aborted)
+                                 : make_error_code(std::errc::io_error));
+    }
+  }
+  return total_read;
 }
 
 bool TlsSocket::IsUDS() const {
@@ -551,7 +815,7 @@ void TlsSocket::AsyncReq::MaybeSendOutputAsyncWithRead() {
 
 void TlsSocket::AsyncReq::AsyncReadProgressCb(io::Result<size_t> read_result) {
   owner_->state_ &= ~READ_IN_PROGRESS;
-  RunPending();
+  owner_->ResumeBlockedAsyncReq();
   if (!read_result) {
     // Erroneous path. Apply the completion callback and exit.
     CompleteAsyncReq(read_result);
@@ -657,7 +921,7 @@ void TlsSocket::AsyncReq::AsyncWriteProgressCb(io::Result<size_t> write_result) 
     }
 
     // We are done. Errornous exit.
-    RunPending();
+    owner_->ResumeBlockedAsyncReq();
     CompleteAsyncReq(write_result);
     return;
   }
@@ -685,7 +949,7 @@ void TlsSocket::AsyncReq::AsyncWriteProgressCb(io::Result<size_t> write_result) 
   }
 
   owner_->state_ &= ~WRITE_IN_PROGRESS;
-  RunPending();
+  owner_->ResumeBlockedAsyncReq();
 
   // We are done with the write, check if we also need to read because we are
   // in NEED_READ_AND_MAYBE_WRITE state
@@ -715,6 +979,19 @@ void TlsSocket::AsyncReq::AsyncRoleBasedAction() {
   PushResult push_res = owner_->PushToEngine(vec_, len_);
   Engine::OpResult op_val = push_res.engine_opcode;
   engine_written_ = push_res.written;
+
+  if (engine_written_ > 0) {
+    // Data was successfully written to the TLS engine.
+    // If the engine has pending output (encrypted data to send), flush it asynchronously.
+    if (owner_->engine_->OutputPending() > 0) {
+      WriteToUpstreamSocketAsync();
+      return;
+    }
+    // Otherwise, all output was consumed internally (no flush needed), so complete the request.
+    CompleteAsyncReq(engine_written_);
+    return;
+  }
+
   if (op_val < 0) {
     HandleOpAsync(op_val);
     return;
@@ -734,7 +1011,7 @@ void TlsSocket::AsyncReq::WriteToUpstreamSocketAsync() {
   DCHECK(!buffer.empty());
   DCHECK((owner_->state_ & WRITE_IN_PROGRESS) == 0);
 
-  DVLOG(2) << "StartUpstreamWrite " << buffer.size();
+  DVSOCK(owner_, 2) << "StartUpstreamWrite " << buffer.size();
   // we do not allow concurrent writes from multiple fibers.
   owner_->state_ |= WRITE_IN_PROGRESS;
 
@@ -784,6 +1061,16 @@ void TlsSocket::AsyncWriteSome(const iovec* v, uint32_t len, io::AsyncProgressCb
   async_write_req_ = std::make_unique<AsyncReq>(std::move(req));
   const int op_val = push_res.engine_opcode;
 
+  if (push_res.written > 0) {
+    // Flush engine's output buffer immediately to avoid extra latency.
+    if (engine_->OutputPending() > 0) {
+      async_write_req_->WriteToUpstreamSocketAsync();
+    } else {
+      async_write_req_->HandleOpAsync(push_res.written);
+    }
+    return;
+  }
+
   // Handle engine state.
   // NEED_WRITE or NEED_READ_AND_MAYBE_WRITE or EOF
   if (op_val < 0) {
@@ -796,25 +1083,95 @@ void TlsSocket::AsyncWriteSome(const iovec* v, uint32_t len, io::AsyncProgressCb
   }
 }
 
-void TlsSocket::AsyncReq::RunPending() {
-  if (!owner_->blocked_async_req_) {
+void TlsSocket::ResumeBlockedAsyncReq() {
+  if (!blocked_async_req_) {
     return;
   }
 
-  auto* blocked = std::exchange(owner_->blocked_async_req_, nullptr);
+  auto* blocked = std::exchange(blocked_async_req_, nullptr);
+  DVSOCK(this, 2) << "Resuming blocked req " << blocked;
+
+  // If an async flush error occurred, fail the blocked request immediately.
+  if (try_send_req_.ec) {
+    blocked->CompleteAsyncReq(nonstd::make_unexpected(try_send_req_.ec));
+    return;
+  }
 
   if (blocked->should_read_) {
     blocked->StartUpstreamRead();
     return;
   }
 
-  if (blocked->role_ == Role::WRITER) {
-    auto current = std::move(owner_->async_write_req_);
-    owner_->AsyncWriteSome(current->vec_, current->len_, std::move(current->caller_completion_cb_));
+  if (blocked->role_ == AsyncReq::WRITER) {
+    auto current = std::move(async_write_req_);
+    AsyncWriteSome(current->vec_, current->len_, std::move(current->caller_completion_cb_));
     return;
   }
-  auto current = std::move(owner_->async_read_req_);
-  owner_->AsyncReadSome(current->vec_, current->len_, std::move(current->caller_completion_cb_));
+  auto current = std::move(async_read_req_);
+  AsyncReadSome(current->vec_, current->len_, std::move(current->caller_completion_cb_));
+}
+
+void TlsSocket::StartPendingTrySend() {
+  if (try_send_req_.active) {
+    return;
+  }
+  DVSOCK(this, 2) << "Starting pending TrySend";
+  try_send_req_.active = true;
+  try_send_req_.ec = {};
+  ScheduleTrySendWrite();
+}
+
+void TlsSocket::ScheduleTrySendWrite() {
+  Engine::Buffer buffer = engine_->PeekOutputBuf();
+  if (buffer.empty()) {
+    DVSOCK(this, 2) << "No output buffer to send, finishing pending TrySend";
+    FinishPendingTrySend();
+    return;
+  }
+  DVSOCK(this, 2) << "Scheduling TrySend of " << buffer.size() << " bytes";
+
+  // check WRITE_IN_PROGRESS enforced by MaybeSendOutputAsync/StartPendingTrySend.
+  state_ |= WRITE_IN_PROGRESS;
+  try_send_req_.iov.iov_base =
+      const_cast<uint8_t*>(buffer.data());  // buffer is not modified, cast is safe.
+  try_send_req_.iov.iov_len = buffer.size();
+
+  next_sock_->AsyncWriteSome(&try_send_req_.iov, 1,
+                             [this](io::Result<size_t> res) { HandleTrySendWrite(res); });
+}
+
+void TlsSocket::HandleTrySendWrite(io::Result<size_t> write_result) {
+  if (!write_result) {
+    try_send_req_.ec = write_result.error();
+    DVSOCK(this, 2) << "TrySend write error: " << try_send_req_.ec.message();
+    FinishPendingTrySend();
+    return;
+  }
+  DVSOCK(this, 2) << "TrySend wrote " << *write_result << " bytes";
+  if (*write_result == 0) {
+    DVSOCK(this, 1) << "TrySend write returned 0 bytes, treating as would_block/error";
+    try_send_req_.ec = make_error_code(std::errc::resource_unavailable_try_again);
+    FinishPendingTrySend();
+    return;
+  }
+  upstream_write_ += *write_result;
+  engine_->ConsumeOutputBuf(*write_result);
+
+  ScheduleTrySendWrite();
+}
+
+void TlsSocket::FinishPendingTrySend() {
+  DCHECK(state_ & WRITE_IN_PROGRESS);
+  state_ &= ~WRITE_IN_PROGRESS;
+  if (try_send_req_.ec) {
+    DVSOCK(this, 2) << "Finishing pending TrySend with error: " << try_send_req_.ec.message();
+  } else {
+    DVSOCK(this, 2) << "Finishing pending TrySend successfully";
+  }
+  try_send_req_.active = false;
+  block_concurrent_cv_.notify_one();
+  // Unblock any async request waiting for write to finish.
+  ResumeBlockedAsyncReq();
 }
 
 void TlsSocket::__DebugForceNeedWriteOnAsyncRead(const iovec* v, uint32_t len,

--- a/util/tls/tls_socket.cc
+++ b/util/tls/tls_socket.cc
@@ -729,7 +729,9 @@ io::Result<size_t> TlsSocket::TrySend(const iovec* v, uint32_t len) {
 }
 
 io::Result<size_t> TlsSocket::TryRecv(io::MutableBytes buf) {
-  static constexpr size_t kMaxIterations = 100;  // To prevent infinite loops in edge cases.
+  // TLS engines may require several consecutive Read/Write calls to make progress.
+  // Spinning a few times (e.g., 4) is safe and helps protocol convergence in fibers.
+  static constexpr size_t kMaxIterations = 4;  // To prevent infinite loops in edge cases.
   size_t total_read{}, max_iterations{kMaxIterations};
   unsigned cnt = 0;
   while (!buf.empty()) {


### PR DESCRIPTION
This change introduces robust low-level non-blocking I/O support for TLS sockets, including:

- Implementation of `TrySend` and `TryRecv` methods in `TlsSocket`, enabling efficient, non-blocking, partial I/O with correct TLS state
 handling.
- Addition of `MaybeSendOutputAsync`, `ReadFromUpstreamSocketAsync`, `WriteToUpstreamSocketAsync`, and `HandleOpAsync` helpers to support async flows and proper error propagation.
- Event-driven read support via `RegisterOnRecv` and `RecvAsync`, allowing integration with notification-based I/O and safe delivery of decrypted data to user callbacks.
- All new APIs are fully integrated with the TLS engine and underlying socket, handling protocol output flushing, partial records, and fiber
 concurrency.
- Tests in `tls_socket_test.cc` now cover TrySend, TryRecv, vectorized sends, event-driven reads, and correct error handling, ensuring correctness and robustness of the new async I/O paths.