### PR TITLE
feat(fibers): add persistent EventCount waiters

### DIFF
--- a/util/fibers/detail/wait_queue.cc
+++ b/util/fibers/detail/wait_queue.cc
@@ -37,7 +37,20 @@ bool WaitQueue::NotifyOne(FiberInterface* active) {
 
   Waiter* waiter = &wait_list_.front();
   DCHECK(waiter) << wait_list_.empty();
-  wait_list_.pop_front();
+
+  // A persistent waiter at the front will always be selected by NotifyOne().
+  // If other waiters are queued behind it, they will be starved because the persistent waiter never
+  // leaves the front of the line. Persistent subscriptions are intended for notifyAll() broadcasts.
+  DCHECK(!waiter->is_persistent() || &wait_list_.front() == &wait_list_.back())
+      << "NotifyOne on a persistent waiter with others queued behind it causes starvation. "
+         "Use notifyAll() with persistent waiters.";
+
+  // If the waiter is one-shot (default), remove it from the list before
+  // notification. If it is persistent, leave it at the front so it can
+  // receive subsequent notifications until explicitly unlinked.
+  if (!waiter->is_persistent()) {
+    wait_list_.pop_front();
+  }
 
   waiter->Notify(active);  // lifetime might end after this call
   return true;
@@ -45,8 +58,23 @@ bool WaitQueue::NotifyOne(FiberInterface* active) {
 
 bool WaitQueue::NotifyAll(FiberInterface* active) {
   bool notified = false;
-  while (NotifyOne(active))
+  auto it = wait_list_.begin();
+
+  // Note: No iterator invalidation here (waiter.Notify() is safe while iterating)
+  // - For fiber-based (one-shot) waiters, ActivateOther() only enqueues the fiber on the ready
+  // queue without yielding, so no notified fiber runs during this loop.
+  // - For callback-based (persistent) waiters, the iterator is advanced before Notify(), so even if
+  // the callback modifies *this* waiter's linkage, the iterator remains valid.
+  while (it != wait_list_.end()) {
+    Waiter& waiter = *it;
+    if (waiter.is_persistent()) {
+      ++it;
+    } else {
+      it = wait_list_.erase(it);
+    }
+    waiter.Notify(active);
     notified = true;
+  }
   return notified;
 }
 

--- a/util/fibers/detail/wait_queue.h
+++ b/util/fibers/detail/wait_queue.h
@@ -16,7 +16,21 @@ namespace detail {
 
 class FiberInterface;
 
-// Event subscription object for either fiber wakeups or generic events
+// Waiter represents a pending notification interest in a WaitQueue. It encapsulates
+// either a suspended FiberInterface (to be resumed) or a synchronous Callback (to be
+// executed). Waiters use intrusive list linkage to avoid allocations during synchronization.
+//
+// Subscription modes:
+// - One-shot (default): Waiter is unlinked before notification. Standard behavior for
+//   mutexes and condition variables where each waiter expects exactly one wakeup.
+// - Persistent: Waiter remains linked after notification. Used for long-lived observers
+//   that need to receive multiple events (e.g., backpressure bridges, event multiplexers).
+//
+// Invariant for persistent waiters:
+// Persistent waiters are intended for broadcast scenarios (NotifyAll). A persistent waiter
+// at the front of the queue will consume every NotifyOne() call, starving any waiters queued behind
+// it. Do NOT mix persistent and one-shot waiters on the same WaitQueue if NotifyOne() will be used.
+// Use separate WaitQueues or only use NotifyAll() for persistent subscriptions.
 class Waiter {
   friend class FiberInterface;
   explicit Waiter(FiberInterface* cntx) : cntx_(cntx) {
@@ -31,11 +45,12 @@ class Waiter {
 
   // For some boost versions/distributions, the default move c'tor does not work well,
   // so we implement it explicitly.
-  Waiter(Waiter&& o) : cntx_{std::move(o.cntx_)} {
+  Waiter(Waiter&& o) : cntx_{std::move(o.cntx_)}, persistent_{o.persistent_} {
     // it does not work well for slist because its reference is used by slist members
     // (probably when caching last).
     o.wait_hook.swap_nodes(wait_hook);
     o.cntx_ = static_cast<FiberInterface*>(nullptr);
+    o.persistent_ = false;
   }
 
   // safe_link is used in assertions via IsLinked() method.
@@ -44,6 +59,16 @@ class Waiter {
 
   bool IsLinked() const {
     return wait_hook.is_linked();
+  }
+
+  // Persistent waiters are NOT unlinked by WaitQueue::NotifyOne() or
+  // WaitQueue::NotifyAll(). Their callback is fired but they remain in the queue.
+  bool is_persistent() const {
+    return persistent_;
+  }
+
+  void set_persistent(bool v) {
+    persistent_ = v;
   }
 
   void Notify(FiberInterface* active) const;
@@ -55,6 +80,7 @@ class Waiter {
   void NotifyImpl(const Callback&, FiberInterface* active) const;
 
   std::variant<FiberInterface*, Callback> cntx_;
+  bool persistent_ = false;
 };
 
 // Intrusive list of non-owned waiter objects.

--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -1147,5 +1147,183 @@ TEST_F(FiberTest, SimpleChannelPopRace) {
   }
 }
 
+//
+// Persistent Waiter Tests ---
+//
+
+// Basic persistence - notifyAll fires callback multiple times, waiter stays linked.
+TEST_F(FiberTest, PersistentWaiterNotifyAll) {
+  EventCount ec;
+  unsigned counter{};
+  auto cb = [&counter] { ++counter; };
+  detail::Waiter waiter{cb};
+
+  auto sub = ec.subscribe_persistent(&waiter);
+  EXPECT_TRUE(waiter.IsLinked());
+
+  ec.notifyAll();
+  ec.notifyAll();
+  ec.notifyAll();
+
+  EXPECT_EQ(counter, 3u);
+  EXPECT_TRUE(waiter.IsLinked());
+  EXPECT_TRUE(waiter.is_persistent());
+}
+
+// SubKey RAII - destruction unlinks and resets persistent flag.
+TEST_F(FiberTest, PersistentWaiterSubKeyRAII) {
+  EventCount ec;
+  unsigned counter{};
+  auto cb = [&counter] { ++counter; };
+  detail::Waiter waiter{cb};
+
+  {
+    auto sub = ec.subscribe_persistent(&waiter);
+    EXPECT_TRUE(waiter.IsLinked());
+    EXPECT_TRUE(waiter.is_persistent());
+
+    ec.notifyAll();
+    EXPECT_EQ(counter, 1u);
+  }  // SubKey destroyed here
+
+  EXPECT_FALSE(waiter.IsLinked());
+  EXPECT_FALSE(waiter.is_persistent());
+
+  // Subsequent notifications must not reach the unlinked waiter.
+  ec.notifyAll();
+  EXPECT_EQ(counter, 1u);
+}
+
+// notify() on a single persistent waiter - no starvation DCHECK.
+TEST_F(FiberTest, PersistentWaiterNotifyOneSingle) {
+  EventCount ec;
+  unsigned counter{};
+  auto cb = [&counter] { ++counter; };
+  detail::Waiter waiter{cb};
+
+  auto sub = ec.subscribe_persistent(&waiter);
+
+  // Only one waiter in the queue: &front == &back, so no DCHECK fires.
+  ec.notify();
+  ec.notify();
+
+  EXPECT_EQ(counter, 2u);
+  EXPECT_TRUE(waiter.IsLinked());
+}
+
+// Mixed queue via notifyAll - persistent stays, one-shot fiber wakes.
+TEST_F(FiberTest, PersistentWaiterMixedNotifyAll) {
+  EventCount ec;
+  unsigned persistent_count{};
+  auto cb = [&persistent_count] { ++persistent_count; };
+  detail::Waiter waiter{cb};
+
+  auto sub = ec.subscribe_persistent(&waiter);
+
+  bool fiber_woke{false};
+  Fiber fb(Launch::dispatch, "oneshot", [&] {
+    ec.await([&] { return fiber_woke; });
+  });
+
+  // Both waiters are now in the queue. Fire notifyAll.
+  fiber_woke = true;
+  ec.notifyAll();
+
+  fb.Join();
+
+  // Persistent waiter got the notification, one-shot fiber completed.
+  EXPECT_GE(persistent_count, 1u);
+  EXPECT_TRUE(waiter.IsLinked());
+}
+
+// SubKey move semantics - ownership transfers correctly.
+TEST_F(FiberTest, PersistentWaiterSubKeyMove) {
+  EventCount ec;
+  unsigned counter{};
+  auto cb = [&counter] { ++counter; };
+  detail::Waiter waiter{cb};
+
+  std::optional<EventCount::SubKey> holder;
+  {
+    auto sub = ec.subscribe_persistent(&waiter);
+    holder.emplace(std::move(sub));
+    // Original sub is moved-from; waiter must still be linked via holder.
+  }
+
+  EXPECT_TRUE(waiter.IsLinked());
+  ec.notifyAll();
+  EXPECT_EQ(counter, 1u);
+
+  // Destroy holder - should unlink.
+  holder.reset();
+  EXPECT_FALSE(waiter.IsLinked());
+  EXPECT_FALSE(waiter.is_persistent());
+
+  ec.notifyAll();
+  EXPECT_EQ(counter, 1u);
+}
+
+// Waiter re-use - persistent then one-shot on same Waiter object.
+TEST_F(FiberTest, PersistentWaiterReuse) {
+  EventCount ec;
+  unsigned counter{};
+  auto cb = [&counter] { ++counter; };
+  detail::Waiter waiter{cb};
+
+  // Phase 1: persistent subscription.
+  {
+    auto sub = ec.subscribe_persistent(&waiter);
+    ec.notifyAll();
+    EXPECT_EQ(counter, 1u);
+    EXPECT_TRUE(waiter.is_persistent());
+  }
+  // SubKey destroyed: persistent flag reset, waiter unlinked.
+  EXPECT_FALSE(waiter.is_persistent());
+  EXPECT_FALSE(waiter.IsLinked());
+
+  // Phase 2: one-shot subscription with the same waiter.
+  auto sub = ec.check_or_subscribe([&] { return false; }, &waiter);
+  ASSERT_TRUE(sub.has_value());
+  EXPECT_TRUE(waiter.IsLinked());
+  EXPECT_FALSE(waiter.is_persistent());
+
+  ec.notifyAll();
+  // One-shot waiter should be unlinked after notification.
+  EXPECT_FALSE(waiter.IsLinked());
+  EXPECT_EQ(counter, 2u);
+}
+
+// (Debug only): Starvation guard - DCHECK fires when notify() hits a persistent
+// waiter with other waiters queued behind it.
+#ifndef NDEBUG
+TEST_F(FiberTest, PersistentWaiterStarvationDCheck) {
+  testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  EXPECT_DEATH(
+      {
+        EventCount ec;
+        unsigned counter{};
+        auto cb = [&counter] { ++counter; };
+        detail::Waiter persistent_waiter{cb};
+
+        auto sub = ec.subscribe_persistent(&persistent_waiter);
+
+        // Add a second (one-shot) waiter behind the persistent one via a fiber.
+        // Launch::dispatch ensures the fiber runs immediately and parks on await().
+        bool wake{false};
+        Fiber fb(Launch::dispatch, "oneshot", [&] { ec.await([&] { return wake; }); });
+
+        // Now there are 2 waiters and the persistent one is at front. DCHECK should fire.
+        ec.notify();
+
+        // Cleanup (unreachable after DCHECK death).
+        wake = true;
+        ec.notifyAll();
+        fb.Join();
+      },
+      "causes starvation");
+}
+#endif
+
 }  // namespace fb2
 }  // namespace util

--- a/util/fibers/synchronization.h
+++ b/util/fibers/synchronization.h
@@ -617,11 +617,11 @@ inline EventCount::SubKey EventCount::subscribe_persistent(detail::Waiter* w) no
   Key key = prepareWait();
   std::unique_lock lk(lock_);
 
-  // No epoch check needed here (unlike one-shot subscribe()). One-shot waiters need the
-  // epoch check because they receive exactly one notification - missing the gap notification
-  // means sleeping forever. Persistent waiters remain linked across ALL future notifications,
-  // so even if a notification fires in the prepareWait()-to-Link() gap, the next notification
-  // will reach this waiter. The caller is expected to check its predicate after subscribing.
+  // No epoch check needed here (unlike one-shot subscribe()). A notification firing in the
+  // prepareWait()-to-Link() gap IS missed by this waiter, but that is safe because:
+  // 1. Persistent waiters stay linked - the next notify/notifyAll will reach them.
+  // 2. The caller MUST check its predicate after subscribing (standard EventCount contract),
+  //    which catches any state change from the missed notification immediately.
   wait_queue_.Link(w);
   return SubKey{std::move(key), w};
 }

--- a/util/fibers/synchronization.h
+++ b/util/fibers/synchronization.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <atomic>
+#include <cassert>
 #include <condition_variable>  // for cv_status
 #include <optional>
 
@@ -20,6 +21,13 @@ namespace fb2 {
 // spurious waits on the consumer side.
 // This class has another wonderful property: notification thread does not need to lock mutex,
 // which means it can be used from the io_context (ring0) fiber.
+//
+// Supports two subscription modes:
+// - One-shot (default): Waiter unlinked after first notification. Use when waiting for a
+//   single event or condition to become true once (see await(), check_or_subscribe()).
+// - Persistent: Waiter remains linked across multiple notifications. Use when you need to
+//   receive all future notifications until explicit unsubscription (see subscribe_persistent()).
+//   Useful for long-lived monitoring or repeated event handling.
 class EventCount {
  public:
   EventCount() noexcept : val_(0) {
@@ -53,20 +61,26 @@ class EventCount {
     }
   };
 
-  // Automatically unlinks waiter when dropped
+  // RAII guard for waiter subscription. Automatically unlinks when destroyed.
+  // For persistent waiters (waiter_->is_persistent() is true): also resets the waiter's persistent
+  // flag on destruction so the waiter can be reused for a different subscription mode.
   class SubKey : public Key {
     friend class EventCount;
-    detail::Waiter* waiter;
+    detail::Waiter* waiter_;
 
-    SubKey(Key&& key, detail::Waiter* w) : Key{std::move(key)}, waiter{w} {
+    SubKey(Key&& key, detail::Waiter* w) noexcept : Key{std::move(key)}, waiter_{w} {
     }
+
+    SubKey(const SubKey&) = delete;
 
    public:
     SubKey(SubKey&& other) noexcept = default;
 
     ~SubKey() {
-      if (me_ != nullptr)
-        me_->unsubscribe(waiter);
+      if (me_ != nullptr) {
+        me_->unsubscribe(waiter_);
+        waiter_->set_persistent(false);
+      }
     }
   };
 
@@ -94,7 +108,16 @@ class EventCount {
   template <typename Condition>
   std::optional<SubKey> check_or_subscribe(Condition condition, detail::Waiter* w);
 
-  // Advanced API, most use-cases will requie await function.
+  // Subscribe a callback-based waiter persistently: both notify() and notifyAll()
+  // fire its callback but do NOT unlink it. Returns a RAII guard that unlinks on
+  // destruction.
+  //
+  // IMPORTANT: The callback must NOT call unsubscribe() or destroy SubKey, because
+  // notification runs under EventCount's internal spinlock and re-entering it would
+  // deadlock. The callback should only set a flag or perform a non-blocking signal.
+  SubKey subscribe_persistent(detail::Waiter* w) noexcept;
+
+  // Advanced API, most use-cases will require await function.
   Key prepareWait() noexcept {
     uint64_t prev = val_.fetch_add(kAddWaiter, std::memory_order_acq_rel);
     return Key(this, prev >> kEpochShift);
@@ -586,6 +609,21 @@ std::optional<EventCount::SubKey> EventCount::check_or_subscribe(Condition condi
       return SubKey{std::move(key), w};
   }
   return {};
+}
+
+inline EventCount::SubKey EventCount::subscribe_persistent(detail::Waiter* w) noexcept {
+  assert(!w->IsLinked());
+  w->set_persistent(true);
+  Key key = prepareWait();
+  std::unique_lock lk(lock_);
+
+  // No epoch check needed here (unlike one-shot subscribe()). One-shot waiters need the
+  // epoch check because they receive exactly one notification - missing the gap notification
+  // means sleeping forever. Persistent waiters remain linked across ALL future notifications,
+  // so even if a notification fires in the prepareWait()-to-Link() gap, the next notification
+  // will reach this waiter. The caller is expected to check its predicate after subscribing.
+  wait_queue_.Link(w);
+  return SubKey{std::move(key), w};
 }
 
 template <typename Condition>


### PR DESCRIPTION
feat(fibers): add persistent EventCount waiters

Adds support for persistent waiters that remain linked in the
EventCount queue across multiple notifications, enabling
callback-based waiters to survive multiple wake/sleep cycles
without re-subscribing.

Why this is needed:
- Fiber-based waiters (await()) create new Waiter instances per
  iteration and work fine with auto-unlink behavior
- Callback-based waiters (IoEvent) reuse the same Waiter instance
  and would be orphaned if auto-unlinked on notification
- in dragonfly: V2 backpressure uses subscribe_persistent() once with io_event_
  waiter, then multiple io_event_.await() calls

Implementation:
- Added persistent_ flag to Waiter with is_persistent()/
  set_persistent() accessors
- Modified NotifyOne/NotifyAll to skip unlinking persistent waiters
- Added subscribe_persistent() API returning RAII SubKey guard
- SubKey destructor unconditionally resets persistent flag and
  unlinks on cleanup for safe waiter reuse
- Waiter move constructor now preserves persistent flag

Safety & Documentation:
- Added DCHECK in NotifyOne to prevent starvation when mixing
  persistent and one-shot waiters (fires in debug builds)
- Documented iterator safety in NotifyAll (no invalidation due to
  deferred fiber activation and pre-advanced iterators)
- Added callback re-entrancy deadlock warning in API docs
- Comprehensive class-level documentation explaining one-shot vs
  persistent subscription modes and usage guidelines

Testing:
- 7 new tests covering: multi-fire notifications, RAII cleanup,
  SubKey move semantics, waiter reuse, mixed queue scenarios,
  single waiter edge case, and starvation guard (death test)

Signed-off-by: Gil Levkovich <69595609+glevkovich@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent subscriptions for event notifications so waiters can remain active across repeated notifications.

* **Improvements**
  * Notification dispatch updated to notify each waiter exactly once while preserving persistent subscribers and avoiding unnecessary removals.

* **Bug Fixes**
  * Added a debug check to detect potential starvation when persistent subscribers are queued ahead of others.

* **Tests**
  * New unit tests covering persistent subscription behavior, RAII unsubscription, move semantics, mixed queues, and starvation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->