### PR TITLE
chore(proactor): organize statistics around completions gathering

### DIFF
--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -82,7 +82,11 @@ def test_put_get_object_minio(minio):
     assert f"put-object done; bytes={upload_size}" in result.stderr, result.stderr
 
     result = _run(
-        minio["binary"], "--cmd=list-objects", f"--bucket={minio['bucket']}", env=minio["env"]
+        minio["binary"],
+        "--cmd=list-objects",
+        f"--bucket={minio['bucket']}",
+        f"--prefix={key}",
+        env=minio["env"],
     )
     assert result.returncode == 0, f"list-objects failed:\n{result.stderr}"
     assert key in result.stdout, f"{key!r} not found in listing:\n{result.stdout}"
@@ -116,7 +120,9 @@ def test_put_get_object(s3_demo):
     assert result.returncode == 0, f"put-object failed:\n{result.stderr}"
     assert f"put-object done; bytes={upload_size}" in result.stderr, result.stderr
 
-    result = _run(s3_demo, "--cmd=list-objects", f"--bucket={bucket}")
+    result = _run(
+        s3_demo, "--cmd=list-objects", f"--bucket={bucket}", f"--prefix={key}"
+    )
     assert result.returncode == 0, f"list-objects failed:\n{result.stderr}"
     assert key in result.stdout, f"{key!r} not found in listing:\n{result.stdout}"
 

