### PR TITLE
test(fibers): add DispatchLocalBrief test

### DIFF
--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -656,6 +656,24 @@ TEST_P(ProactorTest, AsyncCall) {
   EXPECT_EQ(std::cv_status::no_timeout, ec.await_until([&] { return signal; }, next));
 }
 
+TEST_P(ProactorTest, DispatchLocalBrief) {
+  constexpr unsigned kCount = ProactorBase::kTaskQueueLen * 2;
+  std::atomic<unsigned> counter{0};
+  EventCount ec;
+
+  proactor()->Await([&] {
+    for (unsigned i = 0; i < kCount; ++i) {
+      proactor()->DispatchLocalBrief([&counter] {
+        counter.fetch_add(1, std::memory_order_relaxed);
+      });
+    }
+    proactor()->DispatchLocalBrief([&ec] { ec.notify(); });
+  });
+
+  ec.await([&] { return counter.load() == kCount; });
+  EXPECT_EQ(kCount, counter.load());
+}
+
 TEST_P(ProactorTest, AwaitBrief) {
   thread_local int val = 5;
 

--- a/util/fibers/proactor_base.h
+++ b/util/fibers/proactor_base.h
@@ -116,10 +116,17 @@ class ProactorBase {
     return task_queue_.is_full();
   }
 
-  //! Fire and forget - does not wait for the function to run called.
-  //! `f` should not block, lock on mutexes or Await.
-  //! Might block the calling fiber if the queue is full.
+  // Fire and forget - does not wait for the function to run called.
+  // `f` should not block, lock on mutexes or Await.
+  // Might block the calling fiber if the queue is full.
+  // Returns false if the task was enqueued without waiting, true otherwise.
   template <typename Func> bool DispatchBrief(Func&& brief);
+
+  // DispatchLocalBrief is similar to DispatchBrief but is used to dispatch tasks asynchronously
+  // to the same proactor thread.
+  // Unlike DispatchBrief, it never blocks, and if the task queue is full,
+  // it will unload the queue by fetching and running tasks until there is space in the queue.
+  template <typename Func> void DispatchLocalBrief(Func&& brief);
 
   //! Similarly to DispatchBrief but 'f' is wrapped in fiber.
   //! f is allowed to fiber-block or await.
@@ -394,6 +401,19 @@ template <typename Func> bool ProactorBase::DispatchBrief(Func&& f) {
   }
 
   return true;
+}
+
+template <typename Func> void ProactorBase::DispatchLocalBrief(Func&& brief) {
+  assert(InMyThread());
+  while (true) {
+    if (EmplaceTaskQueue(std::forward<Func>(brief)))
+      return;
+
+    Tasklet task;
+    if (task_queue_.try_dequeue(task)) {
+      task();
+    }
+  }
 }
 
 template <typename Func> auto ProactorBase::AwaitBrief(Func&& f) -> decltype(f()) {


### PR DESCRIPTION
## Summary

- Adds `ProactorBase::DispatchLocalBrief`, a fire-and-forget dispatch that must run on the proactor's own thread and never blocks: when the task queue is full, it drains queued tasklets until there is room to enqueue the new one.
- Adds `ProactorTest.DispatchLocalBrief` covering all four proactor/IP variants (epoll/uring × IPv4/IPv6), submitting `2 × kTaskQueueLen` tasks to exercise the self-drain path with an `EventCount` sentinel for completion.
- Tidies `DispatchBrief`'s doc comment (`//!` → `//`) and documents its return value semantics.

## Changes

- `util/fibers/proactor_base.h`: adds `DispatchLocalBrief` declaration and template implementation; updates `DispatchBrief` doc comment.
- `util/fibers/fibers_test.cc`: adds `ProactorTest.DispatchLocalBrief`.

## Test plan

- [x] `build-dbg/fibers_test --gtest_filter="*DispatchLocalBrief*"` — all 4 variants pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new task dispatch method with integrated queue management and automatic overflow handling for scheduling work on the proactor thread.

* **Tests**
  * Added test coverage for the new dispatch method, validating concurrent task execution and synchronization behavior.

* **Documentation**
  * Updated dispatch method documentation to clarify return semantics and behavior expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->