### PR TITLE
build(cmake): modernize build system:hardening,LTO & strict mode support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,23 @@ enable_testing()
 # Project Options
 # ------------------------------------------------------------------------------
 
+# Check if this project is the top-level project
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    set(HELIO_IS_TOP_LEVEL ON)
+else()
+    set(HELIO_IS_TOP_LEVEL OFF)
+endif()
+
 # Helio Feature options
-option(HELIO_USE_SANITIZER "Use ASan and USan sanitizers" OFF)
-option(BUILD_DOCS          "Generate documentation" ON)
-option(BUILD_SHARED_LIBS   "Build shared libraries" OFF)
+option(HELIO_USE_SANITIZER  "Use ASan and USan sanitizers" OFF)
+option(BUILD_DOCS           "Generate documentation" ON)
+option(BUILD_SHARED_LIBS    "Build shared libraries" OFF)
+# During migration: Enable the next lines only if helio is top level and not a submodule
+option(HELIO_HARDENED_BUILD "Enable stack protection and fortify source" ${HELIO_IS_TOP_LEVEL})
+option(HELIO_PERFORMANCE_OPTIMIZATIONS "Enable performance optimizations" ${HELIO_IS_TOP_LEVEL})
+# During migration: temporarily disable strict mode by default, until we clean code in the next PR.
+# option(HELIO_STRICT_BUILD   "Enable strict development mode (High warning levels)" ${HELIO_IS_TOP_LEVEL})
+option(HELIO_STRICT_BUILD   "Enable strict development mode (High warning levels)" OFF)
 
 # Platform-specific defaults
 set(WITH_UNWIND_DEFAULT ON)
@@ -52,13 +65,26 @@ include(third_party) # Dependencies second
 # TODO: Remove this wrapper once all subdirectories (and Dragonfly) are
 # migrated to use 'helio_cxx_test' directly.
 function(cxx_test)
-  message(AUTHOR_WARNING "cxx_test() is deprecated, use helio_cxx_test() instead.")
+  # Check if we have already warned about this deprecation
+  get_property(ALREADY_WARNED GLOBAL PROPERTY CXX_TEST_DEPRECATION_WARNED)
+
+  if(NOT ALREADY_WARNED)
+    message(AUTHOR_WARNING "cxx_test() is deprecated, use helio_cxx_test() instead. (This warning is printed only once)")
+    # Mark as warned so future calls stay silent
+    set_property(GLOBAL PROPERTY CXX_TEST_DEPRECATION_WARNED TRUE)
+  endif()
+
   helio_cxx_test(${ARGV})
 endfunction()
 
 # ------------------------------------------------------------------------------
 # Subdirectories
 # ------------------------------------------------------------------------------
+if (HELIO_STRICT_BUILD)
+  # Only our source code gets the strict warning flags
+  helio_set_strict_warnings()
+endif()
+
 add_subdirectory(base)
 add_subdirectory(io)
 add_subdirectory(examples)

--- a/blaze.sh
+++ b/blaze.sh
@@ -3,15 +3,33 @@
 TARGET_BUILD_TYPE=Debug
 BUILD_PREF=build
 BUILD_SUF=dbg
-COMPILER='g++'
 GENERATOR='-GNinja'
 LAUNCHER=$(command -v ccache)
-if [ -x $LAUNCHER ]; then
+# coloring
+NC=$'\e[0m'
+RED=$'\e[0;31m'
+GREEN=$'\e[0;32m'
+if [ -x "$LAUNCHER" ]; then
   echo "Using launcher $LAUNCHER"
   LAUNCHER="-DCMAKE_CXX_COMPILER_LAUNCHER=$LAUNCHER"
 else
   LAUNCHER=''
 fi
+
+# We can't assume a specific compiler is installed, so check for both GCC and Clang
+if command -v g++ >/dev/null 2>&1; then
+    DEFAULT_CXX='g++'
+    DEFAULT_C='gcc'
+elif command -v clang++ >/dev/null 2>&1; then
+    DEFAULT_CXX='clang++'
+    DEFAULT_C='clang'
+else
+    echo -e "${RED}Error: No C++ compiler (g++ or clang++) found in PATH.${NC}"
+    exit 1
+fi
+
+CXX_COMPILER=$(command -v $DEFAULT_CXX)
+C_COMPILER=$(command -v $DEFAULT_C)
 
 for ((i=1;i <= $#;));do
   ARG=${!i}
@@ -22,7 +40,8 @@ for ((i=1;i <= $#;));do
         shift
         ;;
     -clang)
-        COMPILER=`which clang++`
+        CXX_COMPILER=$(command -v clang++)
+        C_COMPILER=$(command -v clang)
         BUILD_PREF=clang
         shift
         ;;
@@ -38,27 +57,42 @@ for ((i=1;i <= $#;));do
       i=$((i + 1))
       ;;
     *)
-     echo bad option "$ARG"
+     echo -e "${RED}bad option $ARG${NC}"
      exit 1
      ;;
   esac
 done
 
 BUILD_DIR=${BUILD_PREF}-${BUILD_SUF}
-
-set -x
-
 result="$(cmake --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
 major="${result%%.*}"
 remainder="${result#*.}"
 minor="${remainder%.*}"
 
-if [ "$major" -lt 3 ] ||
-    ( [ "$major" -eq 3 ] &&
-        ( [ "$minor" -lt 4 ] )) ; then
-    echo "you are using an older version of cmake, need cmake >= 3.4"
+if [[ "$major" -lt 3 || ("$major" -eq 3 && "$minor" -lt 16) ]]; then
+    echo -e "${RED}you are using an older version of cmake, need cmake >= 3.16${NC}"
     exit 1
 fi
 
-cmake -L -B $BUILD_DIR -DCMAKE_BUILD_TYPE=$TARGET_BUILD_TYPE -DCMAKE_CXX_COMPILER=$COMPILER \
-    "$GENERATOR" $LAUNCHER "$@"
+(
+  set -x
+  cmake -L -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=$TARGET_BUILD_TYPE \
+      -DCMAKE_CXX_COMPILER="$CXX_COMPILER" \
+      -DCMAKE_C_COMPILER="$C_COMPILER" \
+      "$GENERATOR" "$LAUNCHER" "$@"
+)
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -eq 0 ]; then
+    echo -e "${GREEN}========================================================"
+    echo " Success!"
+    echo " Build configuration is under: ${BUILD_DIR}"
+    echo " To build, run: ninja -C ${BUILD_DIR}"
+    echo " To inspect build instructions, check: ${BUILD_DIR}/compile_commands.json"
+    echo "========================================================${NC}"
+else
+
+    echo -e "${RED}CMake configuration failed!${NC}"
+fi
+
+exit $EXIT_CODE

--- a/cmake/internal.cmake
+++ b/cmake/internal.cmake
@@ -33,27 +33,28 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(HELIO_MIMALLOC_OPTS "" CACHE STRING "additional mimalloc compile options")
 set(HELIO_MIMALLOC_LIBNAME "libmimalloc.a" CACHE STRING "name of mimalloc library")
+set(HELIO_STRICT_WARNINGS "" CACHE STRING "strict warning compilation flags")
 
 # Compiler detection logic
 set(USING_CLANG OFF)
 set(USING_GCC OFF)
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(USING_CLANG ON)
-endif()
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set(USING_GCC ON)
+else()
+  message(FATAL_ERROR "Helio only supports Clang or GCC. Detected: ${CMAKE_CXX_COMPILER_ID}")
 endif()
 CHECK_CXX_COMPILER_FLAG("-std=${CXX_STD_VERSION}" COMPILER_SUPPORTS_CXX17)
 if(NOT COMPILER_SUPPORTS_CXX17)
-    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no ${CXX_STD_VERSION} support. \
-                         Please use a different C++ compiler.")
+    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no ${CXX_STD_VERSION} support. Please use a different C++ compiler.")
 endif()
 
 message(STATUS "Compiler ${CMAKE_CXX_COMPILER}, version: ${CMAKE_CXX_COMPILER_VERSION}, C++ standard: c++${CMAKE_CXX_STANDARD}")
 
 # ---[ System Probing & Discovery ]---
 # Can not use CHECK_CXX_COMPILER_FLAG due to linker problems.
-set(_OLD_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}") # Save original flags
+set(_ORIG_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}") # Save original flags, used to restore later.
 
 # Check ASAN
 set(CMAKE_REQUIRED_FLAGS "-fsanitize=address")
@@ -63,7 +64,7 @@ check_cxx_source_compiles("int main() { return 0; }" SUPPORT_ASAN)
 set(CMAKE_REQUIRED_FLAGS "-fsanitize=undefined")
 check_cxx_source_compiles("int main() { return 0; }" SUPPORT_USAN)
 
-set(CMAKE_REQUIRED_FLAGS "${_OLD_REQUIRED_FLAGS}") # Restore original flags
+set(CMAKE_REQUIRED_FLAGS "${_ORIG_REQUIRED_FLAGS}")
 
 check_cxx_source_compiles("
 #include <string.h>
@@ -79,86 +80,175 @@ endif()
 # ---[ Flag Configuration ]---
 if (HELIO_USE_SANITIZER)
   # Shared flag for better stack traces (prevents hidden stack frames)
-  set(SAN_COMMON_FLAGS "-fno-optimize-sibling-calls")
+  set(SANITIZERS_COMMON_FLAGS "-fno-optimize-sibling-calls")
 
   # Address Sanitizer (ASan)
   if (SUPPORT_ASAN)
     # Enable ASan + Scope detection
     set(ASAN_FLAGS "-fsanitize=address -fsanitize-address-use-after-scope")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${ASAN_FLAGS} ${SAN_COMMON_FLAGS}")
+    # Split flags into a list to prevent CMake from quoting them as a single invalid argument (both compile and link)
+    string(REPLACE " " ";" _ASAN_LIST "${ASAN_FLAGS} ${SANITIZERS_COMMON_FLAGS}")
+    foreach(_flag ${_ASAN_LIST})
+      add_compile_options($<$<CONFIG:Debug>:${_flag}>)
+    endforeach()
+    string(REPLACE " " ";" _ASAN_LINK_LIST "${ASAN_FLAGS}")
+    foreach(_flag ${_ASAN_LINK_LIST})
+      add_link_options($<$<CONFIG:Debug>:${_flag}>)
+    endforeach()
   endif()
 
-  # Undefined Behavior Sanitizer
+  # Undefined Behavior Sanitizer (UBSan)
   if (SUPPORT_USAN)
     # Enable USan + Force crash on error (no recover)
     set(USAN_FLAGS "-fsanitize=undefined -fno-sanitize-recover=all")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${USAN_FLAGS} ${SAN_COMMON_FLAGS}")
+    # Split flags into a list to prevent CMake from quoting them as a single invalid argument (both compile and link)
+    string(REPLACE " " ";" _USAN_COMPILE_LIST "${USAN_FLAGS} ${SANITIZERS_COMMON_FLAGS}")
+    foreach(_flag ${_USAN_COMPILE_LIST})
+      add_compile_options($<$<CONFIG:Debug>:${_flag}>)
+    endforeach()
+    string(REPLACE " " ";" _USAN_LINK_LIST "${USAN_FLAGS}")
+    foreach(_flag ${_USAN_LINK_LIST})
+      add_link_options($<$<CONFIG:Debug>:${_flag}>)
+    endforeach()
 
     # Clang-specific linker fixes for USan
     if (USING_CLANG)
-      set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} --start-no-unused-arguments --rtlib=compiler-rt --end-no-unused-arguments")
+      add_link_options($<$<CONFIG:Debug>:--start-no-unused-arguments>)
+      add_link_options($<$<CONFIG:Debug>:--rtlib=compiler-rt>)
+      add_link_options($<$<CONFIG:Debug>:--end-no-unused-arguments>)
     endif()
   endif()
 endif()
 
 # ---[ Compiler Specific Flags ]---
 if (USING_CLANG)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wthread-safety -fcolor-diagnostics -Wno-deprecated-copy")
-endif()
+    add_compile_options(-Wthread-safety -fcolor-diagnostics -Wno-deprecated-copy)
+else() # must be GCC
+  add_compile_options(-fdiagnostics-color=always)
 
-if(USING_GCC)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fdiagnostics-color=auto")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")
+  # --- [TEMPORARY MIGRATION FIX] ---
+  # TODO: Remove this once CI workflows are updated to use HELIO_STRICT_BUILD=ON.
+  #
+  # WHY: The current CI explicitly passes global '-Werror' via CMAKE_CXX_FLAGS.
+  # This causes Abseil (3rd party) to fail on GCC due to 'ignored-attributes'.
+  # We suppress this warning specifically to allow the CI to pass until the
+  # global '-Werror' injection is replaced by our target-based strict mode.
+  add_compile_options(-Wno-error=ignored-attributes)
 
-  # Abseil triggers "ignored-attributes" warnings.
-  # Since CI passes -Werror, we must explicitly downgrade this specific warning to non-fatal.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=ignored-attributes")
-
-  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${HELIO_RELEASE_FLAGS}")
-  set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${HELIO_RELEASE_FLAGS}")
+  if(HELIO_RELEASE_FLAGS)
+    add_compile_options($<$<CONFIG:Release>:${HELIO_RELEASE_FLAGS}>)
+  endif()
 endif()
 
 # ---[ Architecture & Base Options ]---
 if (USE_MOLD)
-  find_path(MOLD_PATH ld PATHS /usr/libexec /usr/local/libexec PATH_SUFFIXES mold
-            REQUIRED NO_DEFAULT_PATH)
-  set(LINKER_OPTS "-B${MOLD_PATH}")
+  find_path(MOLD_PATH ld PATHS /usr/libexec /usr/local/libexec PATH_SUFFIXES mold REQUIRED NO_DEFAULT_PATH)
+  add_link_options("-B${MOLD_PATH}")
 endif()
 
 if (NOT MARCH_OPT)
+  # ARM64 (Linux/Server)
   if (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
     set(MARCH_OPT "-march=armv8.2-a+fp16+rcpc+dotprod+crypto")
+  # Intel/AMD x86_64
   elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "amd64")
-    # FreeBSD uses amd64.
-    # Github actions use DSv2 that may use haswell cpus.
-    # We will make it friendly towards older architectures so that will run on developers laptops.
-    # However, we will tune it towards intel skylakes that are common in public clouds.
-    set(MARCH_OPT "-march=sandybridge -mtune=skylake")
+    # Baseline: Haswell (2013).
+    # Why:
+    #   1. Enables AVX2 (Critical for in-memory DB performance).
+    #   2. Safe for GitHub Actions (Azure DSv2 standards).
+    #   3. Safe for 99% of Cloud Instances (AWS c4+, GCP N1+, Azure Dv2+).
+    # TUNING: Skylake (Optimizes instruction scheduling for modern cloud fleets).
+    set(MARCH_OPT "-march=haswell -mtune=skylake")
   elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-    # MacOS on arm64 - TBD.
+    # Target the M1 baseline.
+    # This works perfectly on M1, M2, and M3.
+    # Using -mcpu handles both the Architecture (v8.5+) and Tuning.
+    set(MARCH_OPT "-mcpu=apple-m1")
   elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "s390x")
+    # IBM Mainframe (s390x)
     set(MARCH_OPT "-march=native -mzvector")
   else()
-    MESSAGE(FATAL_ERROR "Unsupported architecture ${CMAKE_SYSTEM_PROCESSOR}")
+    message(FATAL_ERROR "Unsupported architecture ${CMAKE_SYSTEM_PROCESSOR}")
   endif()
 endif()
 
-# Need -fPIC in order to link against shared libraries. For example when creating python modules.
-set(COMPILE_OPTS "-Wall -Wextra -g -fPIC -fno-builtin-malloc -fno-builtin-calloc")
-set(COMPILE_OPTS "${COMPILE_OPTS} -fno-builtin-realloc -fno-builtin-free")
-set(COMPILE_OPTS "${COMPILE_OPTS} -fno-omit-frame-pointer -Wno-unused-parameter")
-set(COMPILE_OPTS "${COMPILE_OPTS} ${MARCH_OPT}")
-set(CMAKE_CXX_FLAGS "${COMPILE_OPTS} ${CMAKE_CXX_FLAGS} ${LINKER_OPTS}")
-set(CMAKE_C_FLAGS "${COMPILE_OPTS} ${CMAKE_C_FLAGS} ${LINKER_OPTS}")
+# Handle March Opt (Split string into list for add_compile_options)
+separate_arguments(_MARCH_LIST UNIX_COMMAND "${MARCH_OPT}")
+
+# Core Global Compiler Options
+# PURPOSE: Sets the critical baseline for debugging, memory override safety, and profiling.
+add_compile_options(
+  # --- Debugging & Observability ---
+  -g                        # Debug Symbols: Essential for core dump analysis and attaching debuggers.
+  -fno-omit-frame-pointer   # Profiling: Keeps the frame pointer. CRITICAL for low-overhead profiling (perf/eBPF) and fast stack unwinding.
+
+  # --- Linking & Compatibility ---
+  -fPIC                     # Position Independent Code: Required for linking against shared libraries (e.g., Python extensions).
+
+  # --- Memory Management ---
+  # Prevent the compiler from optimizing out standard allocator calls.
+  # CRITICAL: We likely use a custom allocator (jemalloc/mimalloc). We cannot let the compiler assume libc behavior here.
+  -fno-builtin-malloc
+  -fno-builtin-calloc
+  -fno-builtin-realloc
+  -fno-builtin-free
+
+  # --- Warnings & Hygiene ---
+  -Wall -Wextra             # Hygiene: Enable standard warning sets to catch common errors.
+  -Wno-unused-parameter     # Noise Reduction: Suppress warnings for unused args (common in callback-heavy network code).
+
+  # --- Architecture ---
+  ${_MARCH_LIST}            # Hardware Tuning: Apply specific CPU optimizations (e.g., -march=native).
+)
+
 add_compile_definitions(USE_FB2)
 
-IF(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  MESSAGE (CXX_FLAGS " ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}")
-ELSEIF(CMAKE_BUILD_TYPE STREQUAL "Release")
-  MESSAGE (CXX_FLAGS " ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE}")
-ELSE()
-  MESSAGE(FATAL_ERROR "Unsupported build type '${CMAKE_BUILD_TYPE}' or not specified. Use Debug or Release.")
-ENDIF()
+# ---[ Runtime Hardening (Security & Stability) ]---
+if(HELIO_HARDENED_BUILD AND NOT HELIO_USE_SANITIZER)
+    message(STATUS "Applying hardened build options (stack protection, fortify source, control flow protection)")
+
+    # Stack Protector: The "Seatbelt"
+    # prevents: The #1 most common attack (Stack Buffer Overflow).
+    # why: If a buffer overflows, the program crashes immediately instead of letting an attacker hijack execution.
+    # cost: Negligible (<1%). Modern CPUs predict this check perfectly.
+    add_compile_options(-fstack-protector-strong)
+
+    # Fortify Source: The "Standard Library Guard"
+    # prevents: Silent memory corruption in standard functions (memcpy, strcpy, sprintf).
+    # why: Turns "undefined behavior" (random crashes later) into an immediate, traceable abort at the source of the bug.
+    # cost: Zero. It optimizes into safer instructions at compile-time.
+    # note: Only active in optimized builds (Release/RelWithDebInfo).
+    #       Ignored in Debug (-O0) to prevent warnings/errors.
+    add_compile_definitions($<$<NOT:$<CONFIG:Debug>>:_FORTIFY_SOURCE=2>)
+
+    # Control Flow Protection (CET): The "Hardware Lock"
+    # prevents: Advanced ROP/JOP attacks (reusing your own code chunks against you).
+    # why: Uses CPU hardware to verify function calls and returns match.
+    # cost: Harmless NOPs on older CPUs; full hardware protection on modern Intel/AMD CPUs.
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
+      add_compile_options(-fcf-protection=full)
+    endif()
+endif()
+
+# ---[ Performance Optimizations ]---
+if(HELIO_PERFORMANCE_OPTIMIZATIONS)
+    message(STATUS "Applying Release performance optimizations (LTO, Architecture tuning)")
+
+    # Link Time Optimization (LTO)
+    # why: Breaks the "translation unit" barrier. Allows the compiler to inline functions
+    #      across .cpp files (e.g., inlining a hot helper from utility.cc into main.cc).
+    # result: Massively reduces function call overhead in fiber/template-heavy code.
+    #         Often yields 10-20% higher throughput for CPU-bound stores.
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT result OUTPUT output)
+    if(result)
+        message(STATUS "LTO enabled: Enabling whole-program optimization")
+        add_compile_options($<$<CONFIG:Release>:-flto>)
+        add_link_options($<$<CONFIG:Release>:-flto>)
+    else()
+        message(WARNING "LTO not supported: ${output}")
+    endif()
+endif()
 
 # ---[ Helper Functions ]---
 set(ROOT_GEN_DIR ${CMAKE_SOURCE_DIR}/genfiles)
@@ -166,8 +256,7 @@ file(MAKE_DIRECTORY ${ROOT_GEN_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${ROOT_GEN_DIR})
 
 macro(add_include target)
-  set_property(TARGET ${target}
-               APPEND PROPERTY INCLUDE_DIRECTORIES ${ARGN})
+  set_property(TARGET ${target} APPEND PROPERTY INCLUDE_DIRECTORIES ${ARGN})
 endmacro()
 
 macro(add_compile_flag target)
@@ -176,14 +265,13 @@ endmacro()
 
 function(cxx_link target)
   CMAKE_PARSE_ARGUMENTS(parsed "" "" "DATA" ${ARGN})
-
   if (parsed_DATA)
     # symlink data files into build directory
     set(run_dir "${CMAKE_BINARY_DIR}/${target}.runfiles")
     foreach (data_file ${parsed_DATA})
       get_filename_component(src_full_path ${data_file} ABSOLUTE)
       if (NOT EXISTS ${src_full_path})
-        Message(FATAL_ERROR "Can not find ${src_full_path} when processing ${target}")
+        message(FATAL_ERROR "Can not find ${src_full_path} when processing ${target}")
       endif()
       set(target_data_full "${run_dir}/${data_file}")
       get_filename_component(target_data_folder ${target_data_full} PATH)
@@ -209,8 +297,12 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
 function(helio_cxx_test path)
   get_filename_component(name ${path} NAME)
   add_executable(${name} ${path}.cc)
-  CMAKE_PARSE_ARGUMENTS(parsed "" "" "LABELS" ${ARGN})
 
+  if(HELIO_STRICT_WARNINGS)
+    target_compile_options(${name} PRIVATE ${HELIO_STRICT_WARNINGS})
+  endif()
+
+  CMAKE_PARSE_ARGUMENTS(parsed "" "" "LABELS" ${ARGN})
   if (NOT parsed_LABELS)
     set(parsed_LABELS "unit")
   endif()
@@ -227,4 +319,58 @@ function(helio_cxx_test path)
   endforeach(_label)
   SET_PROPERTY(GLOBAL PROPERTY "test_list_property" "${cur_list}")
   add_dependencies(check ${name})
+endfunction()
+
+function(helio_add_executable target_name)
+  add_executable(${target_name} ${ARGN})
+  if(HELIO_STRICT_WARNINGS)
+    target_compile_options(${target_name} PRIVATE ${HELIO_STRICT_WARNINGS})
+  endif()
+endfunction()
+
+function(helio_add_library target_name)
+  add_library(${target_name} ${ARGN})
+  if(HELIO_STRICT_WARNINGS)
+    target_compile_options(${target_name} PRIVATE ${HELIO_STRICT_WARNINGS})
+  endif()
+endfunction()
+
+# Calculates the list of strict warning flags
+# Configures the "Strict Mode" warning set.
+# PURPOSE: Enforces high code quality standards by turning potential bugs (shadowing,
+#          implicit conversions, unsafe casts) into build errors.
+# NOTE: These are applied specifically to 'helio' targets, distinct from global third-party flags.
+function(helio_set_strict_warnings)
+
+  set(_flags
+      # basic warnings
+      -Werror               # Zero Tolerance: Treat all warnings as build errors.
+      -Wall                 # Enable most standard compiler warnings.
+      -Wextra               # Enable extra warnings not covered by -Wall.
+      -Wpedantic            # Enforce strict ISO C++ compliance (no non-standard extensions).
+      # safety & correctness
+      -Wshadow              # Critical: Prevents local variables from hiding member variables (common bug source).
+      -Wnon-virtual-dtor    # OOP Safety: Warns if a class has virtual functions but a non-virtual destructor (prevents leaks).
+      -Woverloaded-virtual  # OOP Safety: Warns if a function hides a virtual function in the base class.
+      -Wunused              # Hygiene: Warns about unused variables, parameters, and functions.
+      # type safety & casting
+      -Wold-style-cast      # Modern C++: Forbids C-style `(int)x` casts. Forces explicit `static_cast<int>(x)`.
+      -Wcast-align          # Hardware Safety: Warns when casting a pointer increases alignment requirements (crashes on ARM).
+      # numeric safety (critical for data stores)
+      -Wconversion          # Data Integrity: Warns on implicit conversions that may lose data (e.g., long to int).
+      -Wsign-conversion     # Data Integrity: Warns on implicit mixed signed/unsigned math (common source of underflows).
+      -Wdouble-promotion    # Performance: Warns when `float` is implicitly promoted to `double` (slower on some FPU/SIMD).
+      # security
+      -Wformat=2            # Security: Strong checks for printf-style format strings (prevents injection attacks).
+  )
+
+  # Sanity Check: When running Sanitizers (ASan/TSan), we disable -Werror. Sanitizers often inject code or
+  # trigger warnings that are false positives during the instrumentation phase.
+  # We want to see the runtime sanitizer report, not fail the build on a compiler warning.
+  if(HELIO_USE_SANITIZER)
+    list(REMOVE_ITEM _flags "-Werror")
+  endif()
+
+  set(HELIO_STRICT_WARNINGS "${_flags}" PARENT_SCOPE)
+  message(STATUS "Strict warning flags set: ${_flags}")
 endfunction()

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -250,6 +250,9 @@ if(NOT abseil_cpp_POPULATED)
   # and then restore it if we use it ourselves.
   set(CMAKE_CXX_FLAGS_RELEASE_OLD ${CMAKE_CXX_FLAGS_RELEASE})
   set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
+  # Treat Abseil source directory as a System Include Directory, to suppress warnings generated on strict builds when
+  # abseil headers are included in our own code.
+  include_directories(SYSTEM ${abseil_cpp_SOURCE_DIR})
   add_subdirectory(${abseil_cpp_SOURCE_DIR} ${abseil_cpp_BINARY_DIR})
   set(CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE_OLD})
 endif()


### PR DESCRIPTION
This is the 2nd PR commit to that tries to modernize the build system in small steps. Refactors the build system to align with modern CMake practices, enhances security defaults, and prepares the codebase for stricter compliance.

**Performance & Architecture:**
* Upgrades the default x86_64 baseline from `sandybridge` to `haswell` to leverage AVX2 instructions.
* Adds specific support for Apple Silicon with `-mcpu=apple-m1`.
* Introduces `HELIO_PERFORMANCE_OPTIMIZATIONS` (default ON for top-level builds) to enable Link Time Optimization (LTO) in Release mode.

**Security Hardening:**
* Introduces `HELIO_HARDENED_BUILD` (default ON for top-level builds).
* Enables `-fstack-protector-strong` and `-fcf-protection=full` (Intel CET) for stack and control flow safety.
* Enables `_FORTIFY_SOURCE=2` for Release builds to prevent memory corruption in standard functions.

**Strict Mode & Quality:**
* Implements `helio_set_strict_warnings()` covering `-Wshadow`, `-Wconversion`, `-Wcast-align`, and `-Werror`.
* Adds `HELIO_STRICT_BUILD` option. Defaults to `OFF` temporarily to allow for a smooth migration before enforcing strict warnings globally.
* Updates `helio_cxx_test`, `helio_add_executable`, and `helio_add_library` to respect the strict warning configuration.
* Marks Abseil headers as `SYSTEM` includes in `third_party.cmake` to suppress external warnings.

**Fixes & Modernization:**
* Fixes a critical bug in Sanitizer flag handling where flags with spaces were incorrectly quoted, causing build failures.
* Modernizes flag application using `add_compile_options` and `add_link_options` instead of legacy string concatenation.
* Updates `blaze.sh` with better compiler detection (`command -v`), colorized output, and clearer success/failure reporting.