### PR TITLE
fix(build): use -force_load for absl log archives on macOS

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -1,17 +1,25 @@
 add_library(base cpu_features.cc hash.cc histogram.cc init.cc logging.cc file_log_sink.cc
     proc_util.cc pthread_utils.cc varz_node.cc cuckoo_map.cc io_buf.cc segment_pool.cc)
 
-if (LEGACY_GLOG) 
+if (LEGACY_GLOG)
   set(LOG_LIBS glog::glog)
 else()
 
   target_compile_definitions(base PUBLIC -DUSE_ABSL_LOG=1)
-  set(LOG_LIBS absl::check absl::log -Wl,--whole-archive absl::log_flags
-      absl::log_initialize -Wl,--no-whole-archive)
+  if (APPLE)
+    # Apple ld has no --whole-archive; force_load archives kept only by static init.
+    set(LOG_LIBS absl::check absl::log
+        "-Wl,-force_load,$<TARGET_FILE:absl::log_flags>"
+        "-Wl,-force_load,$<TARGET_FILE:absl::log_initialize>"
+        absl::log_flags absl::log_initialize)
+  else()
+    set(LOG_LIBS absl::check absl::log -Wl,--whole-archive absl::log_flags
+        absl::log_initialize -Wl,--no-whole-archive)
+  endif()
 endif()
 
-cxx_link(base ${LOG_LIBS} absl::flags_parse 
-    absl::strings absl::symbolize absl::time absl::failure_signal_handler 
+cxx_link(base ${LOG_LIBS} absl::flags_parse
+    absl::strings absl::symbolize absl::time absl::failure_signal_handler
     TRDP::xxhash TRDP::expected)
 
 # Define default gtest_main for tests.


### PR DESCRIPTION
Apple's `ld` rejects the GNU `--whole-archive`/`--no-whole-archive` flags, so the absl-log build path fails to link on macOS with `ld: unknown options: --whole-archive --no-whole-archive`.

Changes:
- On `APPLE`, force-load the absl log archives via `-force_load` (`$<TARGET_FILE:...>`) instead of the GNU whole-archive wrapper.
- Linux/other platforms keep `--whole-archive` unchanged.

Why force_load only two archives:
All log flags are registered in a single translation unit (`absl/log/flags.cc` -> `libabsl_log_flags.a`); `InitializeLog` lives in `libabsl_log_initialize.a`. Their transitive deps carry no static-init registrations, so they are pulled in normally by reference - `-force_load` on those two is the behavioral equivalent of the whole-archive group.

Checked here: https://github.com/dragonflydb/dragonfly/actions/runs/27087945372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build configuration for improved logging library linking on different platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->