### PR TITLE
fix(fibers): long active run tracking

### DIFF
--- a/util/fibers/detail/fiber_interface.h
+++ b/util/fibers/detail/fiber_interface.h
@@ -249,10 +249,16 @@ class FiberInterface {
 
   uint64_t GetRunningTimeCycles() const;
 
-  void SetRunQueueStart() {
-    cpu_tsc_ = base::CycleClock::Now();
+  void SetReadyStart() {
+    ready_tsc_ = base::CycleClock::Now();
   }
 
+  // Sets the start of the CPU time measurement for active fiber.
+  // Used externally for dispatch fiber only when it is activated after being blocked on
+  // I/O wait.
+  void SetCpuStart() {
+    cpu_tsc_ = base::CycleClock::Now();
+  }
  protected:
   static constexpr uint16_t kTerminatedBit = 0x1;
   static constexpr uint16_t kBusyBit = 0x2;
@@ -294,8 +300,10 @@ class FiberInterface {
   // used for sleeping with a timeout. Specifies the time when this fiber should be woken up.
   std::chrono::steady_clock::time_point tp_;
 
-  // A timestamp counter when this fiber became ready,active or got suspended (in cycles).
+  // A timestamp counter when this fiber became active or suspended (in cycles).
   uint64_t cpu_tsc_ = 0;
+  uint64_t ready_tsc_ = 0;
+
   char name_[24];
   FiberPriority prio_;
   uint32_t stack_size_ = 0;

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -269,6 +269,7 @@ void Scheduler::AddReady(FiberInterface* fibi, bool to_front) {
 
   unsigned q_idx = GetQueueIndex(fibi->prio_);
 
+  fibi->SetReadyStart();
   if (to_front) {
     ready_queue_[q_idx].push_front(*fibi);
   } else {
@@ -438,7 +439,6 @@ bool Scheduler::ProcessRemoteReady(FiberInterface* active) {
     // i.e. when fi is already active. In that case we should not add it to the ready queue.
     if (fi != active && !fi->list_hook.is_linked()) {
       DVLOG(2) << "set ready " << fi->name();
-      fi->SetRunQueueStart();
       AddReady(fi, fi->prio_ == FiberPriority::HIGH /* to_front */);
     }
   }
@@ -462,7 +462,7 @@ unsigned Scheduler::ProcessSleep() {
 
     DCHECK(!fi.list_hook.is_linked());
     fi.tp_ = chrono::steady_clock::time_point::max();  // meaning it has timed out.
-    fi.SetRunQueueStart();
+    fi.SetReadyStart();
     ready_queue_[GetQueueIndex(fi.prio_)].push_back(fi);
     FIBER_TRACE(&fi, TRACE_SLEEP_WAKE);
     ++result;


### PR DESCRIPTION
Before we had several bugs:
1. We used the same cpu_tsc_ for tracking latency of ready queue and active state. The problem is that in case we yield (or dispatch fiber switches to other fibers) we first add ourselves to the ready queue, which overrides cpu_tsc_. Later, when we measure (now-cpu_tsc_) to see if a fiber run for a long time, in practice we measured the time since it was added to ReadyQueue. To fix this we intoduce a dedicated ready_tsc_ counter.
2. When dispatch fiber was blocked on I/O we did not reset cpu_tsc_, so when it switched to other fibers, the I/O block time was accounted for its running time, and was wrongly printed as a warning with `--fiber_run_warning_threshold_ms=1` or when increasing `long_runtime_cnt` metric.