### PR TITLE
fix: pass correct URI to beast::request

### DIFF
--- a/util/aws/http_client.cc
+++ b/util/aws/http_client.cc
@@ -76,10 +76,12 @@ std::shared_ptr<Aws::Http::HttpResponse> HttpClient::MakeRequest(
   CHECK(proactor) << "aws: http client: must run in a proactor thread";
 
   auto uri = request->GetUri();
-  std::string uri_str = uri.GetURLEncodedPath();
-  uri_str += uri.GetQueryString();  // should be prefixed with '?' and url encoded.
+  std::string full_path = uri.GetURLEncodedPath();
+  std::string query = uri.GetQueryString();
+  CHECK(query.empty() || query[0] == '?'); // should be prefixed with '?' and url encoded.
+  full_path += query;
   h2::request<h2::string_body> boost_req{BoostMethod(request->GetMethod()),
-                                         uri_str, kHttpVersion1_1};
+                                         full_path, kHttpVersion1_1};
   for (const auto& h : request->GetHeaders()) {
     boost_req.set(h.first, h.second);
   }


### PR DESCRIPTION
Current code passed scheme and the domain name (aka `https://example.com/foo?bar`) into the URI of the request, while it should have sent only the path part (aka `/foo?bar`).

Fixes most of the issue  https://github.com/dragonflydb/dragonfly/issues/6279

I found additional issues in dragonfly code when loading snapshot from path with prefix containing special characters, which will be addressed separately.

Tested manually with ovhcloud and AWS S3.