### PR TITLE
feat(azure): support HTTP endpoints for Azurite emulator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
           cd build
 
           ninja -k 5 base/all io/all strings/all util/all echo_server ping_iouring_server \
-            https_client_cli s3_demo
+            https_client_cli s3_demo gcs_demo
           ls -la
 
     - name: Test
@@ -138,6 +138,21 @@ jobs:
         echo "MINIO_SECRET_KEY=minioadmin"          >> $GITHUB_ENV
         echo "MINIO_BUCKET=ci-test-bucket"          >> $GITHUB_ENV
 
+    - name: Start Azurite
+      if: matrix.config.name == 'ubuntu24-gcc' && matrix.os.arch == 'amd64'
+      run: |
+        curl -fsSL https://nodejs.org/dist/v22.16.0/node-v22.16.0-linux-x64.tar.xz | tar -xJ -C /tmp
+        export PATH=/tmp/node-v22.16.0-linux-x64/bin:$PATH
+        npm install -g azurite
+        azurite-blob --blobHost 0.0.0.0 --skipApiVersionCheck &
+        for i in $(seq 1 20); do
+          curl -sf http://localhost:10000/ 2>/dev/null && break
+          # Azurite returns 400 for bare /, so check for any response
+          curl -so /dev/null -w '%{http_code}' http://localhost:10000/ 2>/dev/null | grep -q '400' && break
+          sleep 1
+        done
+        echo "AZURITE_ENDPOINT=http://localhost:10000" >> $GITHUB_ENV
+
     - name: Authenticate to AWS
       if: >
         matrix.config.name == 'ubuntu24-gcc' && matrix.os.arch == 'amd64' &&
@@ -152,7 +167,7 @@ jobs:
       env:
         S3_TEST_BUCKET: ${{ secrets.S3_REGTEST_BUCKET }}
       run: |
-          PIP_BREAK_SYSTEM_PACKAGES=1 pip install pytest
+          PIP_BREAK_SYSTEM_PACKAGES=1 pip install pytest azure-storage-blob
           pwd  # /__w/helio/helio
           cat <<EOF > asan_suppressions.txt
           leak:ares_malloc_zero
@@ -187,4 +202,3 @@ jobs:
       with:
          files: ./coverage.info
          fail_ci_if_error: false
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,12 +145,16 @@ jobs:
         export PATH=/tmp/node-v22.16.0-linux-x64/bin:$PATH
         npm install -g azurite
         azurite-blob --blobHost 0.0.0.0 --skipApiVersionCheck &
+        ready=0
         for i in $(seq 1 20); do
-          curl -sf http://localhost:10000/ 2>/dev/null && break
-          # Azurite returns 400 for bare /, so check for any response
-          curl -so /dev/null -w '%{http_code}' http://localhost:10000/ 2>/dev/null | grep -q '400' && break
+          if curl -sf http://localhost:10000/ 2>/dev/null || \
+             [ "$(curl -so /dev/null -w '%{http_code}' http://localhost:10000/ 2>/dev/null)" = "400" ]; then
+            ready=1
+            break
+          fi
           sleep 1
         done
+        test "$ready" -eq 1
         echo "AZURITE_ENDPOINT=http://localhost:10000" >> $GITHUB_ENV
 
     - name: Authenticate to AWS

