### PR TITLE
SubmitEntry: fix outdated namespace comment

### DIFF
--- a/util/fibers/submit_entry.h
+++ b/util/fibers/submit_entry.h
@@ -240,5 +240,5 @@ class SubmitEntry {
 
 };
 
-}  // namespace uring
+}  // namespace fb2
 }  // namespace util


### PR DESCRIPTION
## Summary
Fix outdated namespace comment in SubmitEntry class.

## Changes
- The closing comment incorrectly referenced 'namespace uring'
- Actual namespace is 'util::fb2' where SubmitEntry is defined
- Change the comment from `// namespace uring` to `// namespace fb2`

## Testing
- No functional changes, only documentation fix
- Tests pass (comment-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Corrected an internal namespace comment for accuracy.
  * No functional changes, public APIs, or user-visible behavior were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->