### PR TITLE
feat(aws): allow programmatic S3 endpoint override on AwsCredsProvider

### DIFF
--- a/base/file_log_sink.cc
+++ b/base/file_log_sink.cc
@@ -147,7 +147,10 @@ bool FileLogSink::LogFile::Open(const std::string& base_path, int severity,
     string link_path = absl::StrCat(base_path, ".", kSeverityNames[severity]);
     string target = path_.substr(path_.rfind('/') + 1);
     unlink(link_path.c_str());
-    (void)symlink(target.c_str(), link_path.c_str());
+    if (symlink(target.c_str(), link_path.c_str()) != 0) {
+      fprintf(stderr, "file_log_sink: symlink from %s to %s failed: %s\n", link_path.c_str(),
+              target.c_str(), strerror(errno));
+    }
   }
 
   return true;

--- a/examples/s3_demo.cc
+++ b/examples/s3_demo.cc
@@ -25,10 +25,13 @@
 #include "util/fibers/pool.h"
 #include "util/http/http_client.h"
 
-// Returns nullptr (plain HTTP) when AWS_S3_ENDPOINT is an http:// URL, otherwise a TLS context.
-SSL_CTX* MakeS3SslCtx() {
-  const char* ep = getenv("AWS_S3_ENDPOINT");
-  if (ep && strncmp(ep, "http://", 7) == 0)
+// Returns nullptr (plain HTTP) when the resolved endpoint is an http:// URL,
+// otherwise a TLS context. Checks --endpoint flag first, then AWS_S3_ENDPOINT.
+SSL_CTX* MakeS3SslCtx(const std::string& override_ep) {
+  auto is_http = [](const char* s) { return s && strncmp(s, "http://", 7) == 0; };
+  if (is_http(override_ep.c_str()))
+    return nullptr;
+  if (override_ep.empty() && is_http(getenv("AWS_S3_ENDPOINT")))
     return nullptr;
   return util::http::TlsClient::CreateSslContext();
 }
@@ -67,12 +70,12 @@ bool InitAws(util::cloud::aws::AwsCredsProvider* creds, SSL_CTX** ssl_ctx) {
     LOG(ERROR) << "failed to init credentials: " << ec.message();
     return false;
   }
-  *ssl_ctx = MakeS3SslCtx();
+  *ssl_ctx = MakeS3SslCtx(absl::GetFlag(FLAGS_endpoint));
   return true;
 }
 
 void ListBuckets() {
-  util::cloud::aws::AwsCredsProvider creds_provider;
+  util::cloud::aws::AwsCredsProvider creds_provider({}, absl::GetFlag(FLAGS_endpoint));
   SSL_CTX* ssl_ctx;
   if (!InitAws(&creds_provider, &ssl_ctx)) return;
   absl::Cleanup free_ctx([ssl_ctx] { if (ssl_ctx) util::http::TlsClient::FreeContext(ssl_ctx); });
@@ -93,7 +96,7 @@ void ListObjects(const std::string& bucket, const std::string& prefix) {
     return;
   }
 
-  util::cloud::aws::AwsCredsProvider creds_provider;
+  util::cloud::aws::AwsCredsProvider creds_provider({}, absl::GetFlag(FLAGS_endpoint));
   SSL_CTX* ssl_ctx;
   if (!InitAws(&creds_provider, &ssl_ctx)) return;
   absl::Cleanup free_ctx([ssl_ctx] { if (ssl_ctx) util::http::TlsClient::FreeContext(ssl_ctx); });
@@ -124,7 +127,7 @@ void GetObject(const std::string& bucket, const std::string& key) {
     return;
   }
 
-  util::cloud::aws::AwsCredsProvider creds_provider;
+  util::cloud::aws::AwsCredsProvider creds_provider({}, absl::GetFlag(FLAGS_endpoint));
   SSL_CTX* ssl_ctx;
   if (!InitAws(&creds_provider, &ssl_ctx)) return;
   absl::Cleanup free_ctx([ssl_ctx] { if (ssl_ctx) util::http::TlsClient::FreeContext(ssl_ctx); });
@@ -231,7 +234,7 @@ void PutObject(const std::string& bucket, const std::string& key) {
     return;
   }
 
-  util::cloud::aws::AwsCredsProvider creds_provider;
+  util::cloud::aws::AwsCredsProvider creds_provider({}, absl::GetFlag(FLAGS_endpoint));
   SSL_CTX* ssl_ctx;
   if (!InitAws(&creds_provider, &ssl_ctx)) return;
   absl::Cleanup free_ctx([ssl_ctx] { if (ssl_ctx) util::http::TlsClient::FreeContext(ssl_ctx); });

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -136,6 +136,39 @@ def test_list_objects_with_prefix(s3_demo):
     assert result.returncode == 0, f"list-objects with prefix failed:\n{result.stderr}"
 
 
+def test_endpoint_flag_override(minio):
+    """Pass the endpoint via --endpoint instead of AWS_S3_ENDPOINT to exercise
+    AwsCredsProvider::SetEndpointOverride. The override must take precedence
+    over (and work in the absence of) the env var."""
+    endpoint = minio["env"]["AWS_S3_ENDPOINT"]
+    env = {k: v for k, v in minio["env"].items() if k != "AWS_S3_ENDPOINT"}
+
+    result = _run(
+        minio["binary"],
+        "--cmd=list-objects",
+        f"--bucket={minio['bucket']}",
+        f"--endpoint={endpoint}",
+        env=env,
+    )
+    assert result.returncode == 0, f"list-objects with --endpoint failed:\n{result.stderr}"
+    assert "-- page 0 end --" in result.stdout, result.stdout
+
+    # Setting both: --endpoint should win. Point env at a bogus host; --endpoint
+    # at the real minio.
+    env_with_bogus = dict(env)
+    env_with_bogus["AWS_S3_ENDPOINT"] = "http://does-not-resolve.invalid:1"
+    result = _run(
+        minio["binary"],
+        "--cmd=list-objects",
+        f"--bucket={minio['bucket']}",
+        f"--endpoint={endpoint}",
+        env=env_with_bogus,
+    )
+    assert result.returncode == 0, (
+        f"--endpoint did not override AWS_S3_ENDPOINT:\n{result.stderr}"
+    )
+
+
 def test_list_objects_cursor_pagination(minio):
     """Upload several objects under a unique prefix and verify cursor-driven listing
     returns every key across multiple pages."""

--- a/util/cloud/aws/aws_creds_provider.cc
+++ b/util/cloud/aws/aws_creds_provider.cc
@@ -233,7 +233,8 @@ io::Result<string> FetchUrl(string_view host, string_view port, string_view path
 
 }  // namespace
 
-AwsCredsProvider::AwsCredsProvider(string region) : region_(std::move(region)) {
+AwsCredsProvider::AwsCredsProvider(string region, string endpoint_override)
+    : region_(std::move(region)), endpoint_override_(std::move(endpoint_override)) {
 }
 
 AwsCredsProvider::~AwsCredsProvider() {
@@ -523,9 +524,15 @@ error_code AwsCredsProvider::RefreshToken() {
 }
 
 string AwsCredsProvider::ServiceEndpoint() const {
-  if (const char* ep = getenv("AWS_S3_ENDPOINT"); ep && *ep) {
+  auto format = [](string_view ep) {
     auto [host, port, path, is_https] = ParseHttpUrl(ep);
     return port == (is_https ? "443" : "80") ? host : absl::StrCat(host, ":", port);
+  };
+  if (!endpoint_override_.empty()) {
+    return format(endpoint_override_);
+  }
+  if (const char* ep = getenv("AWS_S3_ENDPOINT"); ep && *ep) {
+    return format(ep);
   }
   return absl::StrCat("s3.", region_, ".amazonaws.com");
 }

--- a/util/cloud/aws/aws_creds_provider.h
+++ b/util/cloud/aws/aws_creds_provider.h
@@ -43,14 +43,20 @@ class AwsCredsProvider : public CredentialsProvider {
   AwsCredsProvider& operator=(const AwsCredsProvider&) = delete;
 
  public:
-  explicit AwsCredsProvider(std::string region = "");
+  // `region` empty -> defaults to AWS_REGION / AWS_DEFAULT_REGION / "us-east-1".
+  // `endpoint_override` empty -> falls back to AWS_S3_ENDPOINT, then
+  //   "s3.{region}.amazonaws.com". Accepts a bare "host[:port]" or a full URL
+  //   (e.g. "https://s3.dualstack.us-west-2.amazonaws.com"); scheme and path
+  //   are stripped.
+  explicit AwsCredsProvider(std::string region = {}, std::string endpoint_override = {});
   ~AwsCredsProvider();
 
   unsigned connect_ms() const { return connect_ms_; }
 
   std::error_code Init(unsigned connect_ms) final;
 
-  // Returns "s3.{region}.amazonaws.com" (path-style, bucket-agnostic).
+  // Returns the resolved S3 endpoint host[:port]. Precedence: ctor override >
+  // AWS_S3_ENDPOINT env var > "s3.{region}.amazonaws.com".
   std::string ServiceEndpoint() const final;
 
   // Computes AWS SigV4 and sets x-amz-date, x-amz-security-token, Authorization headers.
@@ -72,6 +78,7 @@ class AwsCredsProvider : public CredentialsProvider {
   std::error_code TryIMDS();
 
   std::string region_;
+  std::string endpoint_override_;
   unsigned connect_ms_ = 2000;
 
   enum class CredSource { kNone, kEnv, kProfile, kWebIdentity, kContainer, kIMDS };


### PR DESCRIPTION
## Summary
- Add an optional `endpoint_override` constructor arg to `AwsCredsProvider` for programmatic S3 endpoint configuration (dual-stack, FIPS, MinIO, etc.) without relying on `AWS_S3_ENDPOINT`. Empty string preserves the old behavior, mirroring how `region` falls back to env.
- `ServiceEndpoint()` precedence is now: ctor override → `AWS_S3_ENDPOINT` env var → `s3.{region}.amazonaws.com`.

## Changes
- `util/cloud/aws/aws_creds_provider.{h,cc}`: second ctor arg `endpoint_override`; `ServiceEndpoint()` consults it before the env var; URL parsing is shared via a local lambda.
- `examples/s3_demo.cc`: wire the existing `--endpoint` flag through the native `AwsCredsProvider` path (previously WITH_AWS-only). `MakeS3SslCtx()` now takes the override string and disables TLS for `http://...` from either the flag or the env var.
- `tests/test_s3.py`: new `test_endpoint_flag_override` runs against MinIO and verifies (a) `--endpoint` works with `AWS_S3_ENDPOINT` unset and (b) `--endpoint` wins over a bogus `AWS_S3_ENDPOINT`.
- `base/file_log_sink.cc`: report `symlink(2)` failure to stderr instead of silently dropping the result (fixes a `-Wunused-result` warning).

## Test plan
- [x] `cmake --build build-dbg --target s3_demo` clean
- [x] `pytest tests/test_s3.py` against local MinIO: 3 passed, 2 skipped (real-S3 tests)
- [x] Verified `--endpoint` works with `AWS_S3_ENDPOINT` unset
- [x] Verified `--endpoint` wins over a bogus `AWS_S3_ENDPOINT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom S3 endpoint configuration via `--endpoint` flag with automatic TLS handling based on endpoint protocol.
  * Endpoint flag takes precedence over environment variable configuration.

* **Bug Fixes**
  * Enhanced error reporting for log file symlink creation with detailed system error messages.

* **Tests**
  * Added integration test validating endpoint flag override behavior and precedence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/romange/helio/pull/586?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->