### PR TITLE
fix: epoll async read/write can stack overflow the dispatch fiber

### DIFF
--- a/util/fibers/epoll_socket.cc
+++ b/util/fibers/epoll_socket.cc
@@ -365,7 +365,20 @@ void EpollSocket::AsyncWriteSome(const iovec* v, uint32_t len, io::AsyncProgress
   Result<size_t> res = TrySend(v, len);
 
   if (res || res.error().value() != EAGAIN) {
-    cb(res);
+    // tl_async_cb_depth guards against unbounded synchronous recursion. When TrySend succeeds
+    // without EAGAIN the callback fires inline — if that callback issues another AsyncWrite
+    // which also succeeds inline, the chain recurses entirely on the dispatcher fiber's stack
+    // (32KB) until it overflows. Deferring via DispatchBrief when already inside a completion
+    // callback breaks the chain: the next iteration of the proactor event loop picks it up.
+    thread_local unsigned tl_async_cb_depth = 0;
+    if (tl_async_cb_depth < 5) {
+      ++tl_async_cb_depth;
+      cb(res);
+      --tl_async_cb_depth;
+    } else {
+      auto* proactor = GetProactor();
+      proactor->DispatchBrief([cb = std::move(cb), res]() mutable { cb(res); });
+    }
     return;
   }
 
@@ -377,8 +390,17 @@ void EpollSocket::AsyncWriteSome(const iovec* v, uint32_t len, io::AsyncProgress
 
 // TODO implement async functionality
 void EpollSocket::AsyncReadSome(const iovec* v, uint32_t len, io::AsyncProgressCb cb) {
+  // Same recursion risk as AsyncWriteSome — defer if already inside a completion callback.
+  thread_local unsigned tl_async_cb_depth = 0;
   auto res = ReadSome(v, len);
-  cb(res);
+  if (tl_async_cb_depth < 5) {
+    ++tl_async_cb_depth;
+    cb(res);
+    --tl_async_cb_depth;
+  } else {
+    auto* proactor = GetProactor();
+    proactor->DispatchBrief([cb = std::move(cb), res]() mutable { cb(res); });
+  }
 }
 
 auto EpollSocket::RecvMsg(const msghdr& msg, int flags) -> Result<size_t> {

--- a/util/fibers/epoll_socket.cc
+++ b/util/fibers/epoll_socket.cc
@@ -365,20 +365,9 @@ void EpollSocket::AsyncWriteSome(const iovec* v, uint32_t len, io::AsyncProgress
   Result<size_t> res = TrySend(v, len);
 
   if (res || res.error().value() != EAGAIN) {
-    // tl_async_cb_depth guards against unbounded synchronous recursion. When TrySend succeeds
-    // without EAGAIN the callback fires inline — if that callback issues another AsyncWrite
-    // which also succeeds inline, the chain recurses entirely on the dispatcher fiber's stack
-    // (32KB) until it overflows. Deferring via DispatchBrief when already inside a completion
-    // callback breaks the chain: the next iteration of the proactor event loop picks it up.
-    thread_local unsigned tl_async_cb_depth = 0;
-    if (tl_async_cb_depth < 5) {
-      ++tl_async_cb_depth;
-      cb(res);
-      --tl_async_cb_depth;
-    } else {
-      auto* proactor = GetProactor();
-      proactor->DispatchBrief([cb = std::move(cb), res]() mutable { cb(res); });
-    }
+    // DispatchBrief may preempt the calling fiber if the task queue is full (waits for space).
+    // Preempting inside a cb context is not allowed — design limitation.
+    GetProactor()->DispatchBrief([cb = std::move(cb), res = std::move(res)]() mutable { cb(res); });
     return;
   }
 
@@ -390,17 +379,8 @@ void EpollSocket::AsyncWriteSome(const iovec* v, uint32_t len, io::AsyncProgress
 
 // TODO implement async functionality
 void EpollSocket::AsyncReadSome(const iovec* v, uint32_t len, io::AsyncProgressCb cb) {
-  // Same recursion risk as AsyncWriteSome — defer if already inside a completion callback.
-  thread_local unsigned tl_async_cb_depth = 0;
   auto res = ReadSome(v, len);
-  if (tl_async_cb_depth < 5) {
-    ++tl_async_cb_depth;
-    cb(res);
-    --tl_async_cb_depth;
-  } else {
-    auto* proactor = GetProactor();
-    proactor->DispatchBrief([cb = std::move(cb), res]() mutable { cb(res); });
-  }
+  cb(res);
 }
 
 auto EpollSocket::RecvMsg(const msghdr& msg, int flags) -> Result<size_t> {

--- a/util/fibers/epoll_socket.cc
+++ b/util/fibers/epoll_socket.cc
@@ -347,9 +347,7 @@ void EpollSocket::AsyncWriteSome(const iovec* v, uint32_t len, io::AsyncProgress
   Result<size_t> res = TrySend(v, len);
 
   if (res || res.error().value() != EAGAIN) {
-    // DispatchBrief may preempt the calling fiber if the task queue is full (waits for space).
-    // Preempting inside a cb context is not allowed — design limitation.
-    GetProactor()->DispatchBrief([cb = std::move(cb), res = std::move(res)]() mutable { cb(res); });
+    GetProactor()->DispatchLocalBrief([cb = std::move(cb), res = std::move(res)]() mutable { cb(res); });
     return;
   }
 


### PR DESCRIPTION
Epoll-backed AsyncWriteSome and AsyncReadSome fire their completion callbacks inline when the operation succeeds immediately _ unlike io_uring which always defers through the submission ring. This is an intentional optimization: avoiding the round-trip through the ring reduces latency for sockets that are immediately readable/writable.

However, if a completion callback re-issues an async operation that also completes immediately (e.g. JournalStreamer::OnCompletion _ AsyncWrite _ AsyncWriteSome _ TrySend succeeds), the chain recurses entirely on the dispatcher fiber's 32KB stack. With enough pending buffers this exhausts the stack, silently corrupts adjacent heap memory, and produces a crash with no actionable diagnostic.

This PR fixes this case by applying the cb via DispatchBrief which breaks the cycle/recursion. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed callback timing for asynchronous writes: completion callbacks are now always dispatched through the async scheduler instead of sometimes running inline, improving stability under high concurrency, reducing risk of stack overflows, and ensuring more consistent callback ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->