### PR TITLE
feat(aws): support China (aws-cn) STS partition for IRSA

### DIFF
--- a/util/cloud/aws/CMakeLists.txt
+++ b/util/cloud/aws/CMakeLists.txt
@@ -2,3 +2,5 @@ find_package(OpenSSL)
 
 add_library(aws_cloud_lib aws_creds_provider.cc s3_storage.cc)
 cxx_link(aws_cloud_lib cloud_lib strings_lib TRDP::rapidjson TRDP::pugixml OpenSSL::Crypto)
+
+helio_cxx_test(aws_creds_provider_test aws_cloud_lib LABELS CI)

--- a/util/cloud/aws/aws_creds_provider.cc
+++ b/util/cloud/aws/aws_creds_provider.cc
@@ -4,6 +4,7 @@
 #include "util/cloud/aws/aws_creds_provider.h"
 
 #include <absl/strings/ascii.h>
+#include <absl/strings/match.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_split.h>
 #include <absl/strings/strip.h>
@@ -233,6 +234,21 @@ io::Result<string> FetchUrl(string_view host, string_view port, string_view path
 
 }  // namespace
 
+string_view PartitionDnsSuffix(string_view region) {
+  // China is the only public partition with a non-amazonaws.com suffix; GovCloud
+  // (us-gov-*) and ISO partitions keep amazonaws.com.
+  return absl::StartsWith(region, "cn-") ? "amazonaws.com.cn" : "amazonaws.com";
+}
+
+string StsEndpoint(string_view region) {
+  // China has no global STS endpoint, so it must use the regional host; every
+  // other partition uses the global one.
+  if (absl::StartsWith(region, "cn-")) {
+    return absl::StrCat("sts.", region, ".", PartitionDnsSuffix(region));
+  }
+  return "sts.amazonaws.com";
+}
+
 AwsCredsProvider::AwsCredsProvider(string region, string endpoint_override)
     : region_(std::move(region)), endpoint_override_(std::move(endpoint_override)) {
 }
