### PR TITLE
perf(uring): skip io_uring_enter syscall when SQ is empty and idle

### DIFF
--- a/util/fibers/uring_proactor.cc
+++ b/util/fibers/uring_proactor.cc
@@ -816,11 +816,22 @@ void UringProactor::MainLoop(detail::Scheduler* scheduler) {
     ++stats_.loop_cnt;
     bool has_cpu_work = false;
 
-    // With TASKRUN_FLAG, io_uring_submit can skip io_uring_enter on idle
-    // iterations (IORING_SQ_TASKRUN signals pending work). Without it, we must
-    // always enter the kernel to fetch completions.
-    int num_submitted =
-        taskrun_flag_f_ ? io_uring_submit(&ring_) : io_uring_submit_and_get_events(&ring_);
+    // Under DEFER_TASKRUN, task work runs only when we enter the kernel with
+    // IORING_ENTER_GETEVENTS. io_uring_submit does NOT set that flag unless
+    // SQ_TASKRUN is observed at the moment of the call, so it can submit SQEs
+    // without draining pending completions and add request latency.
+    // Instead, gate the syscall ourselves and always use submit_and_get_events
+    // when we do enter, so deferred completions are flushed.
+    int num_submitted = 0;
+    bool call_submit = true;
+    if (taskrun_flag_f_) {
+      unsigned sq_ready = io_uring_sq_ready(&ring_);
+      bool taskrun_pending = IO_URING_READ_ONCE(*ring_.sq.kflags) & IORING_SQ_TASKRUN;
+      call_submit = (sq_ready > 0) || taskrun_pending;
+    }
+    if (call_submit) {
+      num_submitted = io_uring_submit_and_get_events(&ring_);
+    }
     bool ring_busy = false;
 
     if (num_submitted > 0) {

--- a/util/fibers/uring_proactor.cc
+++ b/util/fibers/uring_proactor.cc
@@ -176,8 +176,8 @@ void UringProactor::Init(unsigned pool_index, size_t ring_size, int wq_fd) {
   poll_first_ = 0;
   buf_ring_f_ = 0;
   bundle_f_ = 0;
-  sync_cancel_f_ = 0;
   incremental_buf_ring_f_ = 0;
+  taskrun_flag_f_ = 0;
 
   // If we setup flags that kernel does not recognize, it fails the setup call.
   if (kver.kernel > 5 || (kver.kernel == 5 && kver.major >= 19)) {
@@ -193,11 +193,12 @@ void UringProactor::Init(unsigned pool_index, size_t ring_size, int wq_fd) {
   }
 
   if (kver.kernel > 6 || (kver.kernel == 6 && kver.major >= 1)) {
-    sync_cancel_f_ = 1;
-
     // This has a positive effect on CPU usage, latency and throughput.
-    params.flags |=
-        (IORING_SETUP_DEFER_TASKRUN | IORING_SETUP_TASKRUN_FLAG | IORING_SETUP_SINGLE_ISSUER);
+    // IORING_SETUP_TASKRUN_FLAG is required for the kernel to publish IORING_SQ_TASKRUN in
+    // sq_flags so that io_uring_submit would enter kernel to fetch completions.
+    params.flags |= (IORING_SETUP_DEFER_TASKRUN | IORING_SETUP_COOP_TASKRUN |
+                     IORING_SETUP_TASKRUN_FLAG | IORING_SETUP_SINGLE_ISSUER);
+    taskrun_flag_f_ = 1;
   }
 
   // Officially it's from 6.12 but we take a margin here, just in case.
@@ -815,13 +816,11 @@ void UringProactor::MainLoop(detail::Scheduler* scheduler) {
     ++stats_.loop_cnt;
     bool has_cpu_work = false;
 
-    // io_uring_submit should be more performant in some case than io_uring_submit_and_get_events
-    // because when there no sqes to flush io_submit may save
-    // a syscall, while io_uring_submit_and_get_events will always do a syscall.
-    // Unfortunately I did not see the impact of it.
-    // Another observation:
-    // AvgCqe/ReapCall goes up if we call here io_uring_submit_and_get_events.
-    int num_submitted = io_uring_submit_and_get_events(&ring_);
+    // With TASKRUN_FLAG, io_uring_submit can skip io_uring_enter on idle
+    // iterations (IORING_SQ_TASKRUN signals pending work). Without it, we must
+    // always enter the kernel to fetch completions.
+    int num_submitted =
+        taskrun_flag_f_ ? io_uring_submit(&ring_) : io_uring_submit_and_get_events(&ring_);
     bool ring_busy = false;
 
     if (num_submitted > 0) {

--- a/util/fibers/uring_proactor.h
+++ b/util/fibers/uring_proactor.h
@@ -201,7 +201,11 @@ class UringProactor : public ProactorBase {
   uint8_t buf_ring_f_ : 1;
   uint8_t bundle_f_ : 1;
   uint8_t incremental_buf_ring_f_ : 1;
-  uint8_t sync_cancel_f_ : 1;
+  // IORING_SETUP_TASKRUN_FLAG + COOP_TASKRUN enabled: kernel publishes
+  // IORING_SQ_TASKRUN in sq_flags, so io_uring_submit can safely skip the
+  // syscall when SQ is empty and no taskrun is pending. Otherwise we must use
+  // io_uring_submit_and_get_events to always enter the kernel.
+  uint8_t taskrun_flag_f_ : 1;
   uint8_t : 2;
 
   EventCount sqe_avail_;


### PR DESCRIPTION
## Summary

Replace the unconditional `io_uring_submit_and_get_events` in the proactor main
loop with `io_uring_submit` on kernels >= 6.1. liburing's `io_uring_submit`
checks `cq_ring_needs_flush` (`IORING_SQ_TASKRUN | IORING_SQ_CQ_OVERFLOW`)
internally and skips the `io_uring_enter` syscall entirely when the SQ is
empty and neither bit is set — idle iterations become a few memory loads.

- Add `IORING_SETUP_COOP_TASKRUN` to the >= 6.1 setup flags. Required for the
  kernel to actually publish `IORING_SQ_TASKRUN` in `sq_flags`; without it
  the `cq_ring_needs_flush` check would always read 0 and we'd lose deferred
  completions.
- Gate the submit call on a new `taskrun_flag_f_` bit. When set, call
  `io_uring_submit`; otherwise (older kernels) keep
  `io_uring_submit_and_get_events`, which always enters the kernel and
  preserves the CQE batching observed in that path.

## Test plan

- [ ] CI green on supported kernels
- [ ] `perf stat -e syscalls:sys_enter_io_uring_enter` shows a drop on
      idle/light-load workloads (kernel >= 6.1)
- [ ] No regression in throughput or CQE-reap rate on older kernels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved async I/O efficiency and reduced latency on Linux systems with kernel 6.1 or later by using a smarter submission path that avoids unnecessary system calls, boosting throughput for I/O-heavy workloads.
* **Compatibility**
  * Retains previous submission behavior on older kernels to preserve compatibility and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/romange/helio/pull/585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->