### PR TITLE
cmake: add PGO (Profile-Guided Optimization) support

### DIFF
--- a/cmake/internal.cmake
+++ b/cmake/internal.cmake
@@ -254,6 +254,50 @@ if(HELIO_PERFORMANCE_OPTIMIZATIONS)
     endif()
 endif()
 
+# ---[ PGO: Profile-Guided Optimization ]---
+# Two-phase workflow:
+#   Phase 1 – instrument:  blaze.sh -release -DWITH_PGO_GENERATE=ON
+#                          Run dragonfly under a representative workload, then stop it.
+#                          Clang: set LLVM_PROFILE_FILE=/path/%p.profraw before launching.
+#                          GCC:   .gcda files land in <build>/pgo-profiles/ automatically.
+#   Phase 2 – optimize:    blaze.sh -release -DWITH_PGO_USE=<profile-path>
+#                          Clang: path to merged .profdata (llvm-profdata merge *.profraw).
+#                          GCC:   path to directory containing .gcda files.
+option(WITH_PGO_GENERATE "Instrument binary for PGO profile collection" OFF)
+set(WITH_PGO_USE "" CACHE STRING
+    "PGO profile path: Clang=merged .profdata file, GCC=directory with .gcda files")
+
+if(WITH_PGO_GENERATE AND WITH_PGO_USE)
+  message(FATAL_ERROR "WITH_PGO_GENERATE and WITH_PGO_USE are mutually exclusive")
+endif()
+
+if(WITH_PGO_GENERATE)
+  message(STATUS "PGO: instrumented build — run workload then rebuild with -DWITH_PGO_USE=<profile>")
+  if(USING_CLANG)
+    add_compile_options(-fprofile-instr-generate)
+    add_link_options(-fprofile-instr-generate)
+  else()
+    set(_PGO_GCDA_DIR "${CMAKE_BINARY_DIR}/pgo-profiles")
+    file(MAKE_DIRECTORY "${_PGO_GCDA_DIR}")
+    add_compile_options(-fprofile-generate=${_PGO_GCDA_DIR})
+    add_link_options(-fprofile-generate=${_PGO_GCDA_DIR})
+  endif()
+endif()
+
+if(WITH_PGO_USE)
+  message(STATUS "PGO: optimized build using profiles from: ${WITH_PGO_USE}")
+  if(USING_CLANG)
+    add_compile_options(-fprofile-instr-use=${WITH_PGO_USE})
+    add_link_options(-fprofile-instr-use=${WITH_PGO_USE})
+    # Silence warnings for functions not exercised during profiling
+    add_compile_options(-Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date)
+  else()
+    # -fprofile-correction tolerates minor source drift between profiling and optimize builds
+    add_compile_options(-fprofile-use=${WITH_PGO_USE} -fprofile-correction)
+    add_link_options(-fprofile-use=${WITH_PGO_USE})
+  endif()
+endif()
+
 # ---[ Helper Functions ]---
 set(ROOT_GEN_DIR ${CMAKE_SOURCE_DIR}/genfiles)
 file(MAKE_DIRECTORY ${ROOT_GEN_DIR})


### PR DESCRIPTION
## Summary

Adds two CMake options to `internal.cmake` enabling profile-guided optimization for any project built on top of helio.

## How to use

PGO is a two-phase build process.

### Phase 1 — collect profiles

Configure and build an instrumented binary:

```bash
./helio/blaze.sh -release -DWITH_PGO_GENERATE=ON -build-dir build-pgo-instrument
ninja -C build-pgo-instrument <your-target>
```

Run the binary under a **representative production workload**, then stop it.

**Clang** — set `LLVM_PROFILE_FILE` so profiles land in a known directory:
```bash
mkdir -p /tmp/pgo-profiles
LLVM_PROFILE_FILE='/tmp/pgo-profiles/%p.profraw' build-pgo-instrument/dragonfly --dbfilename= &
# ... run workload (memtier_benchmark, dfly_bench, etc.) ...
kill <pid>

# Merge raw profiles into a single file
llvm-profdata merge -output=/tmp/pgo-profiles/merged.profdata /tmp/pgo-profiles/*.profraw
```

**GCC** — `.gcda` files are written automatically to `build-pgo-instrument/pgo-profiles/`. No merge step needed.

### Phase 2 — build optimized binary

```bash
# Clang
./helio/blaze.sh -release -DWITH_PGO_USE=/tmp/pgo-profiles/merged.profdata -build-dir build-pgo-opt

# GCC
./helio/blaze.sh -release -DWITH_PGO_USE=build-pgo-instrument/pgo-profiles -build-dir build-pgo-opt

ninja -C build-pgo-opt <your-target>
```

## Implementation notes

- `WITH_PGO_GENERATE` and `WITH_PGO_USE` are mutually exclusive — cmake errors out if both are set
- Clang: suppresses `-Wno-profile-instr-unprofiled` / `-Wno-profile-instr-out-of-date` to avoid noise for cold paths
- GCC: adds `-fprofile-correction` to tolerate minor source drift between profiling and optimize builds
- Expected gain on server workloads: **10–25% throughput**, primarily from improved instruction-cache layout and branch prediction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Profile-Guided Optimization (PGO) build support for supported compilers.
  * Introduced build options to generate profiling data or build using existing profiles.
  * Automatically adjusts compiler and linker flags for each PGO mode, with validation to prevent incompatible configurations from being enabled together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->