@@ -392,7 +408,7 @@ error_code AwsCredsProvider::TryWebIdentity() {
   strings::AppendUrlEncoded(token, &body);
   body += "&RoleSessionName=helio&Version=2011-06-15";
 
-  auto resp = FetchUrl("sts.amazonaws.com", "443", "/", h2::verb::post,
+  auto resp = FetchUrl(StsEndpoint(region_), "443", "/", h2::verb::post,
                        {{"content-type", "application/x-www-form-urlencoded"}}, body, connect_ms_,
                        GetSslCtx());
   if (!resp)
@@ -534,7 +550,7 @@ string AwsCredsProvider::ServiceEndpoint() const {
   if (const char* ep = getenv("AWS_S3_ENDPOINT"); ep && *ep) {
     return format(ep);
   }
-  return absl::StrCat("s3.", region_, ".amazonaws.com");
+  return absl::StrCat("s3.", region_, ".", PartitionDnsSuffix(region_));
 }
 
 void AwsCredsProvider::Sign(detail::HttpRequestBase* req) const {

--- a/util/cloud/aws/aws_creds_provider.h
+++ b/util/cloud/aws/aws_creds_provider.h
@@ -26,6 +26,16 @@ struct AwsCredentials {
   }
 };
 
+// Returns the DNS suffix for the AWS partition `region` belongs to:
+// "amazonaws.com.cn" for China (cn-*) regions, "amazonaws.com" otherwise
+// (standard, GovCloud and ISO partitions all use amazonaws.com).
+std::string_view PartitionDnsSuffix(std::string_view region);
+
+// Returns the STS endpoint host for `region`. China (cn-*) has no global STS
+// endpoint, so it uses the regional "sts.{region}.amazonaws.com.cn"; every other
+// partition uses the global "sts.amazonaws.com".
+std::string StsEndpoint(std::string_view region);
+
 // Implements CredentialsProvider for AWS.
 //
 // Credential chain (same order as current util/aws/ SDK chain):
@@ -45,7 +55,8 @@ class AwsCredsProvider : public CredentialsProvider {
  public:
   // `region` empty -> defaults to AWS_REGION / AWS_DEFAULT_REGION / "us-east-1".
   // `endpoint_override` empty -> falls back to AWS_S3_ENDPOINT, then
-  //   "s3.{region}.amazonaws.com". Accepts a bare "host[:port]" or a full URL
+  //   "s3.{region}.{partition-suffix}" (amazonaws.com.cn for China cn-* regions,
+  //   amazonaws.com otherwise). Accepts a bare "host[:port]" or a full URL
   //   (e.g. "https://s3.dualstack.us-west-2.amazonaws.com"); scheme and path
   //   are stripped.
   explicit AwsCredsProvider(std::string region = {}, std::string endpoint_override = {});
@@ -56,7 +67,8 @@ class AwsCredsProvider : public CredentialsProvider {
   std::error_code Init(unsigned connect_ms) final;
 
   // Returns the resolved S3 endpoint host[:port]. Precedence: ctor override >
-  // AWS_S3_ENDPOINT env var > "s3.{region}.amazonaws.com".
+  // AWS_S3_ENDPOINT env var > "s3.{region}.{partition-suffix}" (amazonaws.com.cn
+  // for China cn-* regions, amazonaws.com otherwise).
   std::string ServiceEndpoint() const final;
 
   // Computes AWS SigV4 and sets x-amz-date, x-amz-security-token, Authorization headers.

--- a/util/cloud/aws/aws_creds_provider_test.cc
+++ b/util/cloud/aws/aws_creds_provider_test.cc
@@ -1,0 +1,62 @@
+// Copyright 2026, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#include "util/cloud/aws/aws_creds_provider.h"
+
+#include <cstdlib>
+
+#include "base/gtest.h"
+
+namespace util {
+namespace cloud::aws {
+
+using namespace std;
+
+class AwsCredsProviderTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // ServiceEndpoint() consults AWS_S3_ENDPOINT first; clear it so the test is
+    // hermetic and exercises the partition-suffix fallback.
+    unsetenv("AWS_S3_ENDPOINT");
+  }
+};
+
+TEST_F(AwsCredsProviderTest, PartitionDnsSuffix) {
+  EXPECT_EQ(PartitionDnsSuffix("us-east-1"), "amazonaws.com");
+  EXPECT_EQ(PartitionDnsSuffix("eu-west-3"), "amazonaws.com");
+  EXPECT_EQ(PartitionDnsSuffix(""), "amazonaws.com");
+  // GovCloud stays on the standard suffix.
+  EXPECT_EQ(PartitionDnsSuffix("us-gov-west-1"), "amazonaws.com");
+
+  EXPECT_EQ(PartitionDnsSuffix("cn-north-1"), "amazonaws.com.cn");
+  EXPECT_EQ(PartitionDnsSuffix("cn-northwest-1"), "amazonaws.com.cn");
+}
+
+TEST_F(AwsCredsProviderTest, StsEndpoint) {
+  // Standard partitions use the global endpoint.
+  EXPECT_EQ(StsEndpoint("us-east-1"), "sts.amazonaws.com");
+  EXPECT_EQ(StsEndpoint("ap-southeast-2"), "sts.amazonaws.com");
+  EXPECT_EQ(StsEndpoint(""), "sts.amazonaws.com");
+
+  // China has no global STS endpoint; it requires the regional host.
+  EXPECT_EQ(StsEndpoint("cn-north-1"), "sts.cn-north-1.amazonaws.com.cn");
+  EXPECT_EQ(StsEndpoint("cn-northwest-1"), "sts.cn-northwest-1.amazonaws.com.cn");
+}
+
+TEST_F(AwsCredsProviderTest, ServiceEndpointStandard) {
+  AwsCredsProvider provider("us-east-1");
+  EXPECT_EQ(provider.ServiceEndpoint(), "s3.us-east-1.amazonaws.com");
+}
+
+TEST_F(AwsCredsProviderTest, ServiceEndpointChina) {
+  AwsCredsProvider provider("cn-north-1");
+  EXPECT_EQ(provider.ServiceEndpoint(), "s3.cn-north-1.amazonaws.com.cn");
+}
+
+TEST_F(AwsCredsProviderTest, ServiceEndpointOverride) {
+  AwsCredsProvider provider("cn-north-1", "https://my-minio.example:9000/");
+  EXPECT_EQ(provider.ServiceEndpoint(), "my-minio.example:9000");
+}
+
+}  // namespace cloud::aws
+}  // namespace util


### PR DESCRIPTION
### Background

* The existing S3 credential provider hardcodes assumptions that we are using the standard `aws` partition: `TryWebIdentity()` always called `sts.amazonaws.com`, and `ServiceEndpoint()` always built `s3.{region}.amazonaws.com`.
* AWS China partition (`aws-cn`) has no global STS endpoint, and uses the `.amazonaws.com.cn` DNS suffix, so IRSA credential acquisition and S3 access both failed there.

### Intent

* Add `PartitionDnsSuffix()` and `StsEndpoint()` helpers to render the regional `sts.{region}.amazonaws.com.cn` (i.e. `cn-north-1` and the `.amazonaws.com.cn` suffix for `cn-*` regions, and wire them into `TryWebIdentity()` (IRSA) and `ServiceEndpoint()` (S3). 
* Adds aws_creds_provider_test.cc to exercise both paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved AWS region partition handling, including correct China-partition DNS suffixes.
  * Updated web-identity credential flow to use the right region-aware STS endpoint.
  * Enhanced S3 endpoint construction to respect partition-specific hostname patterns.

* **Bug Fixes**
  * Fixed AWS credential retrieval to avoid hardcoded global STS and to use the correct endpoint per region/partition.
  * Improved endpoint selection for S3, including deterministic behavior with custom endpoint overrides.

* **Tests**
  * Added coverage for partition DNS suffix logic, STS endpoint selection, and S3 endpoint formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->