### PR TITLE
fix(install): update Boost URL to official archive

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-apt install -y cmake libunwind-dev zip bison ninja-build autoconf-archive libtool
-apt install -y curl
+apt install -y cmake libunwind-dev zip bison ninja-build autoconf-archive libtool file curl
 g++ --version
 
 BVER=1.76.0
@@ -17,11 +16,19 @@ install_boost() {
     if ! [ -d $BOOST ]; then
       url="https://archives.boost.io/release/${BVER}/source/$BOOST.tar.bz2"
       echo "Downloading from $url"
-      if ! [ -e $BOOST.tar.bz2 ]; then wget -nv ${url} -O $BOOST.tar.bz2; fi
+
+      if ! [ -e $BOOST.tar.bz2 ]; then
+        if ! wget -nv ${url} -O $BOOST.tar.bz2; then
+          echo "Error: wget failed to download $BOOST.tar.bz2 from $url"
+          rm -f $BOOST.tar.bz2
+          exit 1
+        fi
+      fi
 
       # Check if file is valid bzip2 archive before extracting
       if ! file $BOOST.tar.bz2 | grep -q 'bzip2 compressed data'; then
         echo "Error: Downloaded file is not a valid bzip2 archive. Possible download error."
+        rm -f $BOOST.tar.bz2
         exit 1
       fi
       tar -xjf $BOOST.tar.bz2 && chown ${SUDO_USER}:${SUDO_USER} -R $BOOST.tar.bz2 $BOOST
@@ -38,7 +45,7 @@ install_boost() {
              threading=multi --without-test --without-math --without-log --without-locale --without-wave
              --without-regex --without-python -j4)
 
-    echo "Building targets with ${b2_args[@]}"
+    echo "Building targets with ${b2_args[*]}"
     ./b2 "${b2_args[@]}" cxxflags='-std=c++14 -Wno-deprecated-declarations'
     ./b2 install "${b2_args[@]}" -d0
     chown ${SUDO_USER}:${SUDO_USER} -R ./


### PR DESCRIPTION
The previous Boost download URL was obsolete and failed to fetch the archive. Updated the script to use the official Boost archives site for reliable installation of Boost 1.76.0. This change ensures the script works with the current Boost distribution.