### PR TITLE
chore: flip LEGACY_GLOG switch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           cat /proc/cpuinfo
           cmake -B build \
             -DCMAKE_BUILD_TYPE=${{matrix.config.build_type}} \
-            -GNinja \
+            -GNinja -DLEGACY_GLOG=OFF \
             -DCMAKE_C_COMPILER="${{matrix.config.compiler.c}}" \
             -DCMAKE_CXX_COMPILER="${{matrix.config.compiler.cxx}}" \
             -DCMAKE_CXX_FLAGS_DEBUG="${{matrix.config.cxx_flags}}" \

--- a/base/file_log_sink.cc
+++ b/base/file_log_sink.cc
@@ -147,7 +147,7 @@ bool FileLogSink::LogFile::Open(const std::string& base_path, int severity,
     string link_path = absl::StrCat(base_path, ".", kSeverityNames[severity]);
     string target = path_.substr(path_.rfind('/') + 1);
     unlink(link_path.c_str());
-    symlink(target.c_str(), link_path.c_str());
+    (void)symlink(target.c_str(), link_path.c_str());
   }
 
   return true;

--- a/base/logging.cc
+++ b/base/logging.cc
@@ -17,10 +17,10 @@ namespace base {
 
 using std::string;
 
-#ifdef __FreeBSD__
-static constexpr char kProcSelf[] = "/proc/curproc/file";
-#else
+#ifdef __linux__
 static constexpr char kProcSelf[] = "/proc/self/exe";
+#elif defined(__FreeBSD__)
+static constexpr char kProcSelf[] = "/proc/curproc/file";
 #endif
 
 static constexpr char kDeletedSuffix[] = " (deleted)";

--- a/base/logging.h
+++ b/base/logging.h
@@ -59,7 +59,7 @@ std::vector<std::string> GetLoggingDirectories();
 
 }  // namespace base
 
-#define CONSOLE_INFO ABSL_LOG(INFO).ToSinkOnly(base::ConsoleLogSink::instance())
+#define CONSOLE_INFO ABSL_LOG(INFO).ToSinkAlso(base::ConsoleLogSink::instance())
 
 #else
 #include <glog/logging.h>

--- a/examples/https_client_cli.cc
+++ b/examples/https_client_cli.cc
@@ -12,7 +12,7 @@
 // the headers and the body from the host and resource you gave.
 // for example:
 // ./https_client --host redis.io --resource /commands/asking/ --vmodule=https_client=2
-// --logbuflevel=-1 --alsologtostderr
+// --logbuflevel=-1 --stderrthreshold=0
 // will print the content from https://redis.io/commands/asking command to the log as well as to the
 // terminal
 #include <openssl/err.h>
@@ -86,7 +86,7 @@ using OpResult = io::Result<RequestResults, std::string>;
 
 OpResult ConnectAndRead(ProactorBase* proactor, std::string_view host, std::string_view service,
                         const char* resource, SSL_CTX* ssl_ctx) {
-  
+
   auto list_res = proactor->Await([&] {
     TlsClient http_client{proactor};
 

--- a/tests/test_echo_server.py
+++ b/tests/test_echo_server.py
@@ -72,7 +72,7 @@ class EchoServerHarness:
         if self.proc:
             raise RuntimeError("echo_server already running")
 
-        args = [str(self.binary), "--alsologtostderr"]
+        args = [str(self.binary), "--stderrthreshold=0"]
         if server_args:
             args.extend(server_args)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now disables a legacy logging option during configuration.
  * INFO-level logs are now also routed to the console.
  * Minor code hygiene change to suppress an unused symlink result warning.
  * Platform-specific selection for the proc/self path refined between Linux and FreeBSD.

* **Documentation**
  * Example and test guidance updated to prefer a stderr-threshold flag for stderr logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->