### PR TITLE
docs: document that TraverseConnectionsOnThread may preempt

### DIFF
--- a/util/listener_interface.h
+++ b/util/listener_interface.h
@@ -65,6 +65,7 @@ class ListenerInterface {
   // traverses all client connection in current thread. cb must adhere to rules from
   // `TraverseConnections`. Specifically, cb should not fiber block so that the underlying
   // connection list won't change during the traversal.
+  // Note: This function may preempt internally (e.g., waiting for active migrations to finish).
   Connection* TraverseConnectionsOnThread(TraverseCB cb, uint32_t limit, Connection* from);
 
   // Must be called from the connection fiber (that runs HandleRequests() function).


### PR DESCRIPTION
Add comment documenting that TraverseConnectionsOnThread can yield internally while waiting for active migrations to complete. We had a bug recently, so this is worth documenting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification on connection handling behavior during system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->