### PR TITLE
Epoll: use busy poll cycle limit

### DIFF
--- a/base/mpmc_bounded_queue.h
+++ b/base/mpmc_bounded_queue.h
@@ -133,9 +133,31 @@ template <typename T> class mpmc_bounded_queue {
     return true;
   }
 
+  // Single consumer version of try_dequeue. Should be used when only one consumer thread exists.
+  // It has better performance than the multi-consumer version.
+  bool try_dequeue_sc(T& data) {
+    size_t pos = dequeue_pos_.load(std::memory_order_relaxed);
+    cell_t& cell = buffer_[pos & buffer_mask_];
+    size_t seq = cell.sequence.load(std::memory_order_acquire);
+    intptr_t dif = (intptr_t)seq - (intptr_t)(pos + 1);
+    if (dif < 0) {
+      return false;  // the queue is empty.
+    }
+
+    dequeue_pos_.store(pos + 1, std::memory_order_relaxed);
+
+    T& src = reinterpret_cast<T&>(cell.storage);
+    data = std::forward<T>(src);
+    src.~T();
+
+    // Commit transaction, free up the cell.
+    cell.sequence.store(pos + buffer_mask_ + 1, std::memory_order_release);
+    return true;
+  }
+
   size_t capacity() const {
     return buffer_mask_ + 1;
-  }
+  } 
 
   // Represents a point in time. The state could change one cpu cycle later.
   // For single producer cases if a queue is empty it will stay empty until the producer enqueue
@@ -150,7 +172,11 @@ template <typename T> class mpmc_bounded_queue {
   }
 
  private:
-  struct cell_t {
+  static constexpr size_t kCacheLineSize = 64;
+  static constexpr size_t kCellAlignment =
+      alignof(T) > kCacheLineSize ? alignof(T) : kCacheLineSize;
+
+  struct alignas(kCellAlignment) cell_t {
     std::atomic<size_t> sequence;
     alignas(T) char storage[sizeof(T)];
   };

--- a/base/mpmc_bounded_queue_test.cc
+++ b/base/mpmc_bounded_queue_test.cc
@@ -4,12 +4,21 @@
 
 #include "base/mpmc_bounded_queue.h"
 
-#include <memory>
+#include <absl/strings/str_cat.h>
 
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "base/flags.h"
 #include "base/gtest.h"
 #include "base/logging.h"
 
+ABSL_FLAG(uint32_t, producers, 1, "Number of producer threads for the benchmark");
+ABSL_FLAG(uint32_t, queue_size, 1024, "Queue size, must be power of 2");
+
 using namespace std;
+using benchmark::DoNotOptimize;
 
 namespace base {
 
@@ -112,5 +121,83 @@ TEST_F(MPMCTest, Moveable) {
   }
   EXPECT_EQ(0, Moveable::ref);
 }
+
+TEST_F(MPMCTest, SingleConsumerDequeue) {
+  mpmc_bounded_queue<int> q(2);
+
+  ASSERT_TRUE(q.try_enqueue(1));
+  ASSERT_TRUE(q.try_enqueue(2));
+
+  int tmp = 0;
+  ASSERT_TRUE(q.try_dequeue_sc(tmp));
+  EXPECT_EQ(1, tmp);
+  ASSERT_TRUE(q.try_enqueue(3));
+
+  ASSERT_TRUE(q.try_dequeue_sc(tmp));
+  EXPECT_EQ(2, tmp);
+  ASSERT_TRUE(q.try_dequeue_sc(tmp));
+  EXPECT_EQ(3, tmp);
+  ASSERT_FALSE(q.try_dequeue_sc(tmp));
+}
+
+// To see hotspots:
+// perf c2c record ./mpmc_bounded_queue_test --bench --producers=8
+// perf c2c report --stdio
+static void BM_MPMCContention(benchmark::State& state) {
+  const unsigned num_producers = absl::GetFlag(FLAGS_producers);
+  const size_t queue_size = absl::GetFlag(FLAGS_queue_size);
+  const size_t kOpsPerProducer = 1 << 20;
+  const size_t total_ops = num_producers * kOpsPerProducer;
+
+  for (auto _ : state) {
+    mpmc_bounded_queue<uint64_t> queue(queue_size);
+    atomic<bool> start{false};
+    atomic<uint64_t> enqueue_failures{0};
+
+    thread consumer([&] {
+      while (!start.load(memory_order_acquire)) {
+      }
+
+      size_t consumed = 0;
+      uint64_t val;
+      while (consumed < total_ops) {
+        if (queue.try_dequeue_sc(val)) {
+          DoNotOptimize(val);
+          ++consumed;
+        }
+      }
+    });
+
+    vector<thread> producers;
+    producers.reserve(num_producers);
+    for (unsigned i = 0; i < num_producers; ++i) {
+      producers.emplace_back([&] {
+        while (!start.load(memory_order_acquire)) {
+        }
+
+        uint64_t fails = 0;
+        for (size_t j = 0; j < kOpsPerProducer; ++j) {
+          while (!queue.try_enqueue(j)) {
+            ++fails;
+          }
+        }
+        enqueue_failures.fetch_add(fails, memory_order_relaxed);
+      });
+    }
+
+    start.store(true, memory_order_release);
+
+    for (auto& t : producers)
+      t.join();
+    consumer.join();
+
+    state.counters["enq_fail/op"] =
+        double(enqueue_failures.load()) / total_ops;
+  }
+
+  state.SetItemsProcessed(state.iterations() * total_ops);
+  state.SetLabel(absl::StrCat(num_producers, "P/1C q=", queue_size));
+}
+BENCHMARK(BM_MPMCContention)->MinTime(2.0)->UseRealTime();
 
 }  // namespace base

--- a/util/fibers/epoll_proactor.cc
+++ b/util/fibers/epoll_proactor.cc
@@ -89,9 +89,7 @@ int EpollCreate() {
 }
 
 int EpollWait(int epoll_fd, EventsBatch* batch, int tm_ms) {
-  struct timespec ts {
-    .tv_sec = tm_ms / 1000, .tv_nsec = (tm_ms % 1000) * 1000000
-  };
+  struct timespec ts{.tv_sec = tm_ms / 1000, .tv_nsec = (tm_ms % 1000) * 1000000};
 
   int epoll_res = kevent(epoll_fd, NULL, 0, batch->cqe, kEvBatchSize, tm_ms < 0 ? NULL : &ts);
   return epoll_res;
@@ -185,7 +183,6 @@ void EpollProactor::MainLoop(detail::Scheduler* scheduler) {
 
   EventsBatch ev_batch;
   uint32_t tq_seq = 0;
-  uint32_t spin_loops = 0;
 
   Tasklet task;
 
@@ -197,7 +194,7 @@ void EpollProactor::MainLoop(detail::Scheduler* scheduler) {
 
     tq_seq = tq_seq_.load(memory_order_acquire);
 
-    if (task_queue_.try_dequeue(task)) {
+    if (task_queue_.try_dequeue_sc(task)) {
       uint32_t cnt = 0;
       uint64_t task_start = base::CycleClock::Now();
       do {
@@ -219,7 +216,8 @@ void EpollProactor::MainLoop(detail::Scheduler* scheduler) {
       } while (task_queue_.try_dequeue(task));
 
       stats_.num_task_runs += cnt;
-      DVLOG(2) << "Tasks runs " << stats_.num_task_runs << "/" << spin_loops;
+      DVLOG(2) << "Tasks runs " << stats_.num_task_runs;
+      ResetBusyPoll();
 
       // We notify at the end that the queue is not full.
       // Tested by ProactorTest.AsyncCall.
@@ -236,8 +234,8 @@ void EpollProactor::MainLoop(detail::Scheduler* scheduler) {
     // 1. No other fibers are active.
     // 2. Specifically SuspendIoLoop was called and returned true.
     // 3. Task queue is empty otherwise we should spin more to unload it.
-    if (task_queue_exhausted && !scheduler->HasAnyReady() && spin_loops >= kMaxSpinLimit) {
-      spin_loops = 0;
+    bool should_poll = (base::CycleClock::Now() - busy_poll_start_cycle()) < busy_poll_cycle_limit_;
+    if (task_queue_exhausted && !scheduler->HasAnyReady() && !should_poll) {
       if (tq_seq_.compare_exchange_weak(tq_seq, WAIT_SECTION_STATE, memory_order_acquire)) {
         // We check stop condition when all the pending events were processed.
         // It's up to the app-user to make sure that the incoming flow of events is stopped before
@@ -267,7 +265,9 @@ void EpollProactor::MainLoop(detail::Scheduler* scheduler) {
 
     uint64_t start_cycle = base::CycleClock::Now();
     int epoll_res = EpollWait(epoll_fd_, &ev_batch, timeout);
-    IdleEnd(start_cycle);
+    if (timeout != 0) {
+      IdleEnd(start_cycle);
+    }
 
     if (epoll_res < 0) {
       epoll_res = errno;
@@ -280,6 +280,7 @@ void EpollProactor::MainLoop(detail::Scheduler* scheduler) {
     uint32_t cqe_count = epoll_res;
     if (cqe_count) {
       ++stats_.completions_fetches;
+      ResetBusyPoll();
 
       while (true) {
         VPRO(2) << "Fetched " << cqe_count << " cqes";
@@ -297,9 +298,12 @@ void EpollProactor::MainLoop(detail::Scheduler* scheduler) {
       };
     }
 
-    RunL2Tasks(scheduler);
+    if (RunL2Tasks(scheduler)) {
+      ResetBusyPoll();
+    }
 
     if (scheduler->Run(FiberPriority::NORMAL) == detail::RunFiberResult::HAS_ACTIVE) {
+      ResetBusyPoll();
       continue;
     }
 
@@ -308,14 +312,19 @@ void EpollProactor::MainLoop(detail::Scheduler* scheduler) {
     }
 
     if (scheduler->Run(FiberPriority::BACKGROUND) == detail::RunFiberResult::HAS_ACTIVE) {
+      ResetBusyPoll();
       continue;
     }
 
-    if (!RunOnIdleTasks()) {
-      // Pause(spin_loops);
-      ++spin_loops;
-      scheduler->DestroyTerminated();
+    bool spin_on_idle_tasks = RunOnIdleTasks();
+    if (spin_on_idle_tasks) {
+      continue;
     }
+
+    if (should_poll) {
+      Pause(3);
+    }
+    scheduler->DestroyTerminated();
   }
 
   VPRO(1) << "total/stalls/cqe_fetches/num_suspends: " << stats_.loop_cnt << "/"

--- a/util/fibers/fiberqueue_threadpool.cc
+++ b/util/fibers/fiberqueue_threadpool.cc
@@ -19,10 +19,10 @@ FiberQueue::FiberQueue(unsigned queue_size) : queue_(queue_size) {
 
 void FiberQueue::Run() {
   bool is_closed = false;
-  CbFunc func;
+  Tasklet func;
 
   auto cb = [&] {
-    if (queue_.try_dequeue(func)) {
+    if (queue_.try_dequeue_sc(func)) {
       push_ec_.notify();
       return true;
     }
@@ -40,13 +40,7 @@ void FiberQueue::Run() {
 
     if (is_closed)
       break;
-    try {
-      func();
-
-    } catch (std::exception& e) {
-      // std::exception_ptr p = std::current_exception();
-      LOG(FATAL) << "Exception " << e.what();
-    }
+    func();
   }
 }
 

--- a/util/fibers/fiberqueue_threadpool.h
+++ b/util/fibers/fiberqueue_threadpool.h
@@ -7,6 +7,11 @@
 #include "util/fibers/detail/result_mover.h"
 #include "util/fibers/synchronization.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waddress"
+#include "base/function2.hpp"
+#pragma GCC diagnostic pop
+
 namespace util {
 namespace fb2 {
 class FiberQueueThreadPool;
@@ -19,6 +24,16 @@ class FiberQueueThreadPool;
 class FiberQueue {
   friend class FiberQueueThreadPool;
 
+  using Fu2Fun =
+      fu2::function_base<true /* owns */, false /*non-copyable*/, fu2::capacity_fixed<32, 8>,
+                         false /* non-throwing*/, false /* strong exceptions guarantees*/, void()>;
+
+  struct Tasklet : public Fu2Fun {
+    using Fu2Fun::Fu2Fun;
+    using Fu2Fun::operator=;
+  };
+
+  static_assert(sizeof(Tasklet) == 48);
  public:
   explicit FiberQueue(unsigned queue_size = 128);
 
@@ -88,9 +103,7 @@ class FiberQueue {
   void Run();
 
  private:
-  // task index since the last preemption.
-  using CbFunc = std::function<void()>;
-  using FuncQ = base::mpmc_bounded_queue<CbFunc>;
+  using FuncQ = base::mpmc_bounded_queue<Tasklet>;
 
   FuncQ queue_;
 

--- a/util/fibers/proactor_base.cc
+++ b/util/fibers/proactor_base.cc
@@ -373,10 +373,6 @@ void ProactorBase::IdleEnd(uint64_t start) {
   detail::ResetFiberRunSeq();
 }
 
-void ProactorBase::ResetBusyPoll() {
-  busy_poll_start_cycle_ = base::CycleClock::Now();
-}
-
 void ProactorBase::Pause(unsigned count) {
   auto pc = pause_amplifier;
 
@@ -396,7 +392,7 @@ void ProactorBase::ModuleInit() {
   while (true) {
     uint64_t now = GetClockNanos();
     for (unsigned i = 0; i < 10; ++i) {
-      Pause(kMaxSpinLimit);
+      Pause(5);
     }
     delta = GetClockNanos() - now;
     VLOG(1) << "Running 10 Pause() took " << delta / 1000 << "us";

--- a/util/fibers/proactor_base.h
+++ b/util/fibers/proactor_base.h
@@ -219,8 +219,6 @@ class ProactorBase {
 
  protected:
   enum { WAIT_SECTION_STATE = 1UL << 31 };
-  static constexpr unsigned kMaxSpinLimit = 5;
-
   struct PeriodicItem {
     PeriodicTask task;
 
@@ -270,7 +268,9 @@ class ProactorBase {
 
   void IdleEnd(uint64_t start);
 
-  void ResetBusyPoll();
+  void ResetBusyPoll() {
+    busy_poll_start_cycle_ = base::CycleClock::Now();
+  }
 
   uint64_t busy_poll_start_cycle() const {
     return busy_poll_start_cycle_;
@@ -402,7 +402,7 @@ template <typename Func> void ProactorBase::DispatchLocalBrief(Func&& brief) {
       return;
 
     Tasklet task;
-    if (task_queue_.try_dequeue(task)) {
+    if (task_queue_.try_dequeue_sc(task)) {
       task();
     }
   }

--- a/util/fibers/uring_proactor.cc
+++ b/util/fibers/uring_proactor.cc
@@ -856,7 +856,7 @@ void UringProactor::MainLoop(detail::Scheduler* scheduler) {
     // This should handle wait-free and "brief" CPU-only tasks enqued using Async/Await
     // calls. We allocate quota of 500K nsec (500usec) of CPU time per iteration
     // To save redundant timer-calls we start measuring time only when if the queue is not empty.
-    if (task_queue_.try_dequeue(task)) {
+    if (task_queue_.try_dequeue_sc(task)) {
       uint32_t cnt = 0;
       uint64_t task_start = base::CycleClock::Now();
       do {
@@ -867,7 +867,7 @@ void UringProactor::MainLoop(detail::Scheduler* scheduler) {
           has_cpu_work = true;
           break;
         }
-      } while (task_queue_.try_dequeue(task));
+      } while (task_queue_.try_dequeue_sc(task));
       stats_.num_task_runs += cnt;
       DVLOG(2) << "Tasks runs " << stats_.num_task_runs;
 
@@ -952,7 +952,7 @@ void UringProactor::MainLoop(detail::Scheduler* scheduler) {
     // Lets spin a bit to make a system a bit more responsive.
     // Important to spin a bit, otherwise we put too much pressure on  eventfd_write.
     // and we enter too often into kernel space.
-    bool should_poll = GetCurrentBusyCycles() < busy_poll_cycle_limit_;
+    bool should_poll = (base::CycleClock::Now() - busy_poll_start_cycle()) < busy_poll_cycle_limit_;
     if (!ring_busy && should_poll) {
       Pause(3);
 


### PR DESCRIPTION
## Summary
- replace EpollProactor's fixed spin-loop threshold with the shared busy-poll cycle budget
- reset the busy-poll window after real CPU or I/O work, matching UringProactor behavior
- keep zero-timeout epoll probes from resetting idle accounting so they count against the spill budget

## Testing
- Built target: fibers2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Event-loop busy/idle logic reworked to reduce unnecessary spinning and refine idle/termination behavior.
  * Startup spin calibration reduced for faster, more efficient startup.
* **Performance**
  * Queue cell layout adjusted for improved cache alignment and throughput.
* **Behavior**
  * Task exceptions now propagate instead of being locally caught.
* **New Features**
  * Added a lightweight tasklet type and a single-consumer dequeue API.
* **Tests**
  * Added unit test validating single-consumer dequeue behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->