### PR TITLE
fix(fibers): break-cb leaks under sustained accept+close churn

### DIFF
--- a/util/cloud/aws/s3_storage.h
+++ b/util/cloud/aws/s3_storage.h
@@ -34,6 +34,14 @@ class S3Storage {
 
   std::error_code ListBuckets(std::function<void(const BucketItem&)> cb);
 
+  // Deprecated wrapper, kept only to be able to backport helio to older Dragonfly branches.
+  ABSL_MUST_USE_RESULT std::error_code List(std::string_view bucket, std::string_view prefix,
+                                            bool recursive, unsigned max_results,
+                                            std::function<void(const ListItem&)> cb) {
+    std::string continuation_token;
+    return List(bucket, prefix, recursive, max_results, std::move(cb), &continuation_token);
+  }
+
   // Lists objects under `bucket` matching `prefix`. Performs a single request.
   //
   // `max_results` is the page size (max-keys).
@@ -43,9 +51,9 @@ class S3Storage {
   // cleared if this was the last page. Callers drive pagination by looping until the
   // token comes back empty.
   ABSL_MUST_USE_RESULT std::error_code List(std::string_view bucket, std::string_view prefix,
-                                             bool recursive, unsigned max_results,
-                                             std::function<void(const ListItem&)> cb,
-                                             std::string* continuation_token);
+                                            bool recursive, unsigned max_results,
+                                            std::function<void(const ListItem&)> cb,
+                                            std::string* continuation_token);
 
  private:
   std::string BucketEndpoint(std::string_view bucket) const;

--- a/util/cloud/azure/storage.cc
+++ b/util/cloud/azure/storage.cc
@@ -437,6 +437,12 @@ error_code Storage::ListContainers(function<void(const ContainerItem&)> cb) {
   return {};
 }
 
+std::error_code Storage::List(std::string_view container, std::string_view prefix, bool recursive,
+                              unsigned max_results, std::function<void(const ListItem&)> cb) {
+  string continuation_token;
+  return List(container, prefix, recursive, max_results, std::move(cb), &continuation_token);
+}
+
 error_code Storage::List(string_view container, std::string_view prefix, bool recursive,
                          unsigned max_results, function<void(const ListItem&)> cb,
                          string* continuation_token) {

--- a/util/cloud/azure/storage.h
+++ b/util/cloud/azure/storage.h
@@ -27,6 +27,11 @@ class Storage {
   using ListItem = StorageListItem;
   std::error_code ListContainers(std::function<void(const ContainerItem&)> cb);
 
+  // Deprecated wrapper, kept only to be able to backport helio to older Dragonfly branches.
+  ABSL_MUST_USE_RESULT std::error_code List(std::string_view container, std::string_view prefix,
+                                            bool recursive, unsigned max_results,
+                                            std::function<void(const ListItem&)> cb);
+
   // Lists blobs under `container` matching `prefix`. Performs a single request.
   //
   // `max_results` is the page size (maxresults).

--- a/util/cloud/gcp/gcs.cc
+++ b/util/cloud/gcp/gcs.cc
@@ -392,8 +392,19 @@ error_code GCS::ListBuckets(ListBucketCb cb) {
   return {};
 }
 
-error_code GCS::List(string_view bucket, string_view prefix, bool recursive,
-                     unsigned max_results, ListObjectCb cb, string* page_token) {
+std::error_code GCS::List(std::string_view bucket, std::string_view prefix, bool recursive,
+                          ListObjectCb cb) {
+  string page_token;
+  do {
+    error_code ec = List(bucket, prefix, recursive, 1000, cb, &page_token);
+    if (ec)
+      return ec;
+  } while (!page_token.empty());
+  return {};
+}
+
+error_code GCS::List(string_view bucket, string_view prefix, bool recursive, unsigned max_results,
+                     ListObjectCb cb, string* page_token) {
   CHECK(!bucket.empty());
   DCHECK(page_token);
 

--- a/util/cloud/gcp/gcs.h
+++ b/util/cloud/gcp/gcs.h
@@ -30,6 +30,10 @@ class GCS {
 
   std::error_code ListBuckets(ListBucketCb cb);
 
+  // Deprecated wrapper, kept only to be able to backport helio to older Dragonfly branches.
+  ABSL_MUST_USE_RESULT std::error_code List(std::string_view bucket, std::string_view prefix,
+                                            bool recursive, ListObjectCb cb);
+
   // Lists objects under `bucket` matching `prefix`. Performs a single request.
   //
   // `max_results` is the page size (maxResults).
@@ -39,8 +43,8 @@ class GCS {
   // if this was the last page. Callers drive pagination by looping until the token
   // comes back empty.
   ABSL_MUST_USE_RESULT std::error_code List(std::string_view bucket, std::string_view prefix,
-                                             bool recursive, unsigned max_results, ListObjectCb cb,
-                                             std::string* page_token);
+                                            bool recursive, unsigned max_results, ListObjectCb cb,
+                                            std::string* page_token);
 
   http::ClientPool* GetConnectionPool() {
     return client_pool_.get();

--- a/util/fibers/epoll_socket.cc
+++ b/util/fibers/epoll_socket.cc
@@ -47,14 +47,6 @@ int CreateSockFd(int family) {
   return socket(family, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, IPPROTO_TCP);
 }
 
-/*void RegisterEvents(int poll_fd, int sock_fd, uint32_t user_data) {
-  epoll_event ev;
-  ev.events = kEventMask;
-  ev.data.u32 = user_data;
-
-  CHECK_EQ(0, epoll_ctl(poll_fd, EPOLL_CTL_MOD, sock_fd, &ev));
-}*/
-
 #elif defined(__FreeBSD__) || defined(__APPLE__)
 
 constexpr int kEventMask = POLLIN | POLLOUT;
@@ -80,16 +72,6 @@ int CreateSockFd(int family) {
   }
   return fd;
 }
-
-/*
-void RegisterEvents(int poll_fd, int sock_fd, uint32_t user_data) {
-  struct kevent kev[2];
-  uint64_t ud = user_data;
-  EV_SET(&kev[0], sock_fd, EVFILT_WRITE, EV_ADD, 0, 0, (void*)ud);
-  EV_SET(&kev[1], sock_fd, EVFILT_READ, EV_ADD, 0, 0, (void*)ud);
-  CHECK_EQ(0, kevent(poll_fd, kev, 2, NULL, 0, NULL));
-}
-*/
 
 #else
 #error "Unsupported platform"
@@ -545,7 +527,11 @@ void EpollSocket::Wakey(uint32_t ev_mask, int error, EpollProactor* cntr) {
 
   HandleAsyncRequest(ev_mask);
   if (error_cb_ && (ev_mask & kErrMask)) {
-    error_cb_(ev_mask);
+    // Single-shot: a follow-up edge (e.g. POLLHUP after POLLRDHUP) on the
+    // same fd must not invoke the user callback twice.
+    auto cb = std::move(error_cb_);
+    error_cb_ = {};
+    cb(ev_mask);
   }
 }
 

--- a/util/fibers/epoll_socket.h
+++ b/util/fibers/epoll_socket.h
@@ -41,7 +41,7 @@ class EpollSocket : public LinuxSocketBase {
   void CancelOnErrorCb() final;
 
   using FiberSocketBase::IsConnClosed;
-  void RegisterOnRecv(std::function<void (const RecvNotification&)> cb) final;
+  void RegisterOnRecv(std::function<void(const RecvNotification&)> cb) final;
   void ResetOnRecvHook() final;
 
  private:
@@ -78,7 +78,7 @@ class EpollSocket : public LinuxSocketBase {
 
   // Read path
   struct OnRecvRecord {
-    std::function<void (const RecvNotification&)> cb;
+    std::function<void(const RecvNotification&)> cb;
   };
 
   union {

--- a/util/fibers/fiber_socket_test.cc
+++ b/util/fibers/fiber_socket_test.cc
@@ -2,8 +2,15 @@
 // Author: Roman Gershman (romange@gmail.com)
 //
 
+#include <arpa/inet.h>
 #include <gmock/gmock.h>
+#include <netinet/in.h>
+#include <sys/resource.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
 
+#include <atomic>
 #include <thread>
 
 #include "base/gtest.h"
@@ -21,10 +28,11 @@
 namespace util {
 namespace fb2 {
 
-constexpr uint32_t kRingDepth = 8;
 using namespace testing;
 
 #ifdef __linux__
+constexpr uint32_t kRingDepth = 8;
+
 void InitProactor(ProactorBase* p) {
   if (p->GetKind() == ProactorBase::IOURING) {
     static_cast<UringProactor*>(p)->Init(0, kRingDepth);
@@ -37,6 +45,20 @@ void InitProactor(ProactorBase* p) {
   static_cast<EpollProactor*>(p)->Init(0);
 }
 #endif
+
+int ConnectClient(uint16_t listen_port) {
+  int fd = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  CHECK_GE(fd, 0) << "socket() failed: " << strerror(errno);
+
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(listen_port);
+  CHECK_EQ(1, inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr));
+  CHECK_EQ(0, ::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)))
+      << "connect(AF_INET) failed: " << strerror(errno);
+
+  return fd;
+}
 
 using namespace std;
 
@@ -59,6 +81,8 @@ class FiberSocketTest : public testing::TestWithParam<TestParams> {
   void SetUp() final;
 
   void TearDown() final;
+
+  void LaunchAcceptFiber(bool register_error_cb);
 
   static void SetUpTestCase() {
     testing::FLAGS_gtest_death_test_style = "threadsafe";
@@ -85,7 +109,9 @@ class FiberSocketTest : public testing::TestWithParam<TestParams> {
   Fiber accept_fb_;
   std::error_code accept_ec_;
   FiberSocketBase::endpoint_type listen_ep_;
-  uint32_t conn_sock_err_mask_ = 0;
+  std::atomic_uint conn_sock_err_mask_{0};
+  std::atomic_uint conn_sock_err_count_{0};
+  Done error_cb_called_;
 };
 
 INSTANTIATE_TEST_SUITE_P(Engines, FiberSocketTest,
@@ -150,8 +176,16 @@ void FiberSocketTest::SetUp() {
     address = boost::asio::ip::make_address("127.0.0.1");  // IPv4 loopback
   }
   listen_ep_ = FiberSocketBase::endpoint_type{address, listen_port_};
+  conn_sock_err_mask_ = 0;
+  conn_sock_err_count_.store(0, std::memory_order_relaxed);
+  error_cb_called_.Reset();
 
-  accept_fb_ = proactor_->LaunchFiber("AcceptFb", [this] {
+  LaunchAcceptFiber(true);
+}
+
+void FiberSocketTest::LaunchAcceptFiber(bool register_error_cb) {
+  accept_ec_.clear();
+  accept_fb_ = proactor_->LaunchFiber("AcceptFb", [this, register_error_cb] {
     auto accept_res = listen_socket_->Accept();
     VLOG_IF(1, !accept_res) << "Accept res: " << accept_res.error();
 
@@ -160,10 +194,14 @@ void FiberSocketTest::SetUp() {
       FiberSocketBase* sock = *accept_res;
       conn_socket_.reset(sock);
       conn_socket_->SetProactor(proactor_.get());
-      conn_socket_->RegisterOnErrorCb([this](uint32_t mask) {
-        LOG(INFO) << "Error mask: " << mask;
-        conn_sock_err_mask_ = mask;
-      });
+      if (register_error_cb) {
+        conn_socket_->RegisterOnErrorCb([this](uint32_t mask) {
+          LOG(INFO) << "Error mask: " << mask;
+          conn_sock_err_mask_ |= mask;
+          conn_sock_err_count_.fetch_add(1, std::memory_order_relaxed);
+          error_cb_called_.Notify();
+        });
+      }
     } else {
       accept_ec_ = accept_res.error();
     }
@@ -334,6 +372,126 @@ TEST_P(FiberSocketTest, PollCancel) {
 
   // Should not be updated due to cancellation.
   EXPECT_EQ(0, conn_sock_err_mask_);
+}
+
+// Regression test for EpollSocket::Wakey(): a staged peer disconnect can
+// deliver multiple error edges (for example EPOLLRDHUP followed by POLLHUP),
+// but RegisterOnErrorCb must stay single-shot.
+TEST_P(FiberSocketTest, PollSingleShot) {
+  if (UseIPv6()) {
+    GTEST_SKIP() << "PollSingleShot is limited to IPv4";
+  }
+
+  int fd = ConnectClient(listen_port_);
+
+  accept_fb_.Join();
+  ASSERT_FALSE(accept_ec_);
+
+  ASSERT_EQ(0, ::shutdown(fd, SHUT_WR));
+  ASSERT_TRUE(error_cb_called_.WaitFor(1s)) << "first callback did not fire";
+  error_cb_called_.Reset();
+  LOG(INFO) << "First callback fired, now activating the second one";
+
+  // We enforce RST event on server socket by setting linger option with timeout=0.
+  struct linger ling;
+  ling.l_onoff = 1;
+  ling.l_linger = 0;
+  CHECK_EQ(0, setsockopt(fd, SOL_SOCKET, SO_LINGER, &ling, sizeof(ling)));
+  CHECK_EQ(0, ::close(fd));
+
+  ASSERT_FALSE(error_cb_called_.WaitFor(100ms))
+      << "second callback fired, but should have been single-shot";
+
+  EXPECT_EQ(1u, conn_sock_err_count_.load())
+      << "error callback fired " << conn_sock_err_count_.load()
+      << " times, mask=" << conn_sock_err_mask_;
+#ifdef __linux__
+  EXPECT_TRUE(conn_sock_err_mask_ & POLLRDHUP) << "mask=" << conn_sock_err_mask_;
+#endif
+}
+
+// Regression test for uring stale callback-slot cancellation: after socket A's
+// error callback fires, socket B can reuse A's freed completion slot, and then
+// A.CancelOnErrorCb() must not remove B's live poll request.
+TEST_P(FiberSocketTest, PollCancelSlotReuse) {
+  if (UseIPv6()) {
+    GTEST_SKIP() << "PollSingleShot is limited to IPv4";
+  }
+
+  Done done;
+  std::atomic_uint a_count{0}, b_count{0};
+
+  // Accept connection A first and take ownership away from the fixture. The
+  // fixture installs its own error callback, so we immediately cancel it below
+  // and re-arm the socket under the precise sequence this regression needs.
+  int fd_a = ConnectClient(listen_port_);
+  accept_fb_.Join();
+  ASSERT_FALSE(accept_ec_);
+  std::unique_ptr<FiberSocketBase> sock_a = std::move(conn_socket_);
+  ASSERT_TRUE(sock_a);
+
+  proactor_->Await([&] { sock_a->CancelOnErrorCb(); });
+
+  // Accept connection B before A fires. This is important: if we accepted B
+  // later, the accept machinery itself could consume the just-freed uring
+  // completion slot and weaken the repro.
+  LaunchAcceptFiber(false);
+  int fd_b = ConnectClient(listen_port_);
+  accept_fb_.Join();
+  ASSERT_FALSE(accept_ec_);
+  std::unique_ptr<FiberSocketBase> sock_b = std::move(conn_socket_);
+  ASSERT_TRUE(sock_b);
+
+  // Arm A. The callback only records that A fired; the interesting part is what
+  // happens to A's old poll slot after the callback returns.
+  proactor_->Await([&] {
+    sock_a->RegisterOnErrorCb([&](uint32_t) {
+      a_count.fetch_add(1, std::memory_order_relaxed);
+      done.Notify();
+    });
+  });
+
+  // Trigger A's callback. In the buggy uring path, the callback completion slot
+  // is returned to the free-list before the callback runs, and `fired` is not
+  // marked, so a later stale CancelOnErrorCb() can target a reused slot.
+  ASSERT_EQ(0, ::shutdown(fd_a, SHUT_WR)) << strerror(errno);
+  ASSERT_TRUE(done.WaitFor(1s)) << "A callback did not fire";
+  done.Reset();
+
+  EXPECT_EQ(1u, a_count.load());
+
+  // This is the critical sequence:
+  // 1. Register B so it reuses A's just-freed poll slot.
+  // 2. Immediately cancel A.
+  // Without `data->fired = true`, A's stale cancel may remove B's live poll.
+  proactor_->Await([&] {
+    sock_b->RegisterOnErrorCb([&](uint32_t) {
+      b_count.fetch_add(1, memory_order_relaxed);
+      done.Notify();
+    });
+    sock_a->CancelOnErrorCb();
+  });
+
+  // If the bug is present, B's callback never arrives because A's stale remove
+  // destroyed B's poll request.
+  ASSERT_EQ(0, ::shutdown(fd_b, SHUT_WR)) << strerror(errno);
+  bool b_fired = done.WaitFor(100ms);
+  unsigned b_count_val = b_count.load();
+
+  // Cleanup runs regardless of outcome so the fixture tears down cleanly even
+  // when the repro succeeds and B never fires.
+  proactor_->Await([&] {
+    sock_a->CancelOnErrorCb();
+    sock_b->CancelOnErrorCb();
+    std::ignore = sock_a->Close();
+    std::ignore = sock_b->Close();
+  });
+
+  EXPECT_EQ(0, ::close(fd_a));
+  EXPECT_EQ(0, ::close(fd_b));
+
+  ASSERT_TRUE(b_fired) << "stale cancel removed a reused poll slot";
+  EXPECT_EQ(1u, b_count_val);
 }
 
 TEST_P(FiberSocketTest, AsyncWrite) {

--- a/util/fibers/uring_socket.cc
+++ b/util/fibers/uring_socket.cc
@@ -368,7 +368,8 @@ io::Result<size_t> UringSocket::Recv(const io::MutableBytes& mb, int flags) {
 
     if (res >= 0) {
       has_recv_data_ = (fc.flags() & IORING_CQE_F_SOCK_NONEMPTY) ? 1 : 0;
-      DVSOCK(2) << "Received " << res << " bytes " << ", has_more " << has_recv_data_;
+      DVSOCK(2) << "Received " << res << " bytes "
+                << ", has_more " << has_recv_data_;
       return res;
     }
     DVSOCK(2) << "Got " << res;
@@ -391,6 +392,7 @@ io::Result<size_t> UringSocket::Recv(const io::MutableBytes& mb, int flags) {
 void UringSocket::RegisterOnErrorCb(std::function<void(uint32_t)> cb) {
   CHECK(!error_cb_wrapper_);
   DCHECK(IsOpen());
+  DCHECK(cb);
 
   uint32_t event_mask = POLLERR | POLLHUP;
 
@@ -398,6 +400,10 @@ void UringSocket::RegisterOnErrorCb(std::function<void(uint32_t)> cb) {
   error_cb_wrapper_ = ErrorCbRefWrapper::New(std::move(cb));
   auto se_cb = [data = error_cb_wrapper_](detail::FiberInterface*, Proactor::IoResult res,
                                           uint32_t flags, uint32_t) {
+    // Mark the poll id invalid before Destroy so a subsequent CancelOnErrorCb
+    // on the socket skips PrepPollRemove on what may now be a reused
+    // centries_ slot.
+    data->error_cb_id = ErrorCbRefWrapper::kInvalidErrorCbId;
     auto cb = std::move(data->cb);
     ErrorCbRefWrapper::Destroy(data);
     if (res < 0) {
@@ -411,12 +417,24 @@ void UringSocket::RegisterOnErrorCb(std::function<void(uint32_t)> cb) {
   SubmitEntry se = p->GetSubmitEntry(std::move(se_cb));
   se.PrepPollAdd(ShiftedFd(), event_mask);
   se.sqe()->flags |= register_flag();
+
+  // user_data is 32 bits because submit_tag is 0.
   error_cb_wrapper_->error_cb_id = se.sqe()->user_data;
 }
 
 void UringSocket::CancelOnErrorCb() {
   if (!error_cb_wrapper_)
     return;
+
+  // If the error-poll completion already fired, the centries_ slot identified
+  // by error_cb_id has been freed and may have been reused by a subsequent
+  // submission on this proactor. Issuing PrepPollRemove on that user_data now
+  // would cancel an unrelated request. Just release our reference.
+  if (!error_cb_wrapper_->IsArmed()) {
+    ErrorCbRefWrapper::Destroy(error_cb_wrapper_);
+    error_cb_wrapper_ = nullptr;
+    return;
+  }
 
   FiberCall fc(GetProactor());
   fc->PrepPollRemove(error_cb_wrapper_->error_cb_id);

--- a/util/fibers/uring_socket.h
+++ b/util/fibers/uring_socket.h
@@ -45,7 +45,12 @@ class UringSocket : public LinuxSocketBase {
 
   using FiberSocketBase::IsConnClosed;
 
+  // Precondition: the callback must not be empty and must not throw.
+  // It will be called from the proactor thread when an error event is detected on the socket.
+  // The callback is called at most once per registration,
+  // and will be automatically unregistered after the first call.
   void RegisterOnErrorCb(std::function<void(uint32_t)> cb) final;
+
   void CancelOnErrorCb() final;
   void RegisterOnRecv(OnRecvCb cb) final;
   void ResetOnRecvHook() final;
@@ -85,10 +90,18 @@ class UringSocket : public LinuxSocketBase {
     fd_ = (val << kFdShift) | (fd_ & ((1 << kFdShift) - 1));
   }
 
+  // TODO: to move to uring_socket.cc
   struct ErrorCbRefWrapper {
-    uint32_t error_cb_id = 0;
+    static constexpr uint32_t kInvalidErrorCbId = UINT32_MAX;
+
+    uint32_t error_cb_id = kInvalidErrorCbId;
     uint32_t ref_count = 2;  // one for the socket reference, one for the completion lambda.
+
     std::function<void(uint32_t)> cb;
+
+    bool IsArmed() const {
+      return error_cb_id != kInvalidErrorCbId;
+    }
 
     static ErrorCbRefWrapper* New(std::function<void(uint32_t)> cb) {
       return new ErrorCbRefWrapper(std::move(cb));


### PR DESCRIPTION
## Summary

Fix two single-shot error-callback bugs and add focused regressions for them.

### 1. `UringSocket::CancelOnErrorCb()` could cancel the wrong poll

`RegisterOnErrorCb()` stores the poll-add SQE `user_data` in `error_cb_id`. Once the CQE fires, that completion-entry slot can be immediately reused by another submission on the same proactor. If `CancelOnErrorCb()` later issued `PrepPollRemove(error_cb_id)` using the stale id, it could remove a different socket's newly armed poll request.

**Fix:**
- mark the wrapper as no longer armed by invalidating `error_cb_id` in the completion lambda
- skip `PrepPollRemove` in `CancelOnErrorCb()` once the wrapper is no longer armed
- require a non-empty error callback and expose an explicit armed-state helper on `ErrorCbRefWrapper`

### 2. `EpollSocket::Wakey()` could invoke the same error callback twice

A follow-up edge such as `POLLHUP` after an initial `POLLRDHUP` could invoke the same registered callback again on the same fd.

**Fix:**
- make `Wakey()` consume `error_cb_` before invoking it, making the registration effectively single-shot

## Tests

Added focused regressions in `util/fibers/fiber_socket_test.cc`:

- `PollSingleShot`
  - reproduces the epoll duplicate-callback path with a staged peer shutdown / close sequence
  - passes on the fixed code and is skipped for IPv6

- `PollCancelSlotReuse`
  - reproduces the uring stale-slot removal bug with a deterministic two-connection sequence:
    1. arm A
    2. fire A
    3. arm B so it reuses A's freed slot
    4. cancel A
  - verifies B still receives its callback

The socket test harness was also tightened to support these targeted regressions via `LaunchAcceptFiber()` and `ConnectClient()` helpers.

## Validation

Ran:

- `./fiber_socket_test --gtest_filter='*PollSingleShot*:*PollCancelSlotReuse*'`

Result:
- passing variants: `epoll_IPv4`, `uring_IPv4`, and all `PollCancelSlotReuse` parameterizations
- expected skips: IPv6 variants for `PollSingleShot`

## Files

- `util/fibers/epoll_socket.cc`
- `util/fibers/uring_socket.{h,cc}`
- `util/fibers/fiber_socket_test.cc`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simplified API overloads for cloud storage listing (AWS S3, Azure, GCP) that handle pagination internally without requiring explicit continuation/page tokens.

* **Bug Fixes**
  * Fixed error callbacks in socket handling to fire only once, preventing duplicate error notifications from the same socket error.
  * Corrected stale slot reuse issue in uring socket error callback cancellation logic.

* **Tests**
  * Added regression tests for socket error handling edge cases and callback lifecycle validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->