### PR TITLE
fix: disable false iowait accounting in uring_proactor

### DIFF
--- a/util/fibers/uring_proactor.cc
+++ b/util/fibers/uring_proactor.cc
@@ -225,6 +225,23 @@ void UringProactor::Init(unsigned pool_index, size_t ring_size, int wq_fd) {
     LOG(FATAL) << "Error initializing io_uring: (" << init_res << ") "
                << SafeErrorMessage(init_res);
   }
+  // A new io_uring_set_iowait() liburing function allows userspace to disable iowait accounting per ring.
+  // If enable_iowait is set to false, the submit functions will set IORING_ENTER_NO_IOWAIT in the flags to io_uring_enter().
+  // The kernel signals support via IORING_FEAT_NO_IOWAIT feature flag. Available since kernel 6.15.
+  // If kernel does not support IORING_FEAT_NO_IOWAIT, then io_uring_set_iowait will return -EINVAL
+  // and we will fallback to default behavior with iowait enabled.
+  if (init_res == 0 && (params.features & IORING_FEAT_NO_IOWAIT)) {
+    int iowait_res = io_uring_set_iowait(&ring_, 0);
+    if (iowait_res < 0) {
+      iowait_res = -iowait_res;
+      if (iowait_res == EINVAL) {
+        VLOG(1) << "io_uring_set_iowait not supported by kernel, falling back to default iowait behavior";
+      } else {
+        LOG(WARNING) << "io_uring_set_iowait failed: (" << iowait_res << ") "
+                     << SafeErrorMessage(iowait_res);
+      }
+    }
+  }
 
   io_uring_probe* uring_probe = io_uring_get_probe_ring(&ring_);
 


### PR DESCRIPTION
## Problem

DragonflyDB use Helio as core part for io_uring operations. When DragonflyDB starts, mpstat reports ~100% iowait per proactor thread
even with zero actual disk I/O. This is a false positive caused by the
kernel's iowait accounting mechanism.

**Root cause:** proactor threads sleep in `io_uring_enter()` waiting for
network/timer events. The kernel sets `in_iowait=1` whenever a task sleeps
with pending io_uring requests, and charges all idle CPU time as iowait
instead of idle — even though no block I/O is involved.

**Observed behavior:**
```
# mpstat with proactor_threads=2, dragonfly idle, zero disk I/O:
CPU 0:  iowait=100%
CPU 1:  iowait=100%

# iostat simultaneously:
vda   r/s=0.00   w/s=0.00   # no actual I/O
```

## Fix

Kernel 6.15 introduced `IORING_FEAT_NO_IOWAIT` which allows userspace to
disable iowait accounting per ring via `io_uring_set_iowait()`. Since
DragonflyDB uses io_uring for network and timers — not block I/O — iowait
accounting is incorrect and should be disabled.

The fix is conditional: silently skipped on kernels older than 6.15.

## Testing

- Debian 13 amd64
- kernel 6.19 debian backports
- liburing 2.14
- iowait dropped from ~99% to 0% per proactor thread at idle
- no performance regression observed

## References

- `IORING_FEAT_NO_IOWAIT` added in kernel 6.15
- `io_uring_set_iowait()` available since liburing 2.10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced async I/O configuration on Linux systems with improved compatibility for kernel feature detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->