### PR TITLE
feat: stack overflow safeguard for dispatch fiber

### DIFF
--- a/util/fibers/detail/fiber_interface.cc
+++ b/util/fibers/detail/fiber_interface.cc
@@ -244,7 +244,7 @@ __attribute__((no_instrument_function)) TL_FiberInitializer& FbInitializer() noe
   return fb_initializer;
 }
 
-FiberInterface* FiberActive() noexcept {
+__attribute__((no_instrument_function)) FiberInterface* FiberActive() noexcept {
   return FbInitializer().active;
 }
 

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -74,6 +74,9 @@ DispatcherImpl::DispatcherImpl(const ctx::preallocated& palloc, ctx::fixedsize_s
                                detail::Scheduler* sched) noexcept
     : FiberInterface{DISPATCH, FiberPriority::NORMAL, 0, "_dispatch"} {
   stack_size_ = palloc.sctx.size;
+  // Paint canaries before constructing the fiber context so CheckStackMargin works
+  // for the dispatcher the same way it does for worker fibers.
+  InitStackBottom(reinterpret_cast<uint8_t*>(palloc.sp) - palloc.size, palloc.size);
   entry_ = ctx::fiber(std::allocator_arg, palloc, std::move(salloc),
                       [this](ctx::fiber&& caller) { return Run(std::move(caller)); });
   scheduler_ = sched;

--- a/util/fibers/epoll_proactor.cc
+++ b/util/fibers/epoll_proactor.cc
@@ -96,7 +96,7 @@ void OnSigSegv(int sig, siginfo_t* info, void* ucontext_arg) {
   // skip the check rather than producing a false-positive fatal error.
   if (sp && stack_bottom && sp < stack_bottom) {
     const char msg[] = "POSSIBLE FIBER STACK OVERFLOW DETECTED\n";
-    write(STDERR_FILENO, msg, sizeof(msg) - 1);
+    std::ignore = write(STDERR_FILENO, msg, sizeof(msg) - 1);
   }
 
   // Restore the previous handler (e.g. Abseil's) and return. The kernel re-executes the

--- a/util/fibers/epoll_proactor.cc
+++ b/util/fibers/epoll_proactor.cc
@@ -7,8 +7,20 @@
 #include <absl/time/clock.h>
 #include <signal.h>
 #include <string.h>
+#ifndef __APPLE__
 #include <ucontext.h>
+#endif
 #include <unistd.h>
+
+// Portable ASAN detection: Clang exposes __has_feature; GCC defines __SANITIZE_ADDRESS__.
+#if defined(__has_feature)
+#  if __has_feature(address_sanitizer)
+#    define HELIO_ASAN 1
+#  endif
+#endif
+#if !defined(HELIO_ASAN) && defined(__SANITIZE_ADDRESS__)
+#  define HELIO_ASAN 1
+#endif
 
 #ifdef __linux__
 #include <sys/epoll.h>
@@ -50,46 +62,60 @@ constexpr uint64_t kUserDataCbIndex = 1024;
 constexpr size_t kEvBatchSize = 128;
 constexpr size_t kAltStackSize = 65536;
 
+// Stack-overflow detection via SIGSEGV is only supported on Linux and FreeBSD where the
+// mcontext_t layout is known. Excluded on macOS (incompatible ucontext_t) and under
+// sanitizers (they manage their own sigaltstack; our static buffer would corrupt their teardown).
+#if !defined(__APPLE__) && !defined(HELIO_ASAN)
+static struct sigaction g_old_sigsegv_sa;
+
+// no_instrument_function: this handler runs on the alternate signal stack. If the project
+// is built with -finstrument-functions (HELIO_INSTRUMENT_STACK), the compiler-inserted
+// __cyg_profile_func_enter call would run on the already-constrained alt stack and could
+// itself fault or recurse, so we opt out of instrumentation here.
+__attribute__((no_instrument_function))
 // SIGSEGV handler running on the alternate stack (SA_ONSTACK). Detects fiber stack overflows
 // by comparing the interrupted SP against the active fiber's stack_bottom_. fixedsize_stack
 // has no guard page, so si_addr is unreliable — the overflow silently corrupts adjacent
 // memory and the fault manifests later as a secondary access violation.
-void OnSigSegv(int /*sig*/, siginfo_t* /*info*/, void* ucontext_arg) {
+void OnSigSegv(int sig, siginfo_t* info, void* ucontext_arg) {
   auto* fi = detail::FiberActive();
   uintptr_t stack_bottom = fi ? fi->stack_bottom() : 0;
 
   uintptr_t sp = 0;
-#if defined(__aarch64__)
+#if defined(__aarch64__) && defined(__linux__)
   sp = static_cast<ucontext_t*>(ucontext_arg)->uc_mcontext.sp;
-#elif defined(__x86_64__)
+#elif defined(__aarch64__) && defined(__FreeBSD__)
+  sp = static_cast<ucontext_t*>(ucontext_arg)->uc_mcontext.mc_gpregs.gp_sp;
+#elif defined(__x86_64__) && defined(__linux__)
   sp = static_cast<ucontext_t*>(ucontext_arg)->uc_mcontext.gregs[REG_RSP];
+#elif defined(__x86_64__) && defined(__FreeBSD__)
+  sp = static_cast<ucontext_t*>(ucontext_arg)->uc_mcontext.mc_rsp;
 #endif
 
-  if (stack_bottom && sp < stack_bottom) {
-    const char* name = (fi && fi->name()[0]) ? fi->name() : "unknown";
-    // Write directly to stderr — async-signal-safe, no malloc, no locks.
-    const char prefix[] = "FATAL: Fiber stack overflow detected in fiber '";
-    const char suffix[] = "'\n";
-    write(STDERR_FILENO, prefix, sizeof(prefix) - 1);
-    write(STDERR_FILENO, name, strlen(name));
-    write(STDERR_FILENO, suffix, sizeof(suffix) - 1);
-    abort();
+  // sp == 0 means the architecture/OS combination above didn't extract the register;
+  // skip the check rather than producing a false-positive fatal error.
+  if (sp && stack_bottom && sp < stack_bottom) {
+    const char msg[] = "POSSIBLE FIBER STACK OVERFLOW DETECTED\n";
+    write(STDERR_FILENO, msg, sizeof(msg) - 1);
   }
 
-  // Not a stack overflow — restore default handler and re-raise to produce a core dump.
-  signal(SIGSEGV, SIG_DFL);
-  raise(SIGSEGV);
+  // Restore the previous handler (e.g. Abseil's) and return. The kernel re-executes the
+  // faulting instruction under the restored handler, which produces a full stack trace of
+  // the faulting fiber — including the overflow case where we already wrote the banner above.
+  sigaction(SIGSEGV, &g_old_sigsegv_sa, nullptr);
 }
 
+__attribute__((no_instrument_function))
 void InstallSigSegvHandler() {
   struct sigaction sa;
   memset(&sa, 0, sizeof(sa));
   sa.sa_sigaction = OnSigSegv;
   sa.sa_flags = SA_ONSTACK | SA_SIGINFO;
-  if (sigaction(SIGSEGV, &sa, nullptr) != 0) {
+  if (sigaction(SIGSEGV, &sa, &g_old_sigsegv_sa) != 0) {
     LOG(FATAL) << "sigaction(SIGSEGV) failed: " << strerror(errno);
   }
 }
+#endif  // !__APPLE__ && !sanitizers
 
 #ifdef __linux__
 struct EventsBatch {
@@ -198,6 +224,7 @@ void EpollProactor::Init(unsigned pool_index) {
     LOG(FATAL) << "Init was already called";
   }
 
+#if !defined(__APPLE__) && !defined(HELIO_ASAN)
   // Set up a per-thread alternate signal stack so SIGSEGV can be delivered and diagnosed
   // even when a fiber's stack is fully exhausted.
   {
@@ -214,7 +241,10 @@ void EpollProactor::Init(unsigned pool_index) {
       LOG(FATAL) << "sigaltstack failed: " << strerror(errno);
     }
   }
-  InstallSigSegvHandler();
+  if (pool_index == 0) {
+    InstallSigSegvHandler();
+  }
+#endif  // !sanitizers
 
   centries_.resize(512);  // .index = -1
   next_free_ce_ = 0;

--- a/util/fibers/epoll_proactor.cc
+++ b/util/fibers/epoll_proactor.cc
@@ -7,6 +7,8 @@
 #include <absl/time/clock.h>
 #include <signal.h>
 #include <string.h>
+#include <ucontext.h>
+#include <unistd.h>
 
 #ifdef __linux__
 #include <sys/epoll.h>
@@ -46,6 +48,48 @@ namespace {
 constexpr uint64_t kIgnoreIndex = 0;
 constexpr uint64_t kUserDataCbIndex = 1024;
 constexpr size_t kEvBatchSize = 128;
+constexpr size_t kAltStackSize = 65536;
+
+// SIGSEGV handler running on the alternate stack (SA_ONSTACK). Detects fiber stack overflows
+// by comparing the interrupted SP against the active fiber's stack_bottom_. fixedsize_stack
+// has no guard page, so si_addr is unreliable — the overflow silently corrupts adjacent
+// memory and the fault manifests later as a secondary access violation.
+void OnSigSegv(int /*sig*/, siginfo_t* /*info*/, void* ucontext_arg) {
+  auto* fi = detail::FiberActive();
+  uintptr_t stack_bottom = fi ? fi->stack_bottom() : 0;
+
+  uintptr_t sp = 0;
+#if defined(__aarch64__)
+  sp = static_cast<ucontext_t*>(ucontext_arg)->uc_mcontext.sp;
+#elif defined(__x86_64__)
+  sp = static_cast<ucontext_t*>(ucontext_arg)->uc_mcontext.gregs[REG_RSP];
+#endif
+
+  if (stack_bottom && sp < stack_bottom) {
+    const char* name = (fi && fi->name()[0]) ? fi->name() : "unknown";
+    // Write directly to stderr — async-signal-safe, no malloc, no locks.
+    const char prefix[] = "FATAL: Fiber stack overflow detected in fiber '";
+    const char suffix[] = "'\n";
+    write(STDERR_FILENO, prefix, sizeof(prefix) - 1);
+    write(STDERR_FILENO, name, strlen(name));
+    write(STDERR_FILENO, suffix, sizeof(suffix) - 1);
+    abort();
+  }
+
+  // Not a stack overflow — restore default handler and re-raise to produce a core dump.
+  signal(SIGSEGV, SIG_DFL);
+  raise(SIGSEGV);
+}
+
+void InstallSigSegvHandler() {
+  struct sigaction sa;
+  memset(&sa, 0, sizeof(sa));
+  sa.sa_sigaction = OnSigSegv;
+  sa.sa_flags = SA_ONSTACK | SA_SIGINFO;
+  if (sigaction(SIGSEGV, &sa, nullptr) != 0) {
+    LOG(FATAL) << "sigaction(SIGSEGV) failed: " << strerror(errno);
+  }
+}
 
 #ifdef __linux__
 struct EventsBatch {
@@ -153,6 +197,24 @@ void EpollProactor::Init(unsigned pool_index) {
   if (thread_id_ != 0) {
     LOG(FATAL) << "Init was already called";
   }
+
+  // Set up a per-thread alternate signal stack so SIGSEGV can be delivered and diagnosed
+  // even when a fiber's stack is fully exhausted.
+  {
+    // alignas(16): the kernel requires the alternate stack to be aligned to the platform's
+    // stack alignment boundary. Without it the signal frame pushed by the kernel may be
+    // misaligned, causing faults when the handler uses SSE/NEON registers or when function
+    // prologues enforce 16-byte alignment.
+    alignas(16) static thread_local char alt_stack_mem[kAltStackSize];
+    stack_t ss;
+    ss.ss_sp = alt_stack_mem;
+    ss.ss_size = sizeof(alt_stack_mem);
+    ss.ss_flags = 0;
+    if (sigaltstack(&ss, nullptr) != 0) {
+      LOG(FATAL) << "sigaltstack failed: " << strerror(errno);
+    }
+  }
+  InstallSigSegvHandler();
 
   centries_.resize(512);  // .index = -1
   next_free_ce_ = 0;


### PR DESCRIPTION
This PR adds two safeguards:

- sigaltstack + SIGSEGV handler (epoll_proactor.cc): each proactor thread registers a 64KB alternate signal stack and a SA_ONSTACK | SA_SIGINFO handler. When a stack overflow triggers a fault, the handler reads the interrupted SP from ucontext_t, compares it against the active fiber's stack_bottom_, and if it has overflowed writes a clear message to stderr and aborts _ before the corrupted heap produces a misleading crash.

- InitStackBottom for the dispatcher fiber (scheduler.cc): the dispatcher was the only fiber that never called InitStackBottom, leaving stack_bottom_ null and making overflow detection impossible for it. Now it paints canaries and records its stack bounds the same way worker fibers do.

This won't catch every case _ by the time SIGSEGV fires the heap may already be partially corrupted _ but it reliably produces an actionable message instead of a 285-frame backtrace ending in for example `std::string::_M_dispose` like seen in: https://github.com/dragonflydb/dragonfly/issues/3464



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dispatcher initialization now sets stack canaries for its preallocated stack so runtime stack-safety checks behave consistently with worker fibers.
  * Added platform-specific signal diagnostics (Linux/FreeBSD only; disabled on macOS and when sanitizers are active) to detect and report probable fiber stack overflows.
  * Establishes a per-thread alternate signal stack and enables the overflow handler only on the primary proactor thread for reliable diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->