### PR TITLE
chore: ready/terminating and waiter info for PrintAllFiberStackTraces

### DIFF
--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -6,6 +6,7 @@
 #include <absl/strings/str_cat.h>
 #include <absl/time/clock.h>
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <mutex>
@@ -510,7 +511,12 @@ void Scheduler::PrintAllFiberStackTraces() {
     string state = "suspended";
     bool add_time = true;
     if (fb->list_hook.is_linked()) {
-      state = "ready";
+      if(fb->flags_.load(std::memory_order_relaxed) & FiberInterface::kTerminatedBit) {
+        state = "terminating";
+      }
+      else {
+        state = "ready";
+      }
     } else if (active == fb) {
       state = "active";
     } else if (fb->sleep_hook.is_linked()) {
@@ -526,12 +532,15 @@ void Scheduler::PrintAllFiberStackTraces() {
 
     if (add_time) {
       uint64_t tsc = CycleClock::Now();
+      // Last time of context switch
       uint64_t delta = tsc - fb->cpu_tsc_;
       uint64_t freq_ms = CycleClock::Frequency() / 1000;
-      absl::StrAppend(&state, ":", delta / freq_ms, "ms");
+      // Last time the fiber got into the ready queue
+      uint64_t last_ready = tsc - fb->ready_tsc_;
+      absl::StrAppend(&state, ":last_context_switch", delta / freq_ms, "ms:last_ready", last_ready / freq_ms, "ms");
     }
 
-    LOG(INFO) << "------------ Fiber " << fb->name_ << " (" << state << ") ------------\n"
+    LOG(INFO) << "------------ Fiber " << fb->name_ << " with " << fb->join_q_.TotalWaiters() << " waiters(" << state << ") ------------\n"
               << print_cb_str << GetStacktrace();
   };
 

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -540,7 +540,7 @@ void Scheduler::PrintAllFiberStackTraces() {
       absl::StrAppend(&state, ":last_context_switch=", delta / freq_ms, "ms:last_ready=", last_ready / freq_ms, "ms");
     }
 
-    LOG(INFO) << "------------ Fiber " << fb->name_ << fb->name_ << " (" << state << ") ------------\n"
+    LOG(INFO) << "------------ Fiber " << fb->name_ << " (" << state << ") ------------\n"
               << print_cb_str << GetStacktrace();
   };
 

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -6,7 +6,6 @@
 #include <absl/strings/str_cat.h>
 #include <absl/time/clock.h>
 
-#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <mutex>

--- a/util/fibers/detail/scheduler.cc
+++ b/util/fibers/detail/scheduler.cc
@@ -537,10 +537,10 @@ void Scheduler::PrintAllFiberStackTraces() {
       uint64_t freq_ms = CycleClock::Frequency() / 1000;
       // Last time the fiber got into the ready queue
       uint64_t last_ready = tsc - fb->ready_tsc_;
-      absl::StrAppend(&state, ":last_context_switch", delta / freq_ms, "ms:last_ready", last_ready / freq_ms, "ms");
+      absl::StrAppend(&state, ":last_context_switch=", delta / freq_ms, "ms:last_ready=", last_ready / freq_ms, "ms");
     }
 
-    LOG(INFO) << "------------ Fiber " << fb->name_ << " with " << fb->join_q_.TotalWaiters() << " waiters(" << state << ") ------------\n"
+    LOG(INFO) << "------------ Fiber " << fb->name_ << fb->name_ << " (" << state << ") ------------\n"
               << print_cb_str << GetStacktrace();
   };
 

--- a/util/fibers/detail/wait_queue.h
+++ b/util/fibers/detail/wait_queue.h
@@ -104,6 +104,8 @@ class WaitQueue {
   // Return true if any waiter was notified
   bool NotifyAll(FiberInterface* active);
 
+  size_t TotalWaiters() const { return wait_list_.size(); }
+
  private:
   using WaitList = boost::intrusive::list<
       Waiter, boost::intrusive::member_hook<Waiter, Waiter::ListHookType, &Waiter::wait_hook>,

--- a/util/fibers/detail/wait_queue.h
+++ b/util/fibers/detail/wait_queue.h
@@ -104,8 +104,6 @@ class WaitQueue {
   // Return true if any waiter was notified
   bool NotifyAll(FiberInterface* active);
 
-  size_t TotalWaiters() const { return wait_list_.size(); }
-
  private:
   using WaitList = boost::intrusive::list<
       Waiter, boost::intrusive::member_hook<Waiter, Waiter::ListHookType, &Waiter::wait_hook>,


### PR DESCRIPTION
## The following issues exist when printing stack traces

First, upon printing stack traces and when the fiber's `is_linked` is true, helio prints the state as `ready` even for cases where the fiber state is actually `terminating` (kTerminateBit is set).

Second, when `add_time` is true, helio prints the "last time the fber context switched" and not the "last time the fiber was active" i,e, when the fiber was in the ready queue.

Third, we have no information around waiters joining on this fiber. 

## How this will help with the Shudown deadlock ?

We currently do not know if the `heartbeat` is `terminating or if it's ready`. The difference is `important`:

1. If heartbeat is `ready` it's either the fiber is being blocked on some condition (stack trace would show this) or the notification to wake it up and terminate the fiber was missed (or even the fiber was placed in the ready queue but the scheduler never run it for some reason).
2. If heartbeat is `terminating` we know that the dispatcher somehow missed the notification because -> heartbeat would terminate by setting the kTerminateBit, notify and then preempt via SwitchTo `which should wake up the fiber that joined on it by placing it in the ready queue`

## From the stack trace

```
1505 scheduler.cc:534] ------------ Fiber heartbeat_periodic2 (ready:20134ms) ------------
0xd5ac20  boost::context::detail::fiber_ontop<>()
0xd5b920  util::fb2::detail::FiberInterface::SwitchTo()
0xd584d8  util::fb2::detail::Scheduler::Preempt()
```

Honestly, this doesn't look like the fiber is in `ready_queue`. It seems that it's the path in `terminate`:

line 311: `return scheduler_->Preempt(false);`.

Otherwise we would see some `EventCount::` or a larger stacktrace that would show where the heartbeat was preempted/blocked.

Unless the stack is corrupted, I don't see how the fiber can be in the `ready queue` with the stack given above.

Current hypothesis is that the waiter is not being woken up properly upon fiber termination (which I honestly based on the code I don't see how such case can come up).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Fiber diagnostics now show clearer lifecycle status (e.g., "terminating" vs "ready") and, when enabled, include timing details: last context-switch duration and last time the fiber entered the ready queue for better observability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/romange/helio/pull/591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->