--- a/util/fibers/epoll_proactor.cc
+++ b/util/fibers/epoll_proactor.cc
@@ -145,7 +145,7 @@ EpollProactor::~EpollProactor() {
   CHECK(is_stopped_);
   close(epoll_fd_);
 
-  DVLOG(1) << "~EpollProactor";
+  DVLOG(2) << "~EpollProactor";
 }
 
 void EpollProactor::Init(unsigned pool_index) {
@@ -284,12 +284,10 @@ void EpollProactor::MainLoop(detail::Scheduler* scheduler) {
       while (true) {
         VPRO(2) << "Fetched " << cqe_count << " cqes";
         DispatchCompletions(&ev_batch, cqe_count);
+        stats_.num_completions += cqe_count;
 
-        if (cqe_count < kEvBatchSize) {
-          break;
-        }
         epoll_res = EpollWait(epoll_fd_, &ev_batch, 0);
-        if (epoll_res < 0) {
+        if (epoll_res <= 0) {
           break;
         }
         cqe_count = epoll_res;
@@ -317,9 +315,6 @@ void EpollProactor::MainLoop(detail::Scheduler* scheduler) {
       scheduler->DestroyTerminated();
     }
   }
-
-  VPRO(1) << "total/stalls/cqe_fetches/num_suspends: " << stats_.loop_cnt << "/"
-          << stats_.num_stalls << "/" << stats_.completions_fetches << "/" << stats_.num_suspends;
 
   VPRO(1) << "wakeups/stalls/task_int: " << tq_wakeup_ev_.load() << "/" << stats_.task_interrupts;
   VPRO(1) << "centries size: " << centries_.size();

--- a/util/fibers/proactor_base.cc
+++ b/util/fibers/proactor_base.cc
@@ -99,12 +99,11 @@ std::once_flag module_init;
 __thread ProactorBase::TLInfo ProactorBase::tl_info_;
 
 ProactorBase::Stats& ProactorBase::Stats::operator+=(const Stats& other) {
-  static_assert(sizeof(Stats) == 9 * sizeof(uint64_t));
+  static_assert(sizeof(Stats) == 8 * sizeof(uint64_t));
 
   num_stalls += other.num_stalls;
   completions_fetches += other.completions_fetches;
   loop_cnt += other.loop_cnt;
-  num_suspends += other.num_suspends;
   num_task_runs += other.num_task_runs;
   task_interrupts += other.task_interrupts;
   num_completions += other.num_completions;

--- a/util/fibers/proactor_base.cc
+++ b/util/fibers/proactor_base.cc
@@ -428,12 +428,13 @@ void ProactorDispatcher::Run(detail::Scheduler* sched) {
   auto& stats = proactor_->stats();
 
   VLOG(1) << "PRO[" << proactor_->GetPoolIndex()
-          << "] total_loop/stalls/cqe_fetches/num_submits: " << stats.loop_cnt << "/"
+          << "] total_loop/stalls/cqe_fetches/completions_total: "
           << stats.num_stalls << "/" << stats.completions_fetches << "/"
-          << stats.uring_submit_calls;
-  if (stats.completions_fetches > 0)
-    VLOG(1) << "PRO[" << proactor_->GetPoolIndex()
-            << "] AvgCqe/ReapCall: " << double(stats.num_completions) / stats.completions_fetches;
+          << stats.num_completions;
+
+  VLOG_IF(1, stats.uring_submit_calls > 0) << "PRO[" << proactor_->GetPoolIndex()
+            << "] uring_submit_calls/uring_submit_count: "
+            << stats.uring_submit_calls << "/" << stats.uring_submit_sqes;
 }
 
 void ProactorDispatcher::Notify() {

--- a/util/fibers/proactor_base.cc
+++ b/util/fibers/proactor_base.cc
@@ -98,6 +98,22 @@ std::once_flag module_init;
 // in cc file that does not define it.
 __thread ProactorBase::TLInfo ProactorBase::tl_info_;
 
+ProactorBase::Stats& ProactorBase::Stats::operator+=(const Stats& other) {
+  static_assert(sizeof(Stats) == 9 * sizeof(uint64_t));
+
+  num_stalls += other.num_stalls;
+  completions_fetches += other.completions_fetches;
+  loop_cnt += other.loop_cnt;
+  num_suspends += other.num_suspends;
+  num_task_runs += other.num_task_runs;
+  task_interrupts += other.task_interrupts;
+  num_completions += other.num_completions;
+  uring_submit_calls += other.uring_submit_calls;
+  uring_submit_sqes += other.uring_submit_sqes;
+
+  return *this;
+}
+
 ProactorBase::ProactorBase() : task_queue_(kTaskQueueLen) {
   call_once(module_init, &ModuleInit);
 
@@ -168,8 +184,8 @@ bool ProactorBase::RunOnIdleTasks() {
   const string* task_name = nullptr;
   bool should_spin = false;
 
-  static const uint64_t kLoopBudgetCycles = base::CycleClock::FromUsec(10);    // 10 usec
-  static const uint64_t kSlowWarnCycles = base::CycleClock::FromUsec(1500);    // 1.5 ms
+  static const uint64_t kLoopBudgetCycles = base::CycleClock::FromUsec(10);  // 10 usec
+  static const uint64_t kSlowWarnCycles = base::CycleClock::FromUsec(1500);  // 1.5 ms
   static const uint64_t kIdleMaxCycles = base::CycleClock::FromUsec(kIdleCycleMaxMicros);
 
   DCHECK_LT(on_idle_next_, on_idle_arr_.size());
@@ -410,6 +426,15 @@ void ProactorBase::ModuleInit() {
 void ProactorDispatcher::Run(detail::Scheduler* sched) {
   proactor_->cpu_measure_cycle_start_ = base::CycleClock::Now();
   proactor_->MainLoop(sched);
+  auto& stats = proactor_->stats();
+
+  VLOG(1) << "PRO[" << proactor_->GetPoolIndex()
+          << "] total_loop/stalls/cqe_fetches/num_submits: " << stats.loop_cnt << "/"
+          << stats.num_stalls << "/" << stats.completions_fetches << "/"
+          << stats.uring_submit_calls;
+  if (stats.completions_fetches > 0)
+    VLOG(1) << "PRO[" << proactor_->GetPoolIndex()
+            << "] AvgCqe/ReapCall: " << double(stats.num_completions) / stats.completions_fetches;
 }
 
 void ProactorDispatcher::Notify() {

--- a/util/fibers/proactor_base.h
+++ b/util/fibers/proactor_base.h
@@ -197,8 +197,12 @@ class ProactorBase {
   struct Stats {
     uint64_t num_stalls = 0, completions_fetches = 0, loop_cnt = 0, num_suspends = 0;
     uint64_t num_task_runs = 0, task_interrupts = 0;
-    uint64_t cqe_count = 0;
-    uint64_t uring_submit_calls = 0;
+    uint64_t num_completions = 0;
+
+    // Number of times we called io_uring_submit_and_get_events(),
+    // and number of SQES submitted.
+    uint64_t uring_submit_calls = 0, uring_submit_sqes = 0;
+    Stats& operator+=(const Stats& other);
   };
 
   const Stats& stats() const {

--- a/util/fibers/proactor_base.h
+++ b/util/fibers/proactor_base.h
@@ -195,7 +195,7 @@ class ProactorBase {
   }
 
   struct Stats {
-    uint64_t num_stalls = 0, completions_fetches = 0, loop_cnt = 0, num_suspends = 0;
+    uint64_t num_stalls = 0, completions_fetches = 0, loop_cnt = 0;
     uint64_t num_task_runs = 0, task_interrupts = 0;
     uint64_t num_completions = 0;
 

--- a/util/fibers/uring_proactor.cc
+++ b/util/fibers/uring_proactor.cc
@@ -954,7 +954,7 @@ void UringProactor::MainLoop(detail::Scheduler* scheduler) {
     // and we enter too often into kernel space.
     bool should_poll = GetCurrentBusyCycles() < busy_poll_cycle_limit_;
     if (!ring_busy && should_poll) {
-      Pause(2);
+      Pause(3);
 
       // We should not spin too much using sched_yield or it burns a fuckload of cpu.
       scheduler->DestroyTerminated();

--- a/util/fibers/uring_proactor.cc
+++ b/util/fibers/uring_proactor.cc
@@ -346,15 +346,17 @@ void UringProactor::ProcessCqeBatch(unsigned count, io_uring_cqe** cqes,
 
 void UringProactor::ReapCompletions(unsigned init_count, io_uring_cqe** cqes,
                                     detail::FiberInterface* current) {
+  DCHECK_GT(init_count, 0U);
   unsigned batch_count = init_count;
-  while (batch_count > 0) {
+  do {
     ProcessCqeBatch(batch_count, cqes, current);
     io_uring_cq_advance(&ring_, batch_count);
-    reaped_cqe_cnt_ += batch_count;
-    if (batch_count < kCqeBatchLen)
-      break;
+    stats_.num_completions += batch_count;
+
+    // There could be completions added during the processing of the batch,
+    // so we check again.
     batch_count = io_uring_peek_batch_cqe(&ring_, cqes, kCqeBatchLen);
-  }
+  } while (batch_count > 0);
 
   // In case some of the timer completions filled schedule_periodic_list_.
   for (auto& task_pair : schedule_periodic_list_) {
@@ -832,12 +834,13 @@ void UringProactor::MainLoop(detail::Scheduler* scheduler) {
       call_submit = (sq_ready > 0) || taskrun_pending;
     }
     if (call_submit) {
+      stats_.uring_submit_calls++;
       num_submitted = io_uring_submit_and_get_events(&ring_);
     }
     bool ring_busy = false;
 
     if (num_submitted > 0) {
-      ++stats_.uring_submit_calls;
+      stats_.uring_submit_sqes += num_submitted;
       DVLOG(3) << "Submitted " << num_submitted;
     } else if (num_submitted == -EBUSY) {
       VLOG(1) << "EBUSY " << io_uring_sq_ready(&ring_);
@@ -882,9 +885,6 @@ void UringProactor::MainLoop(detail::Scheduler* scheduler) {
     if (cqe_count) {
       ++stats_.completions_fetches;
 
-      // cqe tail (ring->cq.ktail) can be updated asynchronously by the kernel even if we
-      // do now execute any syscalls. Therefore we count how many completions we handled
-      // and reap the same amount.
       ReapCompletions(cqe_count, cqes, dispatcher);
 
       if (ShouldPollL2Tasks()) {
@@ -954,7 +954,7 @@ void UringProactor::MainLoop(detail::Scheduler* scheduler) {
     // and we enter too often into kernel space.
     bool should_poll = GetCurrentBusyCycles() < busy_poll_cycle_limit_;
     if (!ring_busy && should_poll) {
-      Pause(3);
+      Pause(2);
 
       // We should not spin too much using sched_yield or it burns a fuckload of cpu.
       scheduler->DestroyTerminated();
@@ -1028,14 +1028,10 @@ void UringProactor::MainLoop(detail::Scheduler* scheduler) {
     }
   }
 
-  VPRO(1) << "total/stalls/cqe_fetches/num_submits: " << stats_.loop_cnt << "/" << stats_.num_stalls
-          << "/" << stats_.completions_fetches << "/" << stats_.uring_submit_calls;
   VPRO(1) << "jump_counts: ";
   for (unsigned i = 0; i < JUMP_FROM_TOTAL; ++i) {
     VPRO(1) << i << ": " << jump_counts[i];
   }
-  if (stats_.completions_fetches > 0)
-    VPRO(1) << "AvgCqe/ReapCall: " << double(reaped_cqe_cnt_) / stats_.completions_fetches;
   VPRO(1) << "tq_wakeups/tq_wakeup_saved/tq_full/tq_task_int: " << tq_wakeup_ev_.load() << "/"
           << tq_wakeup_skipped_ev_.load() << "/" << tq_full_ev_.load() << "/"
           << stats_.task_interrupts;

--- a/util/fibers/uring_proactor.h
+++ b/util/fibers/uring_proactor.h
@@ -243,7 +243,6 @@ class UringProactor : public ProactorBase {
   uint32_t direct_fds_cnt_ = 0;
   uint32_t get_entry_sq_full_ = 0, get_entry_await_ = 0;
   uint32_t epoll_add_id_ = 1;
-  uint64_t reaped_cqe_cnt_ = 0;
   std::atomic_int64_t last_wake_ts_{0};
 };
 


### PR DESCRIPTION
Also, remove wrong optimization where we break from the completion loop early. I verified it does not hold and with small batch we can still get next one if we peek.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved completion-event reaping and CQ draining across proactors to better process queued work and lower stall risk.
  * Updated completion counting so reported metrics reflect the actual number of processed completions.

* **Improvements / Observability**
  * Refined shutdown and end-of-loop diagnostics to reduce log noise and highlight the most relevant counters.
  * Enhanced per-run proactor logging with additional run statistics and a conditional completion ratio.
  * Adjusted submission/counter timing and idle pacing to improve metric consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->