### PR TITLE
fix(socket): graceful Shutdown on invalid fd

### DIFF
--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -172,90 +172,120 @@ def test_endpoint_flag_override(minio):
     )
 
 
-class _FailingUploadHandler(http.server.BaseHTTPRequestHandler):
-    """Fake S3 endpoint: accepts CreateMultipartUpload, fails every UploadPart
-    with 507 + `Connection: close`, mirroring MinIO's behavior when out of disk.
-    Reproduces dragonflydb/dragonfly#7410."""
+def _make_failing_upload_handler(*, connection_close: bool):
+    """Build an http handler that accepts CreateMultipartUpload but answers
+    every UploadPart with 507. `connection_close=True` mirrors MinIO's
+    XMinioStorageFull response (drives the Shutdown crash path).
+    `connection_close=False` keeps the socket alive so all retries hit
+    DoesServerPushback (drives the RobustSender retry-exhaustion path)."""
 
-    def log_message(self, *args, **kwargs):  # silence per-request stderr noise
-        pass
+    class Handler(http.server.BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
 
-    def _send(self, status: int, body: bytes, *, close: bool = False):
-        self.send_response(status)
-        self.send_header("Content-Type", "application/xml")
-        self.send_header("Content-Length", str(len(body)))
-        if close:
-            self.send_header("Connection", "close")
-            self.close_connection = True
-        self.end_headers()
-        self.wfile.write(body)
+        def log_message(self, *args, **kwargs):
+            pass
 
-    def do_POST(self):
-        query = parse_qs(urlparse(self.path).query, keep_blank_values=True)
-        if "uploads" in query:
+        def _send(self, status: int, body: bytes, *, close: bool):
+            self.send_response(status)
+            self.send_header("Content-Type", "application/xml")
+            self.send_header("Content-Length", str(len(body)))
+            if close:
+                self.send_header("Connection", "close")
+                self.close_connection = True
+            else:
+                self.send_header("Connection", "keep-alive")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_POST(self):
+            query = parse_qs(urlparse(self.path).query, keep_blank_values=True)
+            if "uploads" in query:
+                body = (
+                    b'<?xml version="1.0" encoding="UTF-8"?>'
+                    b"<InitiateMultipartUploadResult>"
+                    b"<Bucket>fake</Bucket><Key>fake</Key>"
+                    b"<UploadId>fake-upload-id</UploadId>"
+                    b"</InitiateMultipartUploadResult>"
+                )
+                self._send(200, body, close=False)
+                return
+            self._send(404, b"<Error/>", close=False)
+
+        def do_PUT(self):
             body = (
                 b'<?xml version="1.0" encoding="UTF-8"?>'
-                b"<InitiateMultipartUploadResult>"
-                b"<Bucket>fake</Bucket><Key>fake</Key>"
-                b"<UploadId>fake-upload-id</UploadId>"
-                b"</InitiateMultipartUploadResult>"
+                b"<Error><Code>XMinioStorageFull</Code>"
+                b"<Message>Storage backend has reached its capacity</Message></Error>"
             )
-            self._send(200, body)
-            return
-        self._send(404, b"<Error/>")
+            content_len = int(self.headers.get("Content-Length", "0"))
+            if content_len:
+                self.rfile.read(content_len)
+            self._send(507, body, close=connection_close)
 
-    def do_PUT(self):
-        body = (
-            b'<?xml version="1.0" encoding="UTF-8"?>'
-            b"<Error><Code>XMinioStorageFull</Code>"
-            b"<Message>Storage backend has reached its capacity</Message></Error>"
-        )
-        content_len = int(self.headers.get("Content-Length", "0"))
-        if content_len:
-            self.rfile.read(content_len)
-        self._send(507, body, close=True)
+    return Handler
 
 
-@pytest.fixture()
-def failing_s3_endpoint():
-    """Run a fake S3 server on localhost that 507s every UploadPart."""
-    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _FailingUploadHandler)
+def _start_fake_s3(handler_cls):
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
     port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
+    return server, thread, f"http://127.0.0.1:{port}"
+
+
+@pytest.fixture()
+def failing_s3_endpoint_close():
+    """Fake S3 that 507s UploadPart with `Connection: close` (MinIO out-of-disk)."""
+    server, thread, url = _start_fake_s3(_make_failing_upload_handler(connection_close=True))
     try:
-        yield f"http://127.0.0.1:{port}"
+        yield url
     finally:
         server.shutdown()
         server.server_close()
         thread.join(timeout=5)
 
 
-def test_upload_part_507_no_crash(failing_s3_endpoint):
-    """Regression: dragonflydb/dragonfly#7410.
+@pytest.fixture()
+def failing_s3_endpoint_keepalive():
+    """Fake S3 that 507s UploadPart but keeps the connection alive, so all
+    retries hit the DoesServerPushback path in RobustSender::Send."""
+    server, thread, url = _start_fake_s3(_make_failing_upload_handler(connection_close=False))
+    try:
+        yield url
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
 
-    A 507 on UploadPart with `Connection: close` caused a SIGABRT inside
-    helio's socket Shutdown path (fd_ < 0 CHECK). After the fix, the upload
-    must exit gracefully with a propagated error and no crash."""
+
+def _put_object_against(endpoint: str) -> subprocess.CompletedProcess:
     binary = _find_s3_demo()
     if not binary:
         pytest.skip("s3_demo binary not found")
-
     env = {k: v for k, v in os.environ.items() if not k.startswith("AWS_")}
     env.update({
         "AWS_ACCESS_KEY_ID": "fake",
         "AWS_SECRET_ACCESS_KEY": "fake",
         "AWS_DEFAULT_REGION": "us-east-1",
     })
-    result = _run(
+    return _run(
         binary,
         "--cmd=put-object",
         "--bucket=fake-bucket",
         "--key=fake/key.bin",
         "--upload_size=16",
-        f"--endpoint={failing_s3_endpoint}",
+        f"--endpoint={endpoint}",
         env=env,
     )
+
+
+def test_upload_part_507_no_crash(failing_s3_endpoint_close):
+    """Regression: dragonflydb/dragonfly#7410.
+
+    A 507 on UploadPart with `Connection: close` caused a SIGABRT inside
+    helio's socket Shutdown path (fd_ < 0 CHECK fail). After the fix, the
+    upload must exit gracefully with a propagated error and no crash."""
+    result = _put_object_against(failing_s3_endpoint_close)
 
     # SIGABRT shows up as a negative returncode (-signal.SIGABRT) on POSIX.
     assert result.returncode >= 0, (
@@ -264,7 +294,36 @@ def test_upload_part_507_no_crash(failing_s3_endpoint):
     assert "Check failed: fd_" not in result.stderr, (
         f"hit the LinuxSocketBase::Shutdown CHECK:\n{result.stderr}"
     )
-    # Either Upload() or Close() should have surfaced the failure.
+    assert "put-object close error" in result.stderr or "put-object write error" in result.stderr, (
+        f"expected a graceful upload error in stderr, got:\n{result.stderr}"
+    )
+
+
+def test_upload_part_507_retry_exhaustion_propagates_error(failing_s3_endpoint_keepalive):
+    """Regression: RobustSender::Send must return an error after exhausting
+    pushback retries. Before the fix, the for-loop fell out returning a
+    default-constructed (success) error_code; s3_storage then tried to parse
+    the (empty) response and logged `missing ETag in response`.
+
+    With the keep-alive variant of the fake server, all 3 attempts take the
+    DoesServerPushback path — exhausting retries cleanly so this path is
+    actually exercised (the close variant short-circuits with end_of_stream
+    on the third attempt's send)."""
+    result = _put_object_against(failing_s3_endpoint_keepalive)
+
+    assert result.returncode >= 0, (
+        f"s3_demo terminated by signal {-result.returncode}:\n{result.stderr}"
+    )
+    # The smoking gun for the retry-exhaustion bug: with the bug present
+    # Send returned success and s3_storage logged this while looking for ETag.
+    assert "missing ETag in response" not in result.stderr, (
+        "RobustSender returned success on retry-exhaustion; "
+        "caller tried to parse the response and hit missing-ETag:\n" + result.stderr
+    )
+    # And we should still see at least 3 pushback retries having been attempted.
+    assert result.stderr.count("Retrying(") >= 3, (
+        f"expected RobustSender to exhaust 3 pushback retries:\n{result.stderr}"
+    )
     assert "put-object close error" in result.stderr or "put-object write error" in result.stderr, (
         f"expected a graceful upload error in stderr, got:\n{result.stderr}"
     )

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -273,7 +273,7 @@ def _put_object_against(endpoint: str) -> subprocess.CompletedProcess:
         "--cmd=put-object",
         "--bucket=fake-bucket",
         "--key=fake/key.bin",
-        "--upload_size=16",
+        "--upload_size=256",  # small upload size to make it faster.
         f"--endpoint={endpoint}",
         env=env,
     )

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import http.server
 import os
 import subprocess
+import threading
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -166,6 +169,104 @@ def test_endpoint_flag_override(minio):
     )
     assert result.returncode == 0, (
         f"--endpoint did not override AWS_S3_ENDPOINT:\n{result.stderr}"
+    )
+
+
+class _FailingUploadHandler(http.server.BaseHTTPRequestHandler):
+    """Fake S3 endpoint: accepts CreateMultipartUpload, fails every UploadPart
+    with 507 + `Connection: close`, mirroring MinIO's behavior when out of disk.
+    Reproduces dragonflydb/dragonfly#7410."""
+
+    def log_message(self, *args, **kwargs):  # silence per-request stderr noise
+        pass
+
+    def _send(self, status: int, body: bytes, *, close: bool = False):
+        self.send_response(status)
+        self.send_header("Content-Type", "application/xml")
+        self.send_header("Content-Length", str(len(body)))
+        if close:
+            self.send_header("Connection", "close")
+            self.close_connection = True
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        query = parse_qs(urlparse(self.path).query, keep_blank_values=True)
+        if "uploads" in query:
+            body = (
+                b'<?xml version="1.0" encoding="UTF-8"?>'
+                b"<InitiateMultipartUploadResult>"
+                b"<Bucket>fake</Bucket><Key>fake</Key>"
+                b"<UploadId>fake-upload-id</UploadId>"
+                b"</InitiateMultipartUploadResult>"
+            )
+            self._send(200, body)
+            return
+        self._send(404, b"<Error/>")
+
+    def do_PUT(self):
+        body = (
+            b'<?xml version="1.0" encoding="UTF-8"?>'
+            b"<Error><Code>XMinioStorageFull</Code>"
+            b"<Message>Storage backend has reached its capacity</Message></Error>"
+        )
+        content_len = int(self.headers.get("Content-Length", "0"))
+        if content_len:
+            self.rfile.read(content_len)
+        self._send(507, body, close=True)
+
+
+@pytest.fixture()
+def failing_s3_endpoint():
+    """Run a fake S3 server on localhost that 507s every UploadPart."""
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _FailingUploadHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_upload_part_507_no_crash(failing_s3_endpoint):
+    """Regression: dragonflydb/dragonfly#7410.
+
+    A 507 on UploadPart with `Connection: close` caused a SIGABRT inside
+    helio's socket Shutdown path (fd_ < 0 CHECK). After the fix, the upload
+    must exit gracefully with a propagated error and no crash."""
+    binary = _find_s3_demo()
+    if not binary:
+        pytest.skip("s3_demo binary not found")
+
+    env = {k: v for k, v in os.environ.items() if not k.startswith("AWS_")}
+    env.update({
+        "AWS_ACCESS_KEY_ID": "fake",
+        "AWS_SECRET_ACCESS_KEY": "fake",
+        "AWS_DEFAULT_REGION": "us-east-1",
+    })
+    result = _run(
+        binary,
+        "--cmd=put-object",
+        "--bucket=fake-bucket",
+        "--key=fake/key.bin",
+        "--upload_size=16",
+        f"--endpoint={failing_s3_endpoint}",
+        env=env,
+    )
+
+    # SIGABRT shows up as a negative returncode (-signal.SIGABRT) on POSIX.
+    assert result.returncode >= 0, (
+        f"s3_demo terminated by signal {-result.returncode}:\n{result.stderr}"
+    )
+    assert "Check failed: fd_" not in result.stderr, (
+        f"hit the LinuxSocketBase::Shutdown CHECK:\n{result.stderr}"
+    )
+    # Either Upload() or Close() should have surfaced the failure.
+    assert "put-object close error" in result.stderr or "put-object write error" in result.stderr, (
+        f"expected a graceful upload error in stderr, got:\n{result.stderr}"
     )
 
 

--- a/util/cloud/utils.cc
+++ b/util/cloud/utils.cc
@@ -187,6 +187,7 @@ error_code RobustSender::Send(unsigned num_iterations, detail::HttpRequestBase* 
     // Writing can return `broken_pipe` so we need to retry.
     if (FiberSocketBase::IsConnClosed(send_err)) {
       VLOG(1) << "Retrying. Connection closed with error: " << send_err.message();
+      ec = send_err;
       continue;
     }
     RETURN_ERROR(send_err);
@@ -198,6 +199,7 @@ error_code RobustSender::Send(unsigned num_iterations, detail::HttpRequestBase* 
     // Reading from closed socket can result in `connection_aborted`.
     if (FiberSocketBase::IsConnClosed(header_err)) {
       VLOG(1) << "Retrying. Connection closed with error: " << header_err.message();
+      ec = header_err;
       continue;
     }
     // Unfortunately earlier versions of boost (1.74-) have a bug that do not support the body_limit
@@ -227,6 +229,7 @@ error_code RobustSender::Send(unsigned num_iterations, detail::HttpRequestBase* 
     if (DoesServerPushback(msg.result())) {
       LOG(INFO) << "Retrying(" << client_handle->native_handle() << ") with " << msg;
 
+      ec = make_error_code(errc::resource_unavailable_try_again);
       ThisFiber::SleepFor(100ms);
       continue;
     }
@@ -235,6 +238,7 @@ error_code RobustSender::Send(unsigned num_iterations, detail::HttpRequestBase* 
       VLOG(1) << "Refreshing token";
       RETURN_ERROR(provider_->RefreshToken());
       provider_->Sign(req);
+      ec = make_error_code(errc::permission_denied);
       continue;
     }
 

--- a/util/cloud/utils.h
+++ b/util/cloud/utils.h
@@ -215,6 +215,9 @@ class RobustSender {
 
   RobustSender(http::ClientPool* pool, CredentialsProvider* provider);
 
+  // In case of failure, returns the error of the last retry attempt or a unrecoverable error.
+  // If succeeds, returns an empty error code and fills result with the response parser
+  // and client handle.
   std::error_code Send(unsigned num_iterations, detail::HttpRequestBase* req, SenderResult* result);
 
  private:

--- a/util/fibers/fiber_socket_base.cc
+++ b/util/fibers/fiber_socket_base.cc
@@ -181,11 +181,13 @@ error_code LinuxSocketBase::Listen(unsigned backlog) {
 }
 
 auto LinuxSocketBase::Shutdown(int how) -> error_code {
-  CHECK_GE(fd_, 0);
+  DCHECK_GE(fd_, 0);
+  error_code ec;
+  if (fd_ < 0)
+    return make_error_code(errc::bad_file_descriptor);
 
   // If we shutdown and then try to Send/Recv - the call will stall since no data
   // is sent/received. Therefore we remember the state to allow consistent API experience.
-  error_code ec;
   if (fd_ & IS_SHUTDOWN)
     return ec;
 

--- a/util/http/http_client.cc
+++ b/util/http/http_client.cc
@@ -66,7 +66,7 @@ std::error_code Client::Reconnect() {
 
   if (socket_) {
     error_code ec = socket_->Close();
-    LOG_IF(WARNING, !ec) << "Socket close failed: " << ec.message();
+    LOG_IF(WARNING, ec) << "Socket close failed: " << ec.message();
     socket_.reset();
   }
 
@@ -123,9 +123,9 @@ auto Client::Send(Verb verb, string_view url, string_view body, Response* respon
 #endif
 
 void Client::Shutdown() {
-  if (socket_) {
+  if (socket_ && socket_->IsOpen()) {
     std::error_code ec = socket_->Shutdown(SHUT_RDWR);
-    LOG_IF(WARNING, !ec) << "Socket Shutdown failed: " << ec.message();
+    LOG_IF(WARNING, ec) << "Socket Shutdown failed: " << ec.message();
   }
 }
 


### PR DESCRIPTION
## Summary
- `LinuxSocketBase::Shutdown` no longer SIGABRTs when `fd_ < 0`; it returns `bad_file_descriptor` (DCHECK retained for debug builds).
- `Client::Shutdown` guards with `socket_->IsOpen()` so a shutdown on an already-invalidated HTTP client socket is a no-op.
- Fixes two inverted `LOG_IF(WARNING, !ec)` conditions in `http_client.cc` that logged on success rather than on error.

Fixes dragonflydb/dragonfly#7410 — the S3 upload error path destroys a `SenderResult` whose embedded HTTP client calls `Shutdown` on a socket with `fd_ == -1` (e.g. after MinIO returns `507` with `Connection: close`), previously crashing the server.

## Test plan
- [x] Existing socket / http client tests pass
- [x] Manually reproduce the S3 error path against MinIO and confirm SAVE returns `-ERR` instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Treat invalid/closed sockets as a normal runtime error instead of relying only on debug assertions.
  * Only attempt socket shutdown when a socket exists and is open; improved warning logging when shutdown/close fail.
  * Preserve and return the most relevant retry-related errors when send attempts encounter connection closure, server pushback, or auth refresh.

* **Tests**
  * Added regression tests that simulate a failing storage endpoint to ensure uploads fail gracefully without crashing.

* **Documentation**
  * Clarified behavior of the robust sender in its API comments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/romange/helio/pull/590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->