### PR TITLE
chore: tls socket NEED_WRITE on recv while WRITE_IN_PROGRESS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
           EOF
 
           gdb -ix ./init.gdb --batch -ex r --args ./fibers_test --logtostderr
-          GLOG_logtostderr=1 ctest -V -L CI
+          GLOG_logtostderr=1 GLOG_v=1 ctest -V -L CI
 
     - name: Start Minio
       if: matrix.config.name == 'ubuntu24-gcc' && matrix.os.arch == 'amd64'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
           EOF
 
           gdb -ix ./init.gdb --batch -ex r --args ./fibers_test --logtostderr
-          GLOG_logtostderr=1 GLOG_v=1 ctest -V -L CI
+          GLOG_logtostderr=1 ctest -V -L CI
 
     - name: Start Minio
       if: matrix.config.name == 'ubuntu24-gcc' && matrix.os.arch == 'amd64'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           ls -la
 
     - name: Test
-      timeout-minutes: 2
+      timeout-minutes: 3
       run: |
           cd build
 

--- a/util/tls/tls_socket.cc
+++ b/util/tls/tls_socket.cc
@@ -392,11 +392,12 @@ auto TlsSocket::MaybeSendOutput() -> error_code {
 
 auto TlsSocket::HandleUpstreamRead() -> error_code {
   if (engine_->OutputPending() != 0) {
-    // All tls operations should make sure that output is flushed before finisihing.
-    // If the state machine requested reading, then the output has been flushed,
-    // or there is a concurrent write in progress.
+    // Normally output is flushed before the read path needs upstream data, or a concurrent
+    // write fiber is already in progress (WRITE_IN_PROGRESS). During a TLS 1.3 KeyUpdate the
+    // write fiber may exit (e.g. after a connection reset) without draining the ack, leaving
+    // OutputPending > 0 with WRITE_IN_PROGRESS clear. Flush here; MaybeSendOutput will either
+    // succeed or return the connection error, which is the right outcome either way.
     if ((state_ & WRITE_IN_PROGRESS) == 0) {
-      LOG(DFATAL) << "Should not happen";
       RETURN_ON_ERROR(MaybeSendOutput());
     }
   }

--- a/util/tls/tls_socket.cc
+++ b/util/tls/tls_socket.cc
@@ -370,24 +370,17 @@ auto TlsSocket::MaybeSendOutput() -> error_code {
   if (engine_->OutputPending() == 0)
     return {};
 
-  // This function is present in both read and write paths.
-  // meaning that both of them can be called concurrently from differrent fibers and then
-  // race over flushing the output buffer. We use state_ to prevent that.
+  // Called from both the read and write paths, which may run concurrently on different fibers.
+  // On the write path this is straightforward. On the read path, the TLS engine can generate
+  // outbound data that must be flushed before reading can continue — this happens during
+  // protocol renegotiation (TLS 1.2) or a KeyUpdate exchange (TLS 1.3), both of which cause
+  // SSL_read to return SSL_ERROR_WANT_WRITE.
+  // In that case a concurrent write fiber may already hold WRITE_IN_PROGRESS. We must wait for
+  // it to finish rather than spinning: without yielding, the fiber spins indefinitely and never
+  // passes control to anyone else, so WRITE_IN_PROGRESS never clears and the engine loops on
+  // NEED_WRITE forever.
+  // See Tls13KeyUpdateNeedWrite test for the concrete scenario.
   if (state_ & WRITE_IN_PROGRESS) {
-    // This should not happen, as we call MaybeSendOutput from reads only when
-    // there is no ongoing write.
-    LOG(DFATAL) << "Should not happen";
-
-    // Fiber1 (Connection fiber):
-    // Reads SSL renegotiation request
-    // Sets WRITE_IN_PROGRESS in state_
-    // Tries to write renegotiation response to socket
-    // BIO (SSL buffer) gets filled up
-    // Fiber2 (runs command):
-    // Tries to write response to socket
-    // Can't write to socket because WRITE_IN_PROGRESS is set.
-
-    // Wait for the other write to complete.
     fb2::NoOpLock lock;
     block_concurrent_cv_.wait(lock, [&] { return !(state_ & WRITE_IN_PROGRESS); });
 

--- a/util/tls/tls_socket_test.cc
+++ b/util/tls/tls_socket_test.cc
@@ -96,7 +96,7 @@ class TlsSocketTest : public testing::TestWithParam<string_view> {
   thread proactor_thread_;
   unique_ptr<FiberSocketBase> listen_socket_;
   unique_ptr<tls::TlsSocket> server_socket_;
-  SSL_CTX* ssl_ctx_;
+  SSL_CTX* ssl_ctx_ = nullptr;
 
   Fiber accept_fb_;
   std::error_code accept_ec_;
@@ -143,7 +143,10 @@ void TlsSocketTest::SetUp() {
 
   accept_fb_ = proactor_->LaunchFiber("AcceptFb", [this] {
     auto accept_res = listen_socket_->Accept();
-    CHECK(accept_res) << "Accept error: " << accept_res.error();
+    if (!accept_res) {
+      VLOG(1) << "Accept error: " << accept_res.error();
+      return;
+    }
 
     FiberSocketBase* sock = *accept_res;
     VLOG(1) << "Accepted connection " << sock->native_handle();
@@ -154,7 +157,7 @@ void TlsSocketTest::SetUp() {
     ssl_ctx_ = CreateSslCntx(SERVER);
     server_socket_->InitSSL(ssl_ctx_);
     auto tls_accept = server_socket_->Accept();
-    CHECK(accept_res) << "Tls Accept error: " << accept_res.error();
+    CHECK(tls_accept) << "Tls Accept error: " << tls_accept.error();
   });
 }
 
@@ -268,6 +271,9 @@ TEST_P(TlsSocketTest, KtlsClientFdApiFeasibility) {
 //   - Server read fiber: calls ReadSome concurrently; SSL_read processes the KeyUpdate
 //     record and must handle SSL_ERROR_WANT_WRITE without crashing.
 TEST_P(TlsSocketTest, Tls13KeyUpdateNeedWrite) {
+  if (GetParam() != "uring")
+    GTEST_SKIP() << "Test requires io_uring (epoll cannot cancel blocked SQEs via close)";
+
   std::string cert_base(TEST_CERT_PATH);
 
   int fd = ::socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP);
@@ -299,13 +305,13 @@ TEST_P(TlsSocketTest, Tls13KeyUpdateNeedWrite) {
   constexpr size_t kChunkSize = 64 * 1024;
   std::vector<uint8_t> chunk(kChunkSize, 'z');
 
-  // Write fiber: floods the client with data until the TCP send buffer fills, at
-  // which point Write() yields while holding WRITE_IN_PROGRESS.
+  // Write fiber: floods the client until the TCP send buffer fills and Write() blocks,
+  // holding WRITE_IN_PROGRESS. Loops until error — server_socket_->Close() below
+  // cancels the blocked io_uring SEND sqe (closing the fd cancels all pending sqes),
+  // which returns an error and exits this loop.
   auto write_fb = proactor_->LaunchFiber("WriteFb", [&] {
-    for (int i = 0; i < 1000; ++i) {
-      if (server_socket_->Write(io::Bytes{chunk.data(), chunk.size()}))
-        break;
-    }
+    while (!server_socket_->Write(io::Bytes{chunk.data(), chunk.size()}))
+      ;
   });
 
   // Read fiber: runs concurrently with the blocked write. When SSL_read processes
@@ -317,7 +323,8 @@ TEST_P(TlsSocketTest, Tls13KeyUpdateNeedWrite) {
     uint8_t buf[256];
     iovec iov{buf, sizeof(buf)};
     while (true) {
-      if (!server_socket_->ReadSome(&iov, 1))
+      auto res = server_socket_->ReadSome(&iov, 1);
+      if (!res || *res == 0)  // error or graceful EOF (close_notify)
         break;
     }
   });
@@ -336,7 +343,24 @@ TEST_P(TlsSocketTest, Tls13KeyUpdateNeedWrite) {
       break;
   }
 
-  proactor_->Await([&] { std::ignore = server_socket_->Shutdown(SHUT_RDWR); });
+  // Close the client connection BEFORE asking the server to shut down.
+  // The server's write fiber is blocked in a pending SEND (TCP send buffer is full because we
+  // never read). On uring, ::shutdown(fd) alone does not cancel the blocked sqe. close() with
+  // unread data in the receive buffer sends TCP RST, which causes the server's WriteSome to fail
+  // with ECONNRESET immediately, clearing WRITE_IN_PROGRESS and allowing server Shutdown to
+  // proceed.
+  //
+  // Sequence after close(fd) → TCP RST:
+  //   1. Write fiber's WriteSome fails (ECONNRESET), exits without draining the KeyUpdate ack,
+  //      clears WRITE_IN_PROGRESS, notify_one().
+  //   2. Read fiber wakes from MaybeSendOutput's cv.wait, returns {}.
+  //   3. RecvMsg loops, engine_->Read() returns NEED_READ_AND_MAYBE_WRITE — ack still in output
+  //      buffer because the write fiber exited before draining it.
+  //   4. HandleUpstreamRead sees OutputPending() > 0 with WRITE_IN_PROGRESS clear, calls
+  //      MaybeSendOutput() which fails with ECONNRESET; error propagates and read fiber exits.
+  { auto _ = std::move(ssl_guard); }  // SSL_shutdown + SSL_free (non-blocking, may be EAGAIN)
+  { auto _ = std::move(fd_guard); }   // close() → RST due to unread data
+
   write_fb.JoinIfNeeded();
   read_fb.JoinIfNeeded();
 }

--- a/util/tls/tls_socket_test.cc
+++ b/util/tls/tls_socket_test.cc
@@ -271,9 +271,6 @@ TEST_P(TlsSocketTest, KtlsClientFdApiFeasibility) {
 //   - Server read fiber: calls ReadSome concurrently; SSL_read processes the KeyUpdate
 //     record and must handle SSL_ERROR_WANT_WRITE without crashing.
 TEST_P(TlsSocketTest, Tls13KeyUpdateNeedWrite) {
-  if (GetParam() != "uring")
-    GTEST_SKIP() << "Test requires io_uring (epoll cannot cancel blocked SQEs via close)";
-
   std::string cert_base(TEST_CERT_PATH);
 
   int fd = ::socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP);

--- a/util/tls/tls_socket_test.cc
+++ b/util/tls/tls_socket_test.cc
@@ -355,11 +355,29 @@ TEST_P(TlsSocketTest, Tls13KeyUpdateNeedWrite) {
   //      buffer because the write fiber exited before draining it.
   //   4. HandleUpstreamRead sees OutputPending() > 0 with WRITE_IN_PROGRESS clear, calls
   //      MaybeSendOutput() which fails with ECONNRESET; error propagates and read fiber exits.
+  LOG(INFO) << "Closing client connection";
   { auto _ = std::move(ssl_guard); }  // SSL_shutdown + SSL_free (non-blocking, may be EAGAIN)
+  LOG(INFO) << "ssl_guard destroyed, closing fd";
   { auto _ = std::move(fd_guard); }   // close() → RST due to unread data
+  LOG(INFO) << "fd_guard destroyed (RST sent), waiting for server fibers";
+
+  // Watchdog: if the server fibers don't unblock within 10s, dump all fiber stacks and abort.
+  fb2::Done watchdog_done;
+  auto watchdog_fb = proactor_->LaunchFiber("WatchdogFb", [&] {
+    if (!watchdog_done.WaitFor(10s)) {
+      LOG(ERROR) << "Deadlock detected — server fibers did not unblock after RST";
+      proactor_->Await([] { fb2::PrintFiberStackTracesInThread(); });
+      LOG(FATAL) << "Deadlock — aborting";
+    }
+  });
 
   write_fb.JoinIfNeeded();
+  LOG(INFO) << "write_fb joined";
   read_fb.JoinIfNeeded();
+  LOG(INFO) << "read_fb joined";
+
+  watchdog_done.Notify();
+  watchdog_fb.Join();
 }
 #endif
 

--- a/util/tls/tls_socket_test.cc
+++ b/util/tls/tls_socket_test.cc
@@ -4,6 +4,7 @@
 
 #include "util/tls/tls_socket.h"
 
+#include <absl/cleanup/cleanup.h>
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_cat.h>
 #include <gmock/gmock.h>
@@ -22,6 +23,7 @@
 #include "util/tls/tls_test_infra.h"
 
 #ifdef __linux__
+#include <fcntl.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -182,11 +184,11 @@ void TlsSocketTest::TearDown() {
 // Uses output parameter to allow assertions inside the function..
 void TlsSocketTest::CreateClientSocket(std::unique_ptr<tls::TlsSocket>& client_sock) {
   SSL_CTX* ssl_ctx = CreateSslCntx(CLIENT);
+  auto ssl_ctx_guard = absl::MakeCleanup([&] { SSL_CTX_free(ssl_ctx); });
   proactor_->Await([&] {
     client_sock.reset(new tls::TlsSocket(proactor_->CreateSocket()));
     client_sock->InitSSL(ssl_ctx);
   });
-  SSL_CTX_free(ssl_ctx);
   error_code ec = proactor_->Await([&] { return client_sock->Connect(listen_ep_); });
   ASSERT_FALSE(ec) << "Connect failed: " << ec.message();
   ASSERT_TRUE(client_sock) << "Client socket is null after connect";
@@ -196,16 +198,19 @@ void TlsSocketTest::CreateClientSocket(std::unique_ptr<tls::TlsSocket>& client_s
 // Requires ktls module support, can be checked with `modinfo tls` and `lsmod | grep tls`.
 TEST_P(TlsSocketTest, KtlsClientFdApiFeasibility) {
   SSL_CTX* client_ctx = CreateSslCntx(CLIENT);
+  auto client_ctx_guard = absl::MakeCleanup([&] { SSL_CTX_free(client_ctx); });
   SSL_CTX_set_options(client_ctx, SSL_OP_ENABLE_KTLS);
 
   int client_fd = ::socket(listen_ep_.protocol().family(), SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP);
   ASSERT_GE(client_fd, 0) << "socket() failed: " << strerror(errno);
+  auto client_fd_guard = absl::MakeCleanup([&] { ::close(client_fd); });
 
   int rc =
       ::connect(client_fd, reinterpret_cast<const sockaddr*>(listen_ep_.data()), listen_ep_.size());
   ASSERT_EQ(rc, 0) << "connect() failed: " << strerror(errno);
 
   SSL* ssl = SSL_new(client_ctx);
+  auto ssl_guard = absl::MakeCleanup([&] { std::ignore = SSL_shutdown(ssl); SSL_free(ssl); });
   ASSERT_NE(ssl, nullptr);
   ASSERT_EQ(SSL_set_fd(ssl, client_fd), 1);
 
@@ -244,10 +249,96 @@ TEST_P(TlsSocketTest, KtlsClientFdApiFeasibility) {
   ASSERT_GT(rc, 0);
   ASSERT_EQ(string_view(client_buf.data(), rc), server_msg);
 
-  std::ignore = SSL_shutdown(ssl);
-  SSL_free(ssl);
-  ::close(client_fd);
-  SSL_CTX_free(client_ctx);
+}
+
+// Reproduces SSL_ERROR_WANT_WRITE on the read path while WRITE_IN_PROGRESS is set.
+//
+// TLS 1.3 KeyUpdate(update_requested) forces the peer's SSL_read to emit a
+// KeyUpdate(update_not_requested) ack. If the BIO is full at that point,
+// SSL_read returns SSL_ERROR_WANT_WRITE, which races with a concurrent write
+// fiber that has already parked with WRITE_IN_PROGRESS.
+//
+// The raw OpenSSL client runs on the gtest test thread (blocking I/O) while the
+// proactor runs server-side fibers on its own thread — no extra threads needed.
+//
+// Setup:
+//   - Test thread (raw SSL): sends SSL_key_update before each write and never reads,
+//     filling the server's TCP send buffer and parking its write fiber.
+//   - Server write fiber: floods the client until TCP buffers fill (WRITE_IN_PROGRESS).
+//   - Server read fiber: calls ReadSome concurrently; SSL_read processes the KeyUpdate
+//     record and must handle SSL_ERROR_WANT_WRITE without crashing.
+TEST_P(TlsSocketTest, Tls13KeyUpdateNeedWrite) {
+  std::string cert_base(TEST_CERT_PATH);
+
+  int fd = ::socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP);
+  ASSERT_GE(fd, 0);
+  auto fd_guard = absl::MakeCleanup([&] { ::close(fd); });
+
+  ASSERT_EQ(
+      0, ::connect(fd, reinterpret_cast<const sockaddr*>(listen_ep_.data()), listen_ep_.size()));
+
+  SSL_CTX* ctx = SSL_CTX_new(TLS_client_method());
+  auto ctx_guard = absl::MakeCleanup([&] { SSL_CTX_free(ctx); });
+  SSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION);
+  SSL_CTX_use_PrivateKey_file(ctx, (cert_base + "/server-key.pem").c_str(), SSL_FILETYPE_PEM);
+  SSL_CTX_use_certificate_chain_file(ctx, (cert_base + "/server-cert.pem").c_str());
+  SSL_CTX_load_verify_locations(ctx, (cert_base + "/ca-cert.pem").c_str(), nullptr);
+  SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nullptr);
+
+  SSL* ssl = SSL_new(ctx);
+  auto ssl_guard = absl::MakeCleanup([&] { SSL_shutdown(ssl); SSL_free(ssl); });
+  SSL_set_fd(ssl, fd);
+
+  // Blocking handshake on the test thread; the proactor thread handles the server side.
+  ASSERT_EQ(1, SSL_connect(ssl)) << ERR_error_string(ERR_get_error(), nullptr);
+  ASSERT_EQ(TLS1_3_VERSION, SSL_version(ssl)) << "expected TLS 1.3 to be negotiated";
+
+  // server_socket_ is set inside accept_fb_; join before launching server fibers.
+  accept_fb_.JoinIfNeeded();
+
+  constexpr size_t kChunkSize = 64 * 1024;
+  std::vector<uint8_t> chunk(kChunkSize, 'z');
+
+  // Write fiber: floods the client with data until the TCP send buffer fills, at
+  // which point Write() yields while holding WRITE_IN_PROGRESS.
+  auto write_fb = proactor_->LaunchFiber("WriteFb", [&] {
+    for (int i = 0; i < 1000; ++i) {
+      if (server_socket_->Write(io::Bytes{chunk.data(), chunk.size()}))
+        break;
+    }
+  });
+
+  // Read fiber: runs concurrently with the blocked write. When SSL_read processes
+  // the incoming KeyUpdate record it returns SSL_ERROR_WANT_WRITE — the exact
+  // NEED_WRITE-while-WRITE_IN_PROGRESS path exercised by this test.
+  // Note: TLS 1.2 exposes the same path via renegotiation (SSL_renegotiate), which
+  // also causes SSL_read to generate output and potentially return SSL_ERROR_WANT_WRITE.
+  auto read_fb = proactor_->LaunchFiber("ReadFb", [&] {
+    uint8_t buf[256];
+    iovec iov{buf, sizeof(buf)};
+    while (true) {
+      if (!server_socket_->ReadSome(&iov, 1))
+        break;
+    }
+  });
+
+  // Switch to non-blocking so SSL_write exits promptly once the TCP send buffer fills.
+  int flags = fcntl(fd, F_GETFL, 0);
+  fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+
+  // Do not call SSL_read — starves the server TCP send buffer so its write fiber
+  // parks with WRITE_IN_PROGRESS. Prepend SSL_key_update to each write to maximise
+  // the chance that SSL_read on the server encounters NEED_WRITE while that flag is set.
+  char buf[1] = {};
+  for (int i = 0; i < 100'000; ++i) {
+    SSL_key_update(ssl, SSL_KEY_UPDATE_REQUESTED);
+    if (SSL_write(ssl, buf, 1) <= 0)
+      break;
+  }
+
+  proactor_->Await([&] { std::ignore = server_socket_->Shutdown(SHUT_RDWR); });
+  write_fb.JoinIfNeeded();
+  read_fb.JoinIfNeeded();
 }
 #endif
 
@@ -670,15 +761,12 @@ void AsyncTlsSocketTest::TearDown() {
 
 unique_ptr<tls::TlsSocket> AsyncTlsSocketTest::CreateClientSock() {
   unique_ptr<tls::TlsSocket> client_sock;
-  {
-    SSL_CTX* ssl_ctx = CreateSslCntx(CLIENT);
-
-    proactor_->Await([&] {
-      client_sock.reset(new tls::TlsSocket(proactor_->CreateSocket()));
-      client_sock->InitSSL(ssl_ctx);
-    });
-    SSL_CTX_free(ssl_ctx);
-  }
+  SSL_CTX* ssl_ctx = CreateSslCntx(CLIENT);
+  auto ssl_ctx_guard = absl::MakeCleanup([&] { SSL_CTX_free(ssl_ctx); });
+  proactor_->Await([&] {
+    client_sock.reset(new tls::TlsSocket(proactor_->CreateSocket()));
+    client_sock->InitSSL(ssl_ctx);
+  });
   return client_sock;
 }
 
@@ -1108,8 +1196,10 @@ TEST_P(MockTlsSocketTest, HandshakeThenWrite) {
     // Create the dummy Context and SSL object
     SSL_CTX* test_ctx = SSL_CTX_new(TLS_method());
     ASSERT_NE(test_ctx, nullptr);
+    auto test_ctx_guard = absl::MakeCleanup([&] { SSL_CTX_free(test_ctx); });
     SSL* test_ssl = SSL_new(test_ctx);
     ASSERT_NE(test_ssl, nullptr);
+    auto test_ssl_guard = absl::MakeCleanup([&] { SSL_free(test_ssl); });
 
     // In this unit test, we use a 'dummy' SSL object that has not performed a real handshake.
     // Because TlsSocket (and underlying OpenSSL checks) internally rely on an active cipher
@@ -1142,9 +1232,6 @@ TEST_P(MockTlsSocketTest, HandshakeThenWrite) {
     ASSERT_TRUE(sock_->Accept());
     ASSERT_FALSE(sock_->Write(io::Bytes(buf, sizeof(buf))));
 
-    // Cleanup, SSL_free frees the internal session because refcount is 1
-    SSL_free(test_ssl);
-    SSL_CTX_free(test_ctx);
   });
 }
 


### PR DESCRIPTION
We had a test in dragonfly that used protocol renegotiation to exercise the same path. However it was unreliable and reproduced very rarely. 1.3 connections use KeyUpdates to exercise the same path (in fact it's the only case the Recv might NEED_WRITE).

I will also remove the test from dragonfly.

* remove DFATAL log
* update comment
* add test
* small refactor -- use absl::Cleanup in tls_socket_test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents a fatal failure and potential deadlock during concurrent TLS write/flush by waiting and proceeding safely instead of aborting.
  * Ensures pending TLS output is flushed correctly after edge cases like connection reset or TLS key-update.
  * Reduces hard failures on accept failures by logging and returning early instead of crashing.

* **Tests**
  * Added a Linux-only TLS 1.3 regression/stress test exercising concurrent read/write and key-update races with non-blocking sockets.
  * Improved test resource cleanup using scoped guards to reduce flakiness.

* **Chores**
  * Increased CI test timeout to allow longer test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/romange/helio/pull/593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->