### PR TITLE
fix(tls): synchronize Close with concurrent Shutdown

### DIFF
--- a/util/tls/tls_socket.h
+++ b/util/tls/tls_socket.h
@@ -132,10 +132,6 @@ class TlsSocket final : public FiberSocketBase {
   // just with the engine. It's up to the caller to send the output buffer to the network.
   PushResult PushToEngine(const iovec* ptr, uint32_t len);
 
-  // Wait for any in-progress read/write operations to complete.
-  // They will return with errors now that the socket is shut down.
-  void WaitForPendingIO();
-
   /// Feed encrypted data from the TLS engine into the network socket.
   error_code MaybeSendOutput();
 


### PR DESCRIPTION
Ensure that Close() acts as a synchronization barrier that waits for any concurrent Shutdown() operations to complete. This prevents a race condition where the TlsSocket could be destroyed while the shutdown fiber is still active, which previously led to destructor assertion failures.

Key changes:

- Modified Shutdown() to notify block_concurrent_cv_ upon completion and flag clearance.

- Updated Close() to wait on block_concurrent_cv_ if SHUTDOWN_IN_PROGRESS is set, ensuring the "killer" fiber has finished its cleanup.

- Inline WaitForPendingIO() logic into Shutdown() and Close() to support specific wait conditions for each lifecycle stage.