### PR TITLE
feat(cloud): add cursor pagination to S3/GCS/Azure List

### DIFF
--- a/examples/gcs_demo.cc
+++ b/examples/gcs_demo.cc
@@ -105,11 +105,11 @@ void Run(SSL_CTX* ctx) {
         cout << "Object: " << item.key << ", size: " << item.size
              << " mtime: " << absl::FromUnixNanos(item.mtime_ns) << endl;
       };
-      string token;
+      string cursor;
       do {
-        ec = gcs.List(bucket, prefix, false, 200, cb, &token);
+        ec = gcs.List(bucket, prefix, false, 200, cb, &cursor);
         if (ec) break;
-      } while (!token.empty());
+      } while (!cursor.empty());
     }
   } else {
     auto cb = [](std::string_view bname) { CONSOLE_INFO << bname; };
@@ -178,11 +178,11 @@ void RunAzure(SSL_CTX* ctx) {
     auto cb = [](const util::cloud::azure::Storage::ListItem& item) {
       CONSOLE_INFO << "Object: " << item.key << " " << item.size << " " << item.mtime_ns << endl;
     };
-    string token;
+    string cursor;
     do {
-      ec = storage.List(bucket, prefix, false, 100, cb, &token);
+      ec = storage.List(bucket, prefix, false, 100, cb, &cursor);
       if (ec) break;
-    } while (!token.empty());
+    } while (!cursor.empty());
     LOG_IF(ERROR, ec) << "Error listing " << bucket << " " << ec.message();
   }
 }

--- a/examples/gcs_demo.cc
+++ b/examples/gcs_demo.cc
@@ -105,7 +105,11 @@ void Run(SSL_CTX* ctx) {
         cout << "Object: " << item.key << ", size: " << item.size
              << " mtime: " << absl::FromUnixNanos(item.mtime_ns) << endl;
       };
-      ec = gcs.List(bucket, prefix, false, cb);
+      string token;
+      do {
+        ec = gcs.List(bucket, prefix, false, 200, cb, &token);
+        if (ec) break;
+      } while (!token.empty());
     }
   } else {
     auto cb = [](std::string_view bname) { CONSOLE_INFO << bname; };
@@ -171,11 +175,14 @@ void RunAzure(SSL_CTX* ctx) {
       }
     }
   } else {
-    ec = storage.List(bucket, prefix, false, 100,
-                      [](const util::cloud::azure::Storage::ListItem& item) {
-                        CONSOLE_INFO << "Object: " << item.key << " " << item.size << " "
-                                     << item.mtime_ns << endl;
-                      });
+    auto cb = [](const util::cloud::azure::Storage::ListItem& item) {
+      CONSOLE_INFO << "Object: " << item.key << " " << item.size << " " << item.mtime_ns << endl;
+    };
+    string token;
+    do {
+      ec = storage.List(bucket, prefix, false, 100, cb, &token);
+      if (ec) break;
+    } while (!token.empty());
     LOG_IF(ERROR, ec) << "Error listing " << bucket << " " << ec.message();
   }
 }

--- a/examples/s3_demo.cc
+++ b/examples/s3_demo.cc
@@ -101,14 +101,21 @@ void ListObjects(const std::string& bucket, const std::string& prefix) {
   bool recursive = prefix.empty();
   util::cloud::aws::S3Storage storage(&creds_provider, ssl_ctx,
                                       util::fb2::ProactorBase::me());
-  auto ec = storage.List(bucket, prefix, recursive,
-                         absl::GetFlag(FLAGS_list_max_results),
-                         [](const util::cloud::aws::S3Storage::ListItem& item) {
-                           std::cout << "* " << item.key << std::endl;
-                         });
-  if (ec) {
-    LOG(ERROR) << "failed to list objects: " << ec.message();
-  }
+  auto print_item = [](const util::cloud::aws::S3Storage::ListItem& item) {
+    std::cout << "* " << item.key << std::endl;
+  };
+
+  unsigned page_size = absl::GetFlag(FLAGS_list_max_results);
+  std::string cursor;
+  unsigned page_num = 0;
+  do {
+    auto ec = storage.List(bucket, prefix, recursive, page_size, print_item, &cursor);
+    if (ec) {
+      LOG(ERROR) << "failed to list objects: " << ec.message();
+      return;
+    }
+    std::cout << "-- page " << page_num++ << " end --" << std::endl;
+  } while (!cursor.empty());
 }
 
 void GetObject(const std::string& bucket, const std::string& key) {

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -134,3 +134,44 @@ def test_list_objects_with_prefix(s3_demo):
         pytest.skip("S3_TEST_BUCKET not set")
     result = _run(s3_demo, "--cmd=list-objects", f"--bucket={bucket}", "--prefix=nonexistent/path/")
     assert result.returncode == 0, f"list-objects with prefix failed:\n{result.stderr}"
+
+
+def test_list_objects_cursor_pagination(minio):
+    """Upload several objects under a unique prefix and verify cursor-driven listing
+    returns every key across multiple pages."""
+    prefix = "helio-ci-test/cursor-pagination/"
+    num_objects = 5
+    page_size = 2
+
+    keys = [f"{prefix}obj_{i:02d}.bin" for i in range(num_objects)]
+    for key in keys:
+        result = _run(
+            minio["binary"],
+            "--cmd=put-object",
+            f"--bucket={minio['bucket']}",
+            f"--key={key}",
+            "--upload_size=16",
+            env=minio["env"],
+        )
+        assert result.returncode == 0, f"put-object {key} failed:\n{result.stderr}"
+
+    result = _run(
+        minio["binary"],
+        "--cmd=list-objects",
+        f"--bucket={minio['bucket']}",
+        f"--prefix={prefix}",
+        f"--list_max_results={page_size}",
+        env=minio["env"],
+    )
+    assert result.returncode == 0, f"list-objects failed:\n{result.stderr}"
+
+    for key in keys:
+        assert key in result.stdout, f"{key!r} missing from listing:\n{result.stdout}"
+
+    # With 5 objects at page size 2: pages 0 and 1 each return 2 objects (truncated),
+    # page 2 returns 1 object (final). Expect at least 3 page markers.
+    expected_pages = (num_objects + page_size - 1) // page_size
+    for i in range(expected_pages):
+        assert f"-- page {i} end --" in result.stdout, (
+            f"missing page {i} marker in stdout:\n{result.stdout}"
+        )

--- a/util/cloud/aws/s3_storage.cc
+++ b/util/cloud/aws/s3_storage.cc
@@ -430,8 +430,10 @@ error_code S3Storage::ListBuckets(function<void(const BucketItem&)> cb) {
 }
 
 error_code S3Storage::List(string_view bucket, string_view prefix, bool recursive,
-                           unsigned max_results, function<void(const ListItem&)> cb) {
+                           unsigned max_results, function<void(const ListItem&)> cb,
+                           string* continuation_token) {
   CHECK(!bucket.empty());
+  DCHECK(continuation_token);
 
   BucketAddressing addressing = ResolveBucketAddressing(creds_, bucket);
   auto pool = CreatePool(addressing.endpoint, ssl_cntx_, pb_, creds_->connect_ms());
@@ -445,37 +447,29 @@ error_code S3Storage::List(string_view bucket, string_view prefix, bool recursiv
     absl::StrAppend(&query, "&delimiter=%2F");
   }
 
-  string base_url = BucketQueryPath(addressing, bucket, query);
-
-  string url = base_url;
-  RobustSender sender(pool.get(), creds_);
-
-  while (true) {
-    detail::EmptyRequestImpl req = FillRequest(addressing.endpoint, url, creds_);
-
-    RobustSender::SenderResult send_res;
-    RETURN_ERROR(sender.Send(kSendRetries, &req, &send_res));
-
-    h2::response_parser<h2::string_body> resp(std::move(*send_res.eb_parser));
-    RETURN_ERROR(send_res.client_handle->Recv(&resp));
-
-    auto msg = resp.release();
-    DVLOG(3) << "aws: List response: " << msg.body();
-
-    bool is_truncated = false;
-    string next_token;
-    RETURN_ERROR(ParseXmlListObjects(msg.body(), &is_truncated, &next_token, cb));
-
-    if (!is_truncated || next_token.empty()) {
-      break;
-    }
-
-    // Build next page URL with continuation token.
-    url = base_url;
+  string url = BucketQueryPath(addressing, bucket, query);
+  if (!continuation_token->empty()) {
     absl::StrAppend(&url, "&continuation-token=");
-    strings::AppendUrlEncoded(next_token, &url);
+    strings::AppendUrlEncoded(*continuation_token, &url);
   }
 
+  RobustSender sender(pool.get(), creds_);
+  detail::EmptyRequestImpl req = FillRequest(addressing.endpoint, url, creds_);
+
+  RobustSender::SenderResult send_res;
+  RETURN_ERROR(sender.Send(kSendRetries, &req, &send_res));
+
+  h2::response_parser<h2::string_body> resp(std::move(*send_res.eb_parser));
+  RETURN_ERROR(send_res.client_handle->Recv(&resp));
+
+  auto msg = resp.release();
+  DVLOG(3) << "aws: List response: " << msg.body();
+
+  bool is_truncated = false;
+  string next_token;
+  RETURN_ERROR(ParseXmlListObjects(msg.body(), &is_truncated, &next_token, cb));
+
+  *continuation_token = (is_truncated ? std::move(next_token) : string{});
   return {};
 }
 

--- a/util/cloud/aws/s3_storage.h
+++ b/util/cloud/aws/s3_storage.h
@@ -8,6 +8,7 @@
 #include <string_view>
 #include <system_error>
 
+#include "absl/base/attributes.h"
 #include "io/file.h"
 #include "util/cloud/aws/aws_creds_provider.h"
 #include "util/cloud/utils.h"
@@ -33,8 +34,18 @@ class S3Storage {
 
   std::error_code ListBuckets(std::function<void(const BucketItem&)> cb);
 
-  std::error_code List(std::string_view bucket, std::string_view prefix, bool recursive,
-                       unsigned max_results, std::function<void(const ListItem&)> cb);
+  // Lists objects under `bucket` matching `prefix`. Performs a single request.
+  //
+  // `max_results` is the page size (max-keys).
+  //
+  // `continuation_token` must not be null: on input it is the resume token (empty means
+  // start from the beginning), on output it holds the token for the next page, or is
+  // cleared if this was the last page. Callers drive pagination by looping until the
+  // token comes back empty.
+  ABSL_MUST_USE_RESULT std::error_code List(std::string_view bucket, std::string_view prefix,
+                                             bool recursive, unsigned max_results,
+                                             std::function<void(const ListItem&)> cb,
+                                             std::string* continuation_token);
 
  private:
   std::string BucketEndpoint(std::string_view bucket) const;

--- a/util/cloud/azure/storage.cc
+++ b/util/cloud/azure/storage.cc
@@ -86,7 +86,7 @@ ContainerName="mycontainer"> <Blobs> <Blob> <Name>my/path.txt</Name> <Properties
                 </Blob>
     .....
 */
-error_code ParseXmlListBlobs(string_view xml_resp,
+error_code ParseXmlListBlobs(string_view xml_resp, string* next_marker,
                              absl::FunctionRef<void(const StorageListItem&)> cb) {
   pugi::xml_document doc;
   pugi::xml_parse_result result = doc.load_buffer(xml_resp.data(), xml_resp.size());
@@ -108,6 +108,10 @@ error_code ParseXmlListBlobs(string_view xml_resp,
     return make_error_code(errc::bad_message);
   }
   VLOG(2) << "ListBlobs Response: " << xml_resp;
+
+  if (next_marker) {
+    *next_marker = root.child_value("NextMarker");
+  }
 
   // Under blobs there can be either Blob or BlobPrefix nodes.
   // The former is a file, the latter is a "directory".
@@ -434,7 +438,10 @@ error_code Storage::ListContainers(function<void(const ContainerItem&)> cb) {
 }
 
 error_code Storage::List(string_view container, std::string_view prefix, bool recursive,
-                         unsigned max_results, function<void(const ListItem&)> cb) {
+                         unsigned max_results, function<void(const ListItem&)> cb,
+                         string* continuation_token) {
+  DCHECK(continuation_token);
+
   SSL_CTX* ctx = creds_->IsHttps() ? http::TlsClient::CreateSslContext() : nullptr;
   absl::Cleanup cleanup([ctx] {
     if (ctx)
@@ -454,6 +461,10 @@ error_code Storage::List(string_view container, std::string_view prefix, bool re
   if (!recursive) {
     absl::StrAppend(&url, "&delimiter=%2f");
   }
+  if (!continuation_token->empty()) {
+    absl::StrAppend(&url, "&marker=");
+    strings::AppendUrlEncoded(*continuation_token, &url);
+  }
 
   detail::EmptyRequestImpl req = FillRequest(endpoint, url, creds_);
   RobustSender sender(pool.get(), creds_);
@@ -464,7 +475,7 @@ error_code Storage::List(string_view container, std::string_view prefix, bool re
   RETURN_ERROR(send_res.client_handle->Recv(&resp));
 
   auto msg = resp.release();
-  RETURN_ERROR(ParseXmlListBlobs(msg.body(), cb));
+  RETURN_ERROR(ParseXmlListBlobs(msg.body(), continuation_token, cb));
   return {};
 }
 

--- a/util/cloud/azure/storage.h
+++ b/util/cloud/azure/storage.h
@@ -7,6 +7,7 @@
 #include <string_view>
 #include <system_error>
 
+#include "absl/base/attributes.h"
 #include "io/file.h"
 #include "util/cloud/azure/creds_provider.h"
 #include "util/cloud/utils.h"
@@ -25,8 +26,19 @@ class Storage {
 
   using ListItem = StorageListItem;
   std::error_code ListContainers(std::function<void(const ContainerItem&)> cb);
-  std::error_code List(std::string_view container, std::string_view prefix, bool recursive,
-                       unsigned max_results, std::function<void(const ListItem&)> cb);
+
+  // Lists blobs under `container` matching `prefix`. Performs a single request.
+  //
+  // `max_results` is the page size (maxresults).
+  //
+  // `continuation_token` must not be null: on input it is the resume marker (empty means
+  // start from the beginning), on output it holds the marker for the next page, or is
+  // cleared if this was the last page. Callers drive pagination by looping until the
+  // marker comes back empty.
+  ABSL_MUST_USE_RESULT std::error_code List(std::string_view container, std::string_view prefix,
+                                             bool recursive, unsigned max_results,
+                                             std::function<void(const ListItem&)> cb,
+                                             std::string* continuation_token);
 
  private:
   Credentials* creds_;

--- a/util/cloud/gcp/gcs.cc
+++ b/util/cloud/gcp/gcs.cc
@@ -384,108 +384,114 @@ error_code GCS::ListBuckets(ListBucketCb cb) {
       break;
     }
     absl::string_view page_token{it->value.GetString(), it->value.GetStringLength()};
-    empty_req.SetUrl(absl::StrCat(url, "&pageToken=", page_token));
+    string next_url = url;
+    absl::StrAppend(&next_url, "&pageToken=");
+    strings::AppendUrlEncoded(page_token, &next_url);
+    empty_req.SetUrl(next_url);
   }
   return {};
 }
 
-error_code GCS::List(string_view bucket, string_view prefix, bool recursive, ListObjectCb cb) {
+error_code GCS::List(string_view bucket, string_view prefix, bool recursive,
+                     unsigned max_results, ListObjectCb cb, string* page_token) {
   CHECK(!bucket.empty());
+  DCHECK(page_token);
 
   string url = "/storage/v1/b/";
-  absl::StrAppend(&url, bucket, "/o?maxResults=200&prefix=");
+  absl::StrAppend(&url, bucket, "/o?maxResults=", max_results, "&prefix=");
   strings::AppendUrlEncoded(prefix, &url);
   if (!recursive) {
     absl::StrAppend(&url, "&delimiter=%2f");
+  }
+  if (!page_token->empty()) {
+    absl::StrAppend(&url, "&pageToken=");
+    strings::AppendUrlEncoded(*page_token, &url);
   }
 
   detail::EmptyRequestImpl empty_req = detail::CreateGCPEmptyRequest(
       h2::verb::get, creds_provider_.ServiceEndpoint(), url, creds_provider_.access_token());
 
-  rj::Document doc;
   RobustSender sender(client_pool_.get(), &creds_provider_);
-  while (true) {
-    RobustSender::SenderResult send_res;
-    RETURN_ERROR(sender.Send(2, &empty_req, &send_res));
+  RobustSender::SenderResult send_res;
+  RETURN_ERROR(sender.Send(2, &empty_req, &send_res));
 
-    h2::response_parser<h2::string_body> resp(std::move(*send_res.eb_parser));
+  h2::response_parser<h2::string_body> resp(std::move(*send_res.eb_parser));
+  RETURN_ERROR(send_res.client_handle->Recv(&resp));
 
-    RETURN_ERROR(send_res.client_handle->Recv(&resp));
+  auto msg = resp.release();
+  VLOG(1) << "List response: " << msg.body();
 
-    auto msg = resp.release();
-    VLOG(1) << "List response: " << msg.body();
+  rj::Document doc;
+  doc.ParseInsitu(&msg.body().front());
+  if (doc.HasParseError()) {
+    return make_error_code(errc::bad_message);
+  }
 
-    doc.ParseInsitu(&msg.body().front());
-    if (doc.HasParseError()) {
-      return make_error_code(errc::bad_message);
-    }
+  auto it = doc.FindMember("items");
+  if (it != doc.MemberEnd()) {
+    FETCH_ARRAY_MEMBER(it->value);
 
-    auto it = doc.FindMember("items");
-    if (it != doc.MemberEnd()) {
-      FETCH_ARRAY_MEMBER(it->value);
+    for (size_t i = 0; i < array.Size(); ++i) {
+      const rapidjson::Value& item = array[i];
 
-      for (size_t i = 0; i < array.Size(); ++i) {
-        const rapidjson::Value& item = array[i];
+      /*
+         "kind": "storage#object",
+            "id": "mybucket/mypath/1730099621171118",
+            "selfLink": "https://www.googleapis.com/storage/v1/b/mybucket/o/mypath",
+            "mediaLink":
+         "https://storage.googleapis.com/download/storage/v1/b/mybucket/o/mypath?generation=1730099621171118&alt=media",
+            "name": "mypath",
+            "bucket": "mybucket",
+            "generation": "1730099621171118",
+            "metageneration": "1",
+            "storageClass": "STANDARD",
+            "size": "28466176",
+            "md5Hash": "...",
+            "crc32c": "...",
+            "etag": "....",
+            "timeCreated": "2024-10-28T07:13:41.174Z",
+            "updated": "2024-10-28T07:13:41.174Z",
+            "timeStorageClassUpdated": "2024-10-28T07:13:41.174Z"
 
-        /*
-           "kind": "storage#object",
-              "id": "mybucket/mypath/1730099621171118",
-              "selfLink": "https://www.googleapis.com/storage/v1/b/mybucket/o/mypath",
-              "mediaLink":
-           "https://storage.googleapis.com/download/storage/v1/b/mybucket/o/mypath?generation=1730099621171118&alt=media",
-              "name": "mypath",
-              "bucket": "mybucket",
-              "generation": "1730099621171118",
-              "metageneration": "1",
-              "storageClass": "STANDARD",
-              "size": "28466176",
-              "md5Hash": "...",
-              "crc32c": "...",
-              "etag": "....",
-              "timeCreated": "2024-10-28T07:13:41.174Z",
-              "updated": "2024-10-28T07:13:41.174Z",
-              "timeStorageClassUpdated": "2024-10-28T07:13:41.174Z"
+      */
 
-        */
-
-        auto it = item.FindMember("name");
-        CHECK(it != item.MemberEnd());
-        absl::string_view key_name(it->value.GetString(), it->value.GetStringLength());
-        it = item.FindMember("size");
-        CHECK(it != item.MemberEnd());
-        absl::string_view sz_str(it->value.GetString(), it->value.GetStringLength());
-        size_t item_size = 0;
-        CHECK(absl::SimpleAtoi(sz_str, &item_size));
-        it = item.FindMember("updated");
-        CHECK(it != item.MemberEnd());
-        absl::string_view mtime_str(it->value.GetString(), it->value.GetStringLength());
-        absl::Time time;
-        string err;
-        int64_t time_ns = 0;
-        if (absl::ParseTime(absl::RFC3339_full, mtime_str, &time, &err)) {
-          time_ns = absl::ToUnixNanos(time);
-        } else {
-          LOG(ERROR) << "Failed to parse time: " << mtime_str << " " << err;
-        }
-        cb(ObjectItem{item_size, key_name, time_ns, false});
+      auto it = item.FindMember("name");
+      CHECK(it != item.MemberEnd());
+      absl::string_view key_name(it->value.GetString(), it->value.GetStringLength());
+      it = item.FindMember("size");
+      CHECK(it != item.MemberEnd());
+      absl::string_view sz_str(it->value.GetString(), it->value.GetStringLength());
+      size_t item_size = 0;
+      CHECK(absl::SimpleAtoi(sz_str, &item_size));
+      it = item.FindMember("updated");
+      CHECK(it != item.MemberEnd());
+      absl::string_view mtime_str(it->value.GetString(), it->value.GetStringLength());
+      absl::Time time;
+      string err;
+      int64_t time_ns = 0;
+      if (absl::ParseTime(absl::RFC3339_full, mtime_str, &time, &err)) {
+        time_ns = absl::ToUnixNanos(time);
+      } else {
+        LOG(ERROR) << "Failed to parse time: " << mtime_str << " " << err;
       }
+      cb(ObjectItem{item_size, key_name, time_ns, false});
     }
-    it = doc.FindMember("prefixes");
-    if (it != doc.MemberEnd()) {
-      FETCH_ARRAY_MEMBER(it->value);
-      for (size_t i = 0; i < array.Size(); ++i) {
-        const auto& item = array[i];
-        absl::string_view str(item.GetString(), item.GetStringLength());
-        cb(ObjectItem{0, str, 0, true});
-      }
+  }
+  it = doc.FindMember("prefixes");
+  if (it != doc.MemberEnd()) {
+    FETCH_ARRAY_MEMBER(it->value);
+    for (size_t i = 0; i < array.Size(); ++i) {
+      const auto& item = array[i];
+      absl::string_view str(item.GetString(), item.GetStringLength());
+      cb(ObjectItem{0, str, 0, true});
     }
+  }
 
-    it = doc.FindMember("nextPageToken");
-    if (it == doc.MemberEnd()) {
-      break;
-    }
-    absl::string_view page_token{it->value.GetString(), it->value.GetStringLength()};
-    empty_req.SetUrl(absl::StrCat(url, "&pageToken=", page_token));
+  it = doc.FindMember("nextPageToken");
+  if (it != doc.MemberEnd()) {
+    page_token->assign(it->value.GetString(), it->value.GetStringLength());
+  } else {
+    page_token->clear();
   }
   return {};
 }

--- a/util/cloud/gcp/gcs.h
+++ b/util/cloud/gcp/gcs.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 
+#include "absl/base/attributes.h"
 #include "util/cloud/gcp/gcp_creds_provider.h"
 #include "util/http/http_client.h"
 #include "util/http/https_client_pool.h"
@@ -28,8 +29,18 @@ class GCS {
   ~GCS();
 
   std::error_code ListBuckets(ListBucketCb cb);
-  std::error_code List(std::string_view bucket, std::string_view prefix, bool recursive,
-                       ListObjectCb cb);
+
+  // Lists objects under `bucket` matching `prefix`. Performs a single request.
+  //
+  // `max_results` is the page size (maxResults).
+  //
+  // `page_token` must not be null: on input it is the resume token (empty means start
+  // from the beginning), on output it holds the token for the next page, or is cleared
+  // if this was the last page. Callers drive pagination by looping until the token
+  // comes back empty.
+  ABSL_MUST_USE_RESULT std::error_code List(std::string_view bucket, std::string_view prefix,
+                                             bool recursive, unsigned max_results, ListObjectCb cb,
+                                             std::string* page_token);
 
   http::ClientPool* GetConnectionPool() {
     return client_pool_.get();


### PR DESCRIPTION
## Summary
- Extend `S3Storage::List`, `GCS::List`, and `azure::Storage::List` with a required `continuation_token` in/out pointer. Each call performs a single request: the token is read on input (empty = start from the beginning) and overwritten with the next page's token on output, or cleared when the last page is reached. Callers drive pagination by looping until the token comes back empty.
- `GCS::List` gains a `max_results` parameter (was hardcoded to 200), matching S3 and Azure.
- Azure's `List` now parses `<NextMarker>` — previously it only returned the first page.
- `examples/s3_demo.cc` drives `list-objects` via the cursor loop and prints `-- page N end --` markers so pagination can be exercised from tests. `examples/gcs_demo.cc` loops externally for the GCS and Azure listings.
- New `test_list_objects_cursor_pagination` in `tests/test_s3.py` uploads 5 objects, lists with page size 2 against MinIO, and asserts every key plus 3 page markers appear in the output.

## Test plan
- [x] `ninja s3_demo gcs_demo` (build-dbg)
- [x] `pytest tests/test_s3.py -v` against local MinIO — `test_put_get_object_minio` and `test_list_objects_cursor_pagination` pass
- [x] Manual end-to-end: `s3_demo --cmd=list-objects --list_max_results=2` on 5 objects produces 3 pages (2/2/1)
- [ ] CI green against real S3/MinIO

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Listings across cloud providers now use caller-driven, single-page pagination with configurable page sizes, explicit per-page end markers during multi-page listings, and consistent resume-token handling.

* **Bug Fixes**
  * Improved pagination reliability and immediate error reporting when page requests fail.

* **Tests**
  * Added an integration test that verifies cursor-based pagination, page-size behavior, and per-page end markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->