### PR TITLE
fix(tls): improve socket shutdown and concurrency safety

### DIFF
--- a/util/tls/tls_socket.h
+++ b/util/tls/tls_socket.h
@@ -132,6 +132,10 @@ class TlsSocket final : public FiberSocketBase {
   // just with the engine. It's up to the caller to send the output buffer to the network.
   PushResult PushToEngine(const iovec* ptr, uint32_t len);
 
+  // Wait for any in-progress read/write operations to complete.
+  // They will return with errors now that the socket is shut down.
+  void WaitForPendingIO();
+
   /// Feed encrypted data from the TLS engine into the network socket.
   error_code MaybeSendOutput();
 
@@ -149,9 +153,10 @@ class TlsSocket final : public FiberSocketBase {
 
   enum {
     WRITE_IN_PROGRESS = 1,
-    READ_IN_PROGRESS = 2,
-    SHUTDOWN_IN_PROGRESS = 4,
-    SHUTDOWN_DONE = 8,
+    READ_IN_PROGRESS = 1 << 1,
+    SHUTDOWN_IN_PROGRESS = 1 << 2,
+    SHUTDOWN_DONE = 1 << 3,
+    USER_RECV_IN_PROGRESS = 1 << 4,
   };
   uint8_t state_{0};
 


### PR DESCRIPTION
* Added waiting for in-progress read/write operations during Shutdown and Close to prevent race conditions and unblock sync operations.

* Introduced USER_RECV_IN_PROGRESS flag to detect and prevent concurrent Recv and TryRecv calls, logging usage errors and returning operation_in_progress.

* Refactored TryRecv to handle internal read conflicts as resource contention, returning EAGAIN instead of crashing.

* Implemented RAII-style cleanup (using absl::MakeCleanup) in andleUpstreamRead to ensure the READ_IN_PROGRESS flag is strictly cleared even if the fiber is cancelled or throws, preventing permanent deadlocks.

* Updated tests to join AcceptFb before RegisterOnRecv to avoid deadlocks and ensure proper event handling.

* Improved logging and error handling in test fibers for better diagnostics.

* Addressed additional concurrency and event notification issues found during test runs, ensuring stable and correct behavior under fiber contention.