### PR TITLE
chore: Implement support for bundles and incremental buffers.

### DIFF
--- a/tests/test_echo_server.py
+++ b/tests/test_echo_server.py
@@ -205,3 +205,21 @@ def test_echo_server_custom_size(echo_server):
     if echo_server.size is not None:
         client_flags = ["--size", str(echo_server.size)]
     echo_server.assert_client_ok(client_args=client_flags)
+
+
+@pytest.mark.server_args(["--multishot", "--size", "50"])
+def test_echo_server_multishot_size_50(echo_server):
+    client_flags = []
+    if echo_server.size is not None:
+        client_flags = ["--size", str(echo_server.size)]
+    echo_server.assert_client_ok(client_args=client_flags)
+
+
+@pytest.mark.server_args(["--multishot", "--size", "50", "--p", "32", "--bufring_size", 
+                          "512"])
+def test_echo_server_multishot_pipeline(echo_server):
+    client_flags = []
+    if echo_server.size is not None:
+        client_flags = ["--size", str(echo_server.size)]
+    for _ in range(10):
+        echo_server.assert_client_ok(client_args=client_flags)


### PR DESCRIPTION
See https://github.com/axboe/liburing/wiki/What's-new-with-io_uring-in-6.11-and-6.12 for incremental buffers explanation and https://github.com/axboe/liburing/wiki/What's-new-with-io_uring-in-6.10 for bundles.

The feature is integrated with RegisterOnRecv.

One last major thing that is left unsolved is the issue of memory management, or what happens when we are out of provided buffers.