--- a/examples/gcs_demo.cc
+++ b/examples/gcs_demo.cc
@@ -121,6 +121,10 @@ void RunAzure(SSL_CTX* ctx) {
 
   error_code ec = provider.Init(1000);
   CHECK(!ec) << "Could not load credentials " << ec.message();
+
+  // Use SSL only when the endpoint is HTTPS (not for emulators like Azurite).
+  SSL_CTX* effective_ctx = provider.IsHttps() ? ctx : nullptr;
+
   auto bucket = GetFlag(FLAGS_bucket);
   if (bucket.empty()) {
     ec = storage.ListContainers([](std::string_view item) { CONSOLE_INFO << item << endl; });
@@ -139,7 +143,8 @@ void RunAzure(SSL_CTX* ctx) {
 
       cloud::azure::WriteFileOptions opts;
       opts.creds_provider = &provider;
-      opts.ssl_cntx = ctx;
+      opts.ssl_cntx = effective_ctx;
+      opts.path_prefix = provider.PathPrefix();
       io::Result<io::WriteFile*> dest_res = cloud::azure::OpenWriteFile(bucket, dest_key, opts);
       CHECK(dest_res) << "Could not open " << dest_key << " " << dest_res.error().message();
       unique_ptr<io::WriteFile> dest(*dest_res);
@@ -154,7 +159,8 @@ void RunAzure(SSL_CTX* ctx) {
       string dest_key = prefix;
       cloud::azure::ReadFileOptions opts;
       opts.creds_provider = &provider;
-      opts.ssl_cntx = ctx;
+      opts.ssl_cntx = effective_ctx;
+      opts.path_prefix = provider.PathPrefix();
 
       io::Result<io::ReadonlyFile*> dest_res = cloud::azure::OpenReadFile(bucket, dest_key, opts);
       CHECK(dest_res) << "Could not open " << dest_key << " " << dest_res.error().message();

--- a/examples/gcs_demo.cc
+++ b/examples/gcs_demo.cc
@@ -144,7 +144,6 @@ void RunAzure(SSL_CTX* ctx) {
       cloud::azure::WriteFileOptions opts;
       opts.creds_provider = &provider;
       opts.ssl_cntx = effective_ctx;
-      opts.path_prefix = provider.PathPrefix();
       io::Result<io::WriteFile*> dest_res = cloud::azure::OpenWriteFile(bucket, dest_key, opts);
       CHECK(dest_res) << "Could not open " << dest_key << " " << dest_res.error().message();
       unique_ptr<io::WriteFile> dest(*dest_res);
@@ -160,7 +159,6 @@ void RunAzure(SSL_CTX* ctx) {
       cloud::azure::ReadFileOptions opts;
       opts.creds_provider = &provider;
       opts.ssl_cntx = effective_ctx;
-      opts.path_prefix = provider.PathPrefix();
 
       io::Result<io::ReadonlyFile*> dest_res = cloud::azure::OpenReadFile(bucket, dest_key, opts);
       CHECK(dest_res) << "Could not open " << dest_key << " " << dest_res.error().message();

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+AZURITE_ACCOUNT = "devstoreaccount1"
+AZURITE_KEY = (
+    "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/"
+    "K1SZFPTOtr/KBHBeksoGMGw=="
+)
+AZURITE_PORT = 10000
+AZURITE_CONN_STR = (
+    f"DefaultEndpointsProtocol=http;"
+    f"AccountName={AZURITE_ACCOUNT};"
+    f"AccountKey={AZURITE_KEY};"
+    f"BlobEndpoint=http://127.0.0.1:{AZURITE_PORT}/{AZURITE_ACCOUNT};"
+)
+CONTAINER = f"ci-test-{uuid.uuid4().hex[:8]}"
+
+
+def _find_gcs_demo() -> Path | None:
+    env_dir = os.environ.get("HELIO_BIN_DIR")
+    if env_dir:
+        cand = Path(env_dir) / "gcs_demo"
+        if cand.exists():
+            return cand
+
+    root = Path(__file__).resolve().parent.parent
+    for base in [root, root.parent]:
+        for cand in [base / "build" / "gcs_demo", base / "build-dbg" / "gcs_demo"]:
+            if cand.exists():
+                return cand
+    return None
+
+
+def _azurite_running() -> bool:
+    """Check whether Azurite is listening on the expected port."""
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(1)
+        return s.connect_ex(("127.0.0.1", AZURITE_PORT)) == 0
+
+
+@pytest.fixture(scope="module")
+def azurite():
+    """Ensure Azurite is running. Try in order: already running (CI), start as
+    subprocess, skip."""
+    if _azurite_running():
+        yield None  # Already running (e.g. started by CI step).
+        return
+
+    azurite_bin = shutil.which("azurite-blob")
+    if not azurite_bin:
+        pytest.skip("azurite-blob not found and Azurite is not already running")
+
+    proc = subprocess.Popen(
+        [azurite_bin, "--blobHost", "0.0.0.0", "--skipApiVersionCheck"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    for _ in range(30):
+        if _azurite_running():
+            break
+        time.sleep(0.5)
+    else:
+        proc.kill()
+        pytest.skip("Azurite did not become ready in time")
+
+    yield proc
+
+    proc.send_signal(signal.SIGTERM)
+    proc.wait(timeout=5)
+
+
+@pytest.fixture(scope="module")
+def gcs_demo(azurite) -> Path:
+    binary = _find_gcs_demo()
+    if not binary:
+        pytest.skip("gcs_demo binary not found")
+    return binary
+
+
+@pytest.fixture(scope="module")
+def az_env() -> dict:
+    """Environment dict with Azurite credentials."""
+    env = os.environ.copy()
+    env["AZURE_STORAGE_CONNECTION_STRING"] = AZURITE_CONN_STR
+    return env
+
+
+@pytest.fixture(scope="module", autouse=True)
+def create_container(azurite, az_env):
+    """Ensure the test container exists in Azurite."""
+    from azure.core.exceptions import ResourceExistsError
+    from azure.storage.blob import BlobServiceClient
+
+    client = BlobServiceClient.from_connection_string(AZURITE_CONN_STR)
+    try:
+        client.create_container(CONTAINER)
+    except ResourceExistsError:
+        pass
+
+
+def _run(binary: Path, *args: str, env: dict) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [str(binary), "--logtostderr", "--azure", *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+
+def test_list_empty(gcs_demo, az_env):
+    """Listing an empty container should succeed."""
+    result = _run(gcs_demo, f"--bucket={CONTAINER}", env=az_env)
+    assert result.returncode == 0, f"list failed:\n{result.stderr}"
+
+
+def test_write_read(gcs_demo, az_env):
+    """Write a blob and read it back, verifying sizes match."""
+    prefix = "helio-ci/blob"
+    result = _run(
+        gcs_demo, f"--bucket={CONTAINER}", f"--prefix={prefix}", "--write=1", env=az_env
+    )
+    assert result.returncode == 0, f"write failed:\n{result.stderr}"
+    assert "Written" in result.stderr, result.stderr
+
+    result = _run(
+        gcs_demo,
+        f"--bucket={CONTAINER}",
+        f"--prefix={prefix}_0",
+        "--read=1",
+        env=az_env,
+    )
+    assert result.returncode == 0, f"read failed:\n{result.stderr}"
+    assert "Read" in result.stderr, result.stderr
+
+
+def test_list_after_write(gcs_demo, az_env):
+    """After writing, the blob should appear in a list."""
+    result = _run(gcs_demo, f"--bucket={CONTAINER}", "--prefix=helio-ci/", env=az_env)
+    assert result.returncode == 0, f"list failed:\n{result.stderr}"
+    assert "helio-ci/" in result.stderr, f"expected blob not listed:\n{result.stderr}"
+
+
+def test_list_containers(gcs_demo, az_env):
+    """ListContainers should return at least the test container."""
+    result = _run(gcs_demo, env=az_env)
+    assert result.returncode == 0, f"list containers failed:\n{result.stderr}"
+    assert CONTAINER in result.stderr, f"container not listed:\n{result.stderr}"

--- a/util/cloud/azure/azure.cc
+++ b/util/cloud/azure/azure.cc
@@ -158,7 +158,7 @@ string_view MapGet(const ConnMap& map, string_view key) {
   return it->second;
 }
 
-bool ParseEndpointHost(string_view endpoint, string* host) {
+bool ParseEndpointHost(string_view endpoint, AccountInfo* out) {
   endpoint = absl::StripAsciiWhitespace(endpoint);
   if (endpoint.empty()) {
     return false;
@@ -170,7 +170,16 @@ bool ParseEndpointHost(string_view endpoint, string* host) {
   }
 
   bool default_port = parsed.port == (parsed.is_https ? "443" : "80");
-  *host = default_port ? std::move(parsed.host) : absl::StrCat(parsed.host, ":", parsed.port);
+  out->service_endpoint =
+      default_port ? std::move(parsed.host) : absl::StrCat(parsed.host, ":", parsed.port);
+  out->is_https = parsed.is_https;
+  if (parsed.path != "/") {
+    string_view p = parsed.path;
+    if (p.size() > 1 && p.back() == '/') {
+      p.remove_suffix(1);
+    }
+    out->path_prefix = string(p);
+  }
   return true;
 }
 
@@ -235,23 +244,26 @@ io::Result<pair<string, unsigned>> ParseImdsTokenResponse(string&& response) {
   return make_pair(string(token_it->value.GetString()), expires_in);
 }
 
-error_code ResolveServiceEndpointFromEnv(string_view account_name, string* service_endpoint,
-                                         string* inferred_account_name) {
+// Fills out->service_endpoint, is_https and path_prefix from environment variables.
+// If out->account_name is empty on entry, infers it from the resolved endpoint.
+error_code ResolveServiceEndpointFromEnv(AccountInfo* out) {
   if (const char* ep = getenv("AZURE_STORAGE_BLOB_ENDPOINT"); ep && *ep) {
-    if (!ParseEndpointHost(ep, service_endpoint)) {
+    if (!ParseEndpointHost(ep, out)) {
       return make_error_code(errc::bad_message);
     }
   } else if (const char* url = getenv("AZURE_STORAGE_ACCOUNT_URL"); url && *url) {
-    if (!ParseEndpointHost(url, service_endpoint)) {
+    if (!ParseEndpointHost(url, out)) {
       return make_error_code(errc::bad_message);
     }
-  } else if (!account_name.empty()) {
-    *service_endpoint = absl::StrCat(account_name, ".blob.", kDefaultEndpointSuffix);
+  } else if (!out->account_name.empty()) {
+    out->service_endpoint = absl::StrCat(out->account_name, ".blob.", kDefaultEndpointSuffix);
   } else {
     return make_error_code(errc::not_supported);
   }
 
-  *inferred_account_name = InferAccountNameFromHost(*service_endpoint);
+  if (out->account_name.empty()) {
+    out->account_name = InferAccountNameFromHost(out->service_endpoint);
+  }
   return {};
 }
 
@@ -260,9 +272,8 @@ error_code ResolveServiceEndpointFromEnv(string_view account_name, string* servi
 error_code Credentials::Init(unsigned connect_ms) {
   connect_ms_ = connect_ms ? connect_ms : 1000;
 
-  account_name_.clear();
+  account_info_ = {};
   account_key_.clear();
-  service_endpoint_.clear();
   sas_query_.clear();
   source_ = CredSource::kNone;
   auth_mode_ = AuthMode::kNone;
@@ -275,7 +286,7 @@ error_code Credentials::Init(unsigned connect_ms) {
     error_code ec = (this->*fn)();
     if (!ec) {
       LOG_FIRST_N(INFO, 1) << "azure: loaded credentials; provider=" << name
-                           << " account=" << account_name_;
+                           << " account=" << account_info_.account_name;
       return true;
     }
     if (ec != errc::not_supported) {
@@ -304,10 +315,10 @@ error_code Credentials::Init(unsigned connect_ms) {
 }
 
 string Credentials::ServiceEndpoint() const {
-  if (!service_endpoint_.empty()) {
-    return service_endpoint_;
+  if (!account_info_.service_endpoint.empty()) {
+    return account_info_.service_endpoint;
   }
-  return absl::StrCat(account_name_, ".blob.", kDefaultEndpointSuffix);
+  return absl::StrCat(account_info_.account_name, ".blob.", kDefaultEndpointSuffix);
 }
 
 error_code Credentials::TryConnectionString() {
@@ -325,14 +336,14 @@ error_code Credentials::TryConnectionString() {
     return make_error_code(errc::not_supported);
   }
 
-  string account_name(MapGet(params, "AccountName"));
+  AccountInfo info;
+  info.account_name = string(MapGet(params, "AccountName"));
   string account_key(MapGet(params, "AccountKey"));
   string sas = NormalizeSasQuery(MapGet(params, "SharedAccessSignature"));
 
-  string endpoint;
   string_view blob_endpoint = MapGet(params, "BlobEndpoint");
   if (!blob_endpoint.empty()) {
-    if (!ParseEndpointHost(blob_endpoint, &endpoint)) {
+    if (!ParseEndpointHost(blob_endpoint, &info)) {
       return make_error_code(errc::bad_message);
     }
   } else {
@@ -340,28 +351,26 @@ error_code Credentials::TryConnectionString() {
     if (endpoint_suffix.empty()) {
       endpoint_suffix = kDefaultEndpointSuffix;
     }
-    if (account_name.empty()) {
+    if (info.account_name.empty()) {
       return make_error_code(errc::bad_message);
     }
-    endpoint = absl::StrCat(account_name, ".blob.", endpoint_suffix);
+    info.service_endpoint = absl::StrCat(info.account_name, ".blob.", endpoint_suffix);
+  }
+
+  if (info.account_name.empty()) {
+    info.account_name = InferAccountNameFromHost(info.service_endpoint);
+  }
+  if (info.account_name.empty()) {
+    return make_error_code(errc::bad_message);
   }
 
   if (!account_key.empty()) {
-    if (account_name.empty()) {
-      account_name = InferAccountNameFromHost(endpoint);
-    }
-    if (account_name.empty()) {
-      return make_error_code(errc::bad_message);
-    }
-
-    SetSharedKey(CredSource::kConnectionString, std::move(account_name), std::move(account_key),
-                 std::move(endpoint));
+    SetSharedKey(CredSource::kConnectionString, std::move(info), std::move(account_key));
     return {};
   }
 
   if (!sas.empty()) {
-    SetSas(CredSource::kConnectionString, std::move(account_name), std::move(endpoint),
-           std::move(sas));
+    SetSas(CredSource::kConnectionString, std::move(info), std::move(sas));
     return {};
   }
 
@@ -369,23 +378,18 @@ error_code Credentials::TryConnectionString() {
 }
 
 error_code Credentials::TryEnvSharedKey() {
-  string account = GetEnvOrEmpty("AZURE_STORAGE_ACCOUNT");
   string key = GetEnvOrEmpty("AZURE_STORAGE_KEY");
   string sas = NormalizeSasQuery(GetEnvOrEmpty("AZURE_STORAGE_SAS_TOKEN"));
 
-  string endpoint;
-  string inferred_account;
-  error_code ep_ec = ResolveServiceEndpointFromEnv(account, &endpoint, &inferred_account);
+  AccountInfo info;
+  info.account_name = GetEnvOrEmpty("AZURE_STORAGE_ACCOUNT");
+  error_code ep_ec = ResolveServiceEndpointFromEnv(&info);
 
   if (!key.empty()) {
-    if (account.empty()) {
-      account = inferred_account;
-    }
-    if (account.empty() || ep_ec) {
+    if (info.account_name.empty() || ep_ec) {
       return ep_ec ? ep_ec : make_error_code(errc::bad_message);
     }
-
-    SetSharedKey(CredSource::kEnv, std::move(account), std::move(key), std::move(endpoint));
+    SetSharedKey(CredSource::kEnv, std::move(info), std::move(key));
     return {};
   }
 
@@ -393,8 +397,7 @@ error_code Credentials::TryEnvSharedKey() {
     if (ep_ec) {
       return ep_ec;
     }
-
-    SetSas(CredSource::kEnv, std::move(account), std::move(endpoint), std::move(sas));
+    SetSas(CredSource::kEnv, std::move(info), std::move(sas));
     return {};
   }
 
@@ -402,14 +405,9 @@ error_code Credentials::TryEnvSharedKey() {
 }
 
 error_code Credentials::TryManagedIdentity() {
-  string account = GetEnvOrEmpty("AZURE_STORAGE_ACCOUNT");
-  string endpoint;
-  string inferred_account;
-
-  RETURN_ERROR(ResolveServiceEndpointFromEnv(account, &endpoint, &inferred_account));
-  if (account.empty()) {
-    account = std::move(inferred_account);
-  }
+  AccountInfo info;
+  info.account_name = GetEnvOrEmpty("AZURE_STORAGE_ACCOUNT");
+  RETURN_ERROR(ResolveServiceEndpointFromEnv(&info));
 
   fb2::ProactorBase* pb = fb2::ProactorBase::me();
   CHECK(pb);
@@ -442,18 +440,22 @@ error_code Credentials::TryManagedIdentity() {
     return token_ttl.error();
   }
 
-  SetBearer(std::move(account), std::move(endpoint), std::move(token_ttl->first),
-            token_ttl->second);
+  SetBearer(std::move(info), std::move(token_ttl->first), token_ttl->second);
   return {};
 }
 
-void Credentials::SetSharedKey(CredSource src, string account, string key, string endpoint) {
-  account_name_ = std::move(account);
-  account_key_ = std::move(key);
-  service_endpoint_ = std::move(endpoint);
-  sas_query_.clear();
+void Credentials::SetCredentials(CredSource src, AccountInfo info, AuthMode mode,
+                                 string key_or_sas) {
+  account_info_ = std::move(info);
   source_ = src;
-  auth_mode_ = AuthMode::kSharedKey;
+  auth_mode_ = mode;
+  if (mode == AuthMode::kSharedKey) {
+    account_key_ = std::move(key_or_sas);
+    sas_query_.clear();
+  } else {
+    account_key_.clear();
+    sas_query_ = std::move(key_or_sas);
+  }
   {
     folly::RWSpinLock::WriteHolder lock(lock_);
     access_token_.clear();
@@ -461,26 +463,19 @@ void Credentials::SetSharedKey(CredSource src, string account, string key, strin
   expire_time_.store(0, std::memory_order_release);
 }
 
-void Credentials::SetSas(CredSource src, string account, string endpoint, string sas) {
-  account_name_ = std::move(account);
-  account_key_.clear();
-  service_endpoint_ = std::move(endpoint);
-  sas_query_ = std::move(sas);
-  source_ = src;
-  auth_mode_ = AuthMode::kSas;
-  {
-    folly::RWSpinLock::WriteHolder lock(lock_);
-    access_token_.clear();
-  }
-  expire_time_.store(0, std::memory_order_release);
+void Credentials::SetSharedKey(CredSource src, AccountInfo info, string key) {
+  SetCredentials(src, std::move(info), AuthMode::kSharedKey, std::move(key));
 }
 
-void Credentials::SetBearer(string account, string endpoint, string token, unsigned ttl) {
-  VLOG(1) << "azure: obtained access token " << token << ", account=" << account
-          << ", endpoint=" << endpoint << ", expires in " << ttl << " seconds";
-  account_name_ = std::move(account);
+void Credentials::SetSas(CredSource src, AccountInfo info, string sas) {
+  SetCredentials(src, std::move(info), AuthMode::kSas, std::move(sas));
+}
+
+void Credentials::SetBearer(AccountInfo info, string token, unsigned ttl) {
+  VLOG(1) << "azure: obtained access token, account=" << info.account_name
+          << ", endpoint=" << info.service_endpoint << ", expires in " << ttl << " seconds";
+  account_info_ = std::move(info);
   account_key_.clear();
-  service_endpoint_ = std::move(endpoint);
   sas_query_.clear();
   source_ = CredSource::kManagedIdentity;
   auth_mode_ = AuthMode::kBearer;
@@ -508,9 +503,10 @@ void Credentials::Sign(detail::HttpRequestBase* req) const {
 
   switch (auth_mode_) {
     case AuthMode::kSharedKey: {
-      string signature =
-          ComputeSignature(account_name_, req->GetMethod(), req->GetHeaders(), account_key_);
-      req->SetHeader("Authorization", absl::StrCat("SharedKey ", account_name_, ":", signature));
+      string signature = ComputeSignature(account_info_.account_name, req->GetMethod(),
+                                          req->GetHeaders(), account_key_);
+      req->SetHeader("Authorization",
+                     absl::StrCat("SharedKey ", account_info_.account_name, ":", signature));
       break;
     }
     case AuthMode::kBearer: {

--- a/util/cloud/azure/creds_provider.h
+++ b/util/cloud/azure/creds_provider.h
@@ -43,7 +43,7 @@ class Credentials : public CredentialsProvider {
 
   // Returns the path prefix from the BlobEndpoint URL (e.g. "/devstoreaccount1" for Azurite).
   // Empty for real Azure endpoints.
-  const std::string& PathPrefix() const {
+  const std::string& GetPathPrefix() const {
     return account_info_.path_prefix;
   }
 

--- a/util/cloud/azure/creds_provider.h
+++ b/util/cloud/azure/creds_provider.h
@@ -9,11 +9,18 @@
 #include <system_error>
 
 #include "base/RWSpinLock.h"
-
 #include "util/cloud/utils.h"
 
 namespace util {
 namespace cloud::azure {
+
+// Endpoint and account identity resolved from a BlobEndpoint URL or account name.
+struct AccountInfo {
+  std::string service_endpoint;
+  std::string account_name;
+  std::string path_prefix;  // non-empty for path-style endpoints (e.g. "/devstoreaccount1")
+  bool is_https = true;
+};
 
 class Credentials : public CredentialsProvider {
  public:
@@ -22,13 +29,23 @@ class Credentials : public CredentialsProvider {
   std::error_code Init(unsigned) final;
 
   const std::string& account_name() const {
-    return account_name_;
+    return account_info_.account_name;
   }
   const std::string& account_key() const {
     return account_key_;
   }
 
   std::string ServiceEndpoint() const;
+
+  bool IsHttps() const {
+    return account_info_.is_https;
+  }
+
+  // Returns the path prefix from the BlobEndpoint URL (e.g. "/devstoreaccount1" for Azurite).
+  // Empty for real Azure endpoints.
+  const std::string& PathPrefix() const {
+    return account_info_.path_prefix;
+  }
 
   void Sign(detail::HttpRequestBase* req) const final;
   std::error_code RefreshToken() final;
@@ -43,18 +60,18 @@ class Credentials : public CredentialsProvider {
   // Helpers to commit credential state. These (and Init/TryXxx) are the only writers;
   // Sign() reads these fields without a lock, so they must not change after Init() returns
   // (except via RefreshToken, which only updates access_token_ under lock_).
-  void SetSharedKey(CredSource src, std::string account, std::string key, std::string endpoint);
-  void SetSas(CredSource src, std::string account, std::string endpoint, std::string sas);
-  void SetBearer(std::string account, std::string endpoint, std::string token, unsigned ttl);
+  void SetCredentials(CredSource src, AccountInfo info, AuthMode mode, std::string key_or_sas);
+  void SetSharedKey(CredSource src, AccountInfo info, std::string key);
+  void SetSas(CredSource src, AccountInfo info, std::string sas);
+  void SetBearer(AccountInfo info, std::string token, unsigned ttl);
 
   static std::string NormalizeSasQuery(std::string_view query);
 
   // Immutable after Init() — read by Sign() without locking.
   CredSource source_ = CredSource::kNone;
   AuthMode auth_mode_ = AuthMode::kNone;
-  std::string account_name_;
+  AccountInfo account_info_;
   std::string account_key_;
-  std::string service_endpoint_;
   std::string sas_query_;
 
   // Mutable at runtime — protected by lock_ / atomic.

--- a/util/cloud/azure/storage.cc
+++ b/util/cloud/azure/storage.cc
@@ -411,7 +411,7 @@ error_code Storage::ListContainers(function<void(const ContainerItem&)> cb) {
   string endpoint = creds_->ServiceEndpoint();
   unique_ptr<http::ClientPool> pool = CreatePool(endpoint, ctx, fb2::ProactorBase::me());
 
-  string list_url = absl::StrCat(creds_->PathPrefix(), "/?comp=list");
+  string list_url = absl::StrCat(creds_->GetPathPrefix(), "/?comp=list");
   detail::EmptyRequestImpl req = FillRequest(endpoint, list_url, creds_);
   RobustSender sender(pool.get(), creds_);
   RobustSender::SenderResult send_res;
@@ -444,7 +444,8 @@ error_code Storage::List(string_view container, std::string_view prefix, bool re
   string endpoint = creds_->ServiceEndpoint();
   unique_ptr<http::ClientPool> pool = CreatePool(endpoint, ctx, fb2::ProactorBase::me());
 
-  string url = absl::StrCat(creds_->PathPrefix(), "/", container, "?restype=container&comp=list");
+  string url =
+      absl::StrCat(creds_->GetPathPrefix(), "/", container, "?restype=container&comp=list");
   absl::StrAppend(&url, "&maxresults=", max_results);
   if (!prefix.empty()) {
     absl::StrAppend(&url, "&prefix=");
@@ -474,7 +475,7 @@ string BuildGetObjUrl(string_view path_prefix, const string& container, const st
 io::Result<io::ReadonlyFile*> OpenReadFile(const std::string& container, const std::string& key,
                                            const ReadFileOptions& opts) {
   DCHECK(opts.creds_provider);
-  string url = BuildGetObjUrl(opts.path_prefix, container, key);
+  string url = BuildGetObjUrl(opts.creds_provider->GetPathPrefix(), container, key);
   return new ReadFile(url, opts);
 }
 
@@ -482,7 +483,7 @@ io::Result<io::WriteFile*> OpenWriteFile(const std::string& container, const std
                                          const WriteFileOptions& opts) {
   DCHECK(opts.creds_provider);
 
-  return new WriteFile(opts.path_prefix, container, key, opts);
+  return new WriteFile(opts.creds_provider->GetPathPrefix(), container, key, opts);
 }
 
 }  // namespace cloud::azure

--- a/util/cloud/azure/storage.cc
+++ b/util/cloud/azure/storage.cc
@@ -173,7 +173,8 @@ detail::EmptyRequestImpl FillRequest(string_view endpoint, string_view url,
 
 class ReadFile final : public io::ReadonlyFile {
  public:
-  ReadFile(string read_obj_url, ReadFileOptions opts) : read_obj_url_(read_obj_url), opts_(opts) {
+  ReadFile(string read_obj_url, ReadFileOptions opts)
+      : read_obj_url_(std::move(read_obj_url)), opts_(std::move(opts)) {
   }
 
   virtual ~ReadFile();
@@ -213,7 +214,7 @@ class ReadFile final : public io::ReadonlyFile {
 // size before uploading.
 class WriteFile : public detail::AbstractStorageFile {
  public:
-  WriteFile(string_view container, string_view key, const WriteFileOptions& opts);
+  WriteFile(string_view path_prefix, string_view container, string_view key, WriteFileOptions opts);
   ~WriteFile();
 
   // Closes the object and completes the multipart upload. Therefore the object
@@ -309,11 +310,12 @@ io::SizeOrError ReadFile::Read(size_t offset, const iovec* v, uint32_t len) {
   return total;
 }
 
-WriteFile::WriteFile(string_view container, string_view key, const WriteFileOptions& opts)
-    : detail::AbstractStorageFile(key, 1UL << 23), opts_(opts) {
+WriteFile::WriteFile(string_view path_prefix, string_view container, string_view key,
+                     WriteFileOptions opts)
+    : detail::AbstractStorageFile(key, 1UL << 23), opts_(std::move(opts)) {
   string endpoint = opts_.creds_provider->ServiceEndpoint();
   pool_ = CreatePool(endpoint, opts_.ssl_cntx, fb2::ProactorBase::me());
-  target_ = absl::StrCat("/", container, "/", key);
+  target_ = absl::StrCat(path_prefix, "/", container, "/", key);
 }
 
 WriteFile::~WriteFile() {
@@ -400,13 +402,17 @@ auto WriteFile::PrepareBlockListReq() -> unique_ptr<UploadBlockListRequest> {
 }  // namespace
 
 error_code Storage::ListContainers(function<void(const ContainerItem&)> cb) {
-  SSL_CTX* ctx = http::TlsClient::CreateSslContext();
-  absl::Cleanup cleanup([ctx] { http::TlsClient::FreeContext(ctx); });
+  SSL_CTX* ctx = creds_->IsHttps() ? http::TlsClient::CreateSslContext() : nullptr;
+  absl::Cleanup cleanup([ctx] {
+    if (ctx)
+      http::TlsClient::FreeContext(ctx);
+  });
 
   string endpoint = creds_->ServiceEndpoint();
   unique_ptr<http::ClientPool> pool = CreatePool(endpoint, ctx, fb2::ProactorBase::me());
 
-  detail::EmptyRequestImpl req = FillRequest(endpoint, "/?comp=list", creds_);
+  string list_url = absl::StrCat(creds_->PathPrefix(), "/?comp=list");
+  detail::EmptyRequestImpl req = FillRequest(endpoint, list_url, creds_);
   RobustSender sender(pool.get(), creds_);
   RobustSender::SenderResult send_res;
   RETURN_ERROR(sender.Send(3, &req, &send_res));
@@ -429,13 +435,16 @@ error_code Storage::ListContainers(function<void(const ContainerItem&)> cb) {
 
 error_code Storage::List(string_view container, std::string_view prefix, bool recursive,
                          unsigned max_results, function<void(const ListItem&)> cb) {
-  SSL_CTX* ctx = http::TlsClient::CreateSslContext();
-  absl::Cleanup cleanup([ctx] { http::TlsClient::FreeContext(ctx); });
+  SSL_CTX* ctx = creds_->IsHttps() ? http::TlsClient::CreateSslContext() : nullptr;
+  absl::Cleanup cleanup([ctx] {
+    if (ctx)
+      http::TlsClient::FreeContext(ctx);
+  });
 
   string endpoint = creds_->ServiceEndpoint();
   unique_ptr<http::ClientPool> pool = CreatePool(endpoint, ctx, fb2::ProactorBase::me());
 
-  string url = absl::StrCat("/", container, "?restype=container&comp=list");
+  string url = absl::StrCat(creds_->PathPrefix(), "/", container, "?restype=container&comp=list");
   absl::StrAppend(&url, "&maxresults=", max_results);
   if (!prefix.empty()) {
     absl::StrAppend(&url, "&prefix=");
@@ -458,23 +467,22 @@ error_code Storage::List(string_view container, std::string_view prefix, bool re
   return {};
 }
 
-string BuildGetObjUrl(const string& container, const string& key) {
-  string url = absl::StrCat("/", container, "/", key);
-  return url;
+string BuildGetObjUrl(string_view path_prefix, const string& container, const string& key) {
+  return absl::StrCat(path_prefix, "/", container, "/", key);
 }
 
 io::Result<io::ReadonlyFile*> OpenReadFile(const std::string& container, const std::string& key,
                                            const ReadFileOptions& opts) {
-  DCHECK(opts.creds_provider && opts.ssl_cntx);
-  string url = BuildGetObjUrl(container, key);
+  DCHECK(opts.creds_provider);
+  string url = BuildGetObjUrl(opts.path_prefix, container, key);
   return new ReadFile(url, opts);
 }
 
 io::Result<io::WriteFile*> OpenWriteFile(const std::string& container, const std::string& key,
                                          const WriteFileOptions& opts) {
-  DCHECK(opts.creds_provider && opts.ssl_cntx);
+  DCHECK(opts.creds_provider);
 
-  return new WriteFile(container, key, opts);
+  return new WriteFile(opts.path_prefix, container, key, opts);
 }
 
 }  // namespace cloud::azure

--- a/util/cloud/azure/storage.h
+++ b/util/cloud/azure/storage.h
@@ -8,6 +8,7 @@
 #include <system_error>
 
 #include "io/file.h"
+#include "util/cloud/azure/creds_provider.h"
 #include "util/cloud/utils.h"
 
 typedef struct ssl_ctx_st SSL_CTX;
@@ -15,11 +16,9 @@ typedef struct ssl_ctx_st SSL_CTX;
 namespace util {
 namespace cloud::azure {
 
-class Credentials;
-
 class Storage {
  public:
-  explicit Storage(CredentialsProvider* creds) : creds_(creds) {
+  explicit Storage(Credentials* creds) : creds_(creds) {
   }
 
   using ContainerItem = std::string_view;
@@ -30,12 +29,13 @@ class Storage {
                        unsigned max_results, std::function<void(const ListItem&)> cb);
 
  private:
-  CredentialsProvider* creds_;
+  Credentials* creds_;
 };
 
 struct ReadFileOptions {
   CredentialsProvider* creds_provider = nullptr;
-  SSL_CTX* ssl_cntx;
+  SSL_CTX* ssl_cntx = nullptr;
+  std::string path_prefix;  // e.g. "/devstoreaccount1" for Azurite
 };
 
 using WriteFileOptions = ReadFileOptions;

--- a/util/cloud/azure/storage.h
+++ b/util/cloud/azure/storage.h
@@ -33,9 +33,8 @@ class Storage {
 };
 
 struct ReadFileOptions {
-  CredentialsProvider* creds_provider = nullptr;
+  Credentials* creds_provider = nullptr;
   SSL_CTX* ssl_cntx = nullptr;
-  std::string path_prefix;  // e.g. "/devstoreaccount1" for Azurite
 };
 
 using WriteFileOptions = ReadFileOptions;


### PR DESCRIPTION
## Summary
- Add `IsHttps()` / `PathPrefix()` to Azure `Credentials` so the storage
  layer can connect over plain HTTP with path-style URLs (Azurite)
- `Storage::List` / `ListContainers` conditionally create SSL context
  and prepend the path prefix to all request URLs
- `OpenReadFile` / `OpenWriteFile` accept optional `ssl_cntx` and
  `path_prefix` via `ReadFileOptions`
- `gcs_demo` conditionally uses SSL based on `provider.IsHttps()`
- New Azurite-based pytest (`tests/test_azure.py`) covering list
  containers, list blobs, write, and read

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Azure support improved: endpoint scheme (HTTP/HTTPS) is respected, SSL usage is conditional, and request path prefixes are preserved so emulator (Azurite) and real endpoints behave correctly.
  * Credential parsing exposes endpoint scheme and path-prefix for correct request construction and URL building.

* **Tests**
  * Added Azure integration tests exercising listing, write/read, prefix-aware listing, and container discovery using Azurite.

* **CI**
  * CI builds the demo binary, starts Azurite for tests, and installs Azure test dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->