### PR TITLE
fix: don't unlink unlinked awaiters on drop

### DIFF
--- a/util/fibers/synchronization.h
+++ b/util/fibers/synchronization.h
@@ -82,6 +82,13 @@ class EventCount {
         waiter_->set_persistent(false);
       }
     }
+
+    // Silently drop this subkey if the waiter is already unlinked.
+    void Drop() {
+      // Reading IsLinked is not thread safe if it really is linked, but the caller guarantees it
+      assert(!waiter_->IsLinked());
+      me_ = nullptr;
+    }
   };
 
   // Notify one waiter, return if any was notified


### PR DESCRIPTION
It will allow us to drop waiters from this callback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization stability by adding a safe "silent drop" for obsolete subscriptions, preventing erroneous unsubscription behavior and reducing teardown-related errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/romange/helio/pull/588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->