### PR TITLE
perf(proactor): use CycleClock in hot path task and on_idle loops

### DIFF
--- a/util/fibers/epoll_proactor.cc
+++ b/util/fibers/epoll_proactor.cc
@@ -189,6 +189,8 @@ void EpollProactor::MainLoop(detail::Scheduler* scheduler) {
 
   Tasklet task;
 
+  const uint64_t kTaskBudgetCycles = base::CycleClock::FromUsec(500);
+
   while (true) {
     ++stats_.loop_cnt;
     bool task_queue_exhausted = true;
@@ -197,16 +199,12 @@ void EpollProactor::MainLoop(detail::Scheduler* scheduler) {
 
     if (task_queue_.try_dequeue(task)) {
       uint32_t cnt = 0;
-      uint64_t task_start = GetClockNanos();
-
-      // update thread-local clock service via GetMonotonicTimeNs().
-      tl_info_.monotonic_time = task_start;
+      uint64_t task_start = base::CycleClock::Now();
       do {
         task();
         ++stats_.num_task_runs;
         ++cnt;
-        tl_info_.monotonic_time = GetClockNanos();
-        if (task_start + 500000 < tl_info_.monotonic_time) {  // Break after 500usec
+        if (base::CycleClock::Now() - task_start > kTaskBudgetCycles) {
           ++stats_.task_interrupts;
           task_queue_exhausted = false;
           break;
@@ -282,7 +280,6 @@ void EpollProactor::MainLoop(detail::Scheduler* scheduler) {
     uint32_t cqe_count = epoll_res;
     if (cqe_count) {
       ++stats_.completions_fetches;
-      tl_info_.monotonic_time = GetClockNanos();
 
       while (true) {
         VPRO(2) << "Fetched " << cqe_count << " cqes";

--- a/util/fibers/proactor_base.cc
+++ b/util/fibers/proactor_base.cc
@@ -163,10 +163,14 @@ bool ProactorBase::RunOnIdleTasks() {
   if (on_idle_arr_.empty())
     return false;
 
-  uint64_t start = GetClockNanos();
+  uint64_t start = base::CycleClock::Now();
   uint64_t curr_ts = start;
   const string* task_name = nullptr;
   bool should_spin = false;
+
+  static const uint64_t kLoopBudgetCycles = base::CycleClock::FromUsec(10);    // 10 usec
+  static const uint64_t kSlowWarnCycles = base::CycleClock::FromUsec(1500);    // 1.5 ms
+  static const uint64_t kIdleMaxCycles = base::CycleClock::FromUsec(kIdleCycleMaxMicros);
 
   DCHECK_LT(on_idle_next_, on_idle_arr_.size());
 
@@ -175,8 +179,6 @@ bool ProactorBase::RunOnIdleTasks() {
     OnIdleWrapper& on_idle = on_idle_arr_[on_idle_next_];
 
     if (on_idle.task && on_idle.next_ts <= curr_ts) {
-      tl_info_.monotonic_time = curr_ts;
-
       int32_t level = on_idle.task();  // run the task
 
       if (level < 0) {
@@ -190,15 +192,14 @@ bool ProactorBase::RunOnIdleTasks() {
           break;  // do/while loop
         }
       } else {  // level >= 0
-        curr_ts = GetClockNanos();
+        curr_ts = base::CycleClock::Now();
 
         if (unsigned(level) >= kOnIdleMaxLevel) {
           level = kOnIdleMaxLevel;
           should_spin = true;
         } else if (on_idle_next_ <
                    on_idle_arr_.size()) {  // check if the array has not been shrunk.
-          uint64_t delta_ns = uint64_t(kIdleCycleMaxMicros) * 1000 / (1 << level);
-          on_idle.next_ts = curr_ts + delta_ns;
+          on_idle.next_ts = curr_ts + (kIdleMaxCycles >> level);
         }
         task_name = &on_idle.task_name;
       }
@@ -209,10 +210,11 @@ bool ProactorBase::RunOnIdleTasks() {
       on_idle_next_ = 0;
       break;
     }
-  } while (curr_ts < start + 10000);  // 10usec for the run.
+  } while (curr_ts - start < kLoopBudgetCycles);
   uint64_t duration = curr_ts - start;
-  if (duration >= 1500'000) {  // 1.5ms
-    LOG_EVERY_T(WARNING, 2) << "OnIdle task is taking too long: " << duration / 1000 << " us "
+  if (duration >= kSlowWarnCycles) {
+    LOG_EVERY_T(WARNING, 2) << "OnIdle task is taking too long: "
+                            << base::CycleClock::ToUsec(duration) << " us "
                             << (task_name ? *task_name : "");
   }
   return should_spin;

--- a/util/fibers/proactor_base.h
+++ b/util/fibers/proactor_base.h
@@ -321,7 +321,7 @@ class ProactorBase {
   struct OnIdleWrapper {
     OnIdleTask task;
     std::string task_name;
-    uint64_t next_ts;  // when to run the next time in nano seconds.
+    uint64_t next_ts;  // when to run the next time in cycles.
   };
 
   std::vector<OnIdleWrapper> on_idle_arr_;

--- a/util/fibers/uring_proactor.cc
+++ b/util/fibers/uring_proactor.cc
@@ -800,6 +800,8 @@ void UringProactor::MainLoop(detail::Scheduler* scheduler) {
   } jump_from = JUMP_FROM_INIT;
   unsigned jump_counts[JUMP_FROM_TOTAL] = {0};
 
+  const uint64_t kTaskBudgetCycles = base::CycleClock::FromUsec(500);
+
   // The loop must follow these rules:
   // 1. if we task-queue is not empty or if we have ready fibers, then we should
   //    not stall in wait_for_cqe(.., 1, ...).
@@ -820,8 +822,8 @@ void UringProactor::MainLoop(detail::Scheduler* scheduler) {
     // IORING_ENTER_GETEVENTS. io_uring_submit does NOT set that flag unless
     // SQ_TASKRUN is observed at the moment of the call, so it can submit SQEs
     // without draining pending completions and add request latency.
-    // Instead, gate the syscall ourselves and always use submit_and_get_events
-    // when we do enter, so deferred completions are flushed.
+    // Therefore, unlike with io_uring_submit, we always set GET_EVENTS when calling io_uring_enter
+    // but similarly to io_uring_submit we check on whether we need to enter at all.
     int num_submitted = 0;
     bool call_submit = true;
     if (taskrun_flag_f_) {
@@ -856,15 +858,11 @@ void UringProactor::MainLoop(detail::Scheduler* scheduler) {
     // To save redundant timer-calls we start measuring time only when if the queue is not empty.
     if (task_queue_.try_dequeue(task)) {
       uint32_t cnt = 0;
-      uint64_t task_start = GetClockNanos();
-
-      // update thread-local clock service via GetMonotonicTimeNs().
-      tl_info_.monotonic_time = task_start;
+      uint64_t task_start = base::CycleClock::Now();
       do {
         task();
         ++cnt;
-        tl_info_.monotonic_time = GetClockNanos();
-        if (task_start + 500000 < tl_info_.monotonic_time) {  // Break after 500usec
+        if (base::CycleClock::Now() - task_start > kTaskBudgetCycles) {
           ++stats_.task_interrupts;
           has_cpu_work = true;
           break;


### PR DESCRIPTION
## Summary

Replace `absl::GetCurrentTimeNanos()` calls and `tl_info_.monotonic_time`
writes in the proactor hot path with `base::CycleClock` (RDTSC / cntvct_el0).
CycleClock is essentially free compared to a vDSO clock_gettime.

- **Task-batch loop** (uring + epoll): the 500µs budget check now uses
  CycleClock. The `FromUsec(500)` division is hoisted to MainLoop entry so
  it runs once per proactor lifetime.
- **RunOnIdleTasks**: 10µs run-budget, 1.5ms slow warning, and per-task
  `next_ts` scheduling all in cycles. `idle_max_cycles >> level` replaces
  the previous `(kIdleCycleMaxMicros * 1000) / (1 << level)` ns math.
  Log output keeps reporting microseconds via `CycleClock::ToUsec`.
- Removes the per-task `tl_info_.monotonic_time = GetClockNanos()` writes
  and the one-shot refresh after `epoll_wait`. The scheduler still
  refreshes the global cache via `UpdateMonotonicTime()` at its own
  cadence, so `GetMonotonicTimeNs()` readers remain functional.

Scope per discussion: hot path + on_idle only. Scheduler internals and the
public `GetMonotonicTimeNs()` / `UpdateMonotonicTime()` API are unchanged.

## Test plan

- [x] `fibers_test` passes (103/103)
- [x] CI green
- [x] Throughput / CPU comparison on a representative workload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched internal timing to a higher-resolution, cycle-based approach for task CPU budgeting to improve precision and fairness.
  * Removed redundant per-task timing refreshes and streamlined idle-task scheduling and loop termination to reduce wakeups and overhead.
  * Improved detection and reporting of slow tasks, yielding more accurate diagnostics and better runtime responsiveness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/romange/helio/pull/587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->