### PR TITLE
Fibers: consume FiberBlockingCounter callbacks

### DIFF
--- a/util/fibers/epoll_proactor.cc
+++ b/util/fibers/epoll_proactor.cc
@@ -217,7 +217,7 @@ void EpollProactor::MainLoop(detail::Scheduler* scheduler) {
           task_queue_avail_.notifyAll();
         }
       } while (task_queue_.try_dequeue(task));
-
+      task = {};  // clean up resources associated with the task.
       stats_.num_task_runs += cnt;
       DVLOG(2) << "Tasks runs " << stats_.num_task_runs << "/" << spin_loops;
 

--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -22,6 +22,7 @@
 #include "util/fibers/fiber_file.h"
 #include "util/fibers/fiberqueue_threadpool.h"
 #include "util/fibers/future.h"
+#include "util/fibers/pool.h"
 #include "util/fibers/simple_channel.h"
 #include "util/fibers/synchronization.h"
 
@@ -246,7 +247,8 @@ TEST_F(FiberTest, Basic) {
   EXPECT_EQ(2, run);
   EXPECT_LT(epoch, FiberSwitchEpoch());
 
-  Fiber fb3("test3", [](int i) {}, 1);
+  Fiber fb3(
+      "test3", [](int i) {}, 1);
   fb3.Join();
   EXPECT_EQ(preempt_cnt_start + 2, ThisFiber::GetPreemptCount());
 }
@@ -278,7 +280,9 @@ TEST_F(FiberTest, Stack) {
 
   // Test with moveable only arguments.
   unique_ptr<int> pass(new int(42));
-  Fiber("test3", [](unique_ptr<int> p) { EXPECT_EQ(42, *p); }, std::move(pass)).Detach();
+  Fiber(
+      "test3", [](unique_ptr<int> p) { EXPECT_EQ(42, *p); }, std::move(pass))
+      .Detach();
 }
 
 TEST_F(FiberTest, Remote) {
@@ -538,6 +542,17 @@ TEST_F(FiberTest, Notify) {
   fb2.Join();
 }
 
+TEST_F(FiberTest, ProactorPoolRunDoesNotRetainMainFiberRef) {
+  auto* main_fb = detail::FiberActive();
+  const uint32_t base_refs = main_fb->DEBUG_use_count();
+
+  unique_ptr<Pool> pool{Pool::Epoll(1)};
+  pool->Run();
+  EXPECT_EQ(base_refs, main_fb->DEBUG_use_count());
+  pool->Stop();
+  EXPECT_EQ(base_refs, main_fb->DEBUG_use_count());
+}
+
 TEST_F(FiberTest, SwitchAndExecute) {
   Future<detail::FiberInterface*> first, second;
   unsigned cnt1 = 0, cnt2 = 0;
@@ -663,9 +678,8 @@ TEST_P(ProactorTest, DispatchLocalBrief) {
 
   proactor()->Await([&] {
     for (unsigned i = 0; i < kCount; ++i) {
-      proactor()->DispatchLocalBrief([&counter] {
-        counter.fetch_add(1, std::memory_order_relaxed);
-      });
+      proactor()->DispatchLocalBrief(
+          [&counter] { counter.fetch_add(1, std::memory_order_relaxed); });
     }
     proactor()->DispatchLocalBrief([&ec] { ec.notify(); });
   });
@@ -1160,7 +1174,8 @@ TEST_F(FiberTest, SimpleChannelPopRace) {
       fb.Join();
 
     ASSERT_EQ(missed, 0) << "Pop() has a TOCTOU race: items pushed between "
-                            "TryPop and IsClosing checks are lost, iter " << iter;
+                            "TryPop and IsClosing checks are lost, iter "
+                         << iter;
     ASSERT_EQ(popped + missed, kExpectedTotal) << "Data loss at iteration " << iter;
   }
 }
@@ -1239,9 +1254,7 @@ TEST_F(FiberTest, PersistentWaiterMixedNotifyAll) {
   auto sub = ec.subscribe_persistent(&waiter);
 
   bool fiber_woke{false};
-  Fiber fb(Launch::dispatch, "oneshot", [&] {
-    ec.await([&] { return fiber_woke; });
-  });
+  Fiber fb(Launch::dispatch, "oneshot", [&] { ec.await([&] { return fiber_woke; }); });
 
   // Both waiters are now in the queue. Fire notifyAll.
   fiber_woke = true;

--- a/util/fibers/synchronization.cc
+++ b/util/fibers/synchronization.cc
@@ -168,6 +168,16 @@ FiberBlockingCounter::FiberBlockingCounter(unsigned start_count) : owner_{detail
   owner_->blocking_counter().Start(start_count);
 }
 
+void FiberBlockingCounter::Release() && {
+  DCHECK(owner_);
+  auto owner = std::move(owner_);
+
+  // Note: Wait() does not guarantee that "owner" refcount will decrease atomically together
+  // with blocking_counter. In other words DEBUG_use_count() is
+  // eventually consistent and may read a higher value right after Wait() resumes.
+  owner->blocking_counter().Dec();
+}
+
 Barrier::Barrier(size_t initial) : initial_{initial}, current_{initial_} {
   DCHECK_NE(0u, initial);
 }

--- a/util/fibers/synchronization.h
+++ b/util/fibers/synchronization.h
@@ -5,12 +5,12 @@
 #pragma once
 
 #include <atomic>
+#include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <cassert>
 #include <condition_variable>  // for cv_status
 #include <memory>
 #include <optional>
-
-#include <boost/smart_ptr/intrusive_ptr.hpp>
+#include <utility>
 
 #include "base/spinlock.h"
 #include "util/fibers/detail/fiber_interface.h"
@@ -291,8 +291,8 @@ class BlockingCounter {
 // Same semantics as BlockingCounter, but backed by the constructing fiber's embedded
 // EmbeddedBlockingCounter (see FiberInterface::blocking_counter()) instead of a heap
 // allocation. Pass by value: copies share the same underlying counter and keep the owning
-// fiber's FiberInterface (and thus the counter) alive via intrusive_ptr refcounting until
-// every copy - including ones captured by remote Dec()-calling closures - is destroyed.
+// fiber's FiberInterface (and thus the counter) alive via intrusive_ptr refcounting until each
+// callback consumes its copy with Release().
 //
 // ONLY use this for a tight, single-call, scoped round: construct, dispatch, Wait(), with
 // nothing else on the constructing fiber touching a blocking counter in between. The fiber
@@ -304,9 +304,12 @@ class FiberBlockingCounter {
  public:
   explicit FiberBlockingCounter(unsigned start_count);
 
-  EmbeddedBlockingCounter* operator->() {
-    return &owner_->blocking_counter();
+  bool Wait() {
+    return owner_->blocking_counter().Wait();
   }
+
+  void Release() &&;
+  void Release() & = delete;
 
  private:
   boost::intrusive_ptr<detail::FiberInterface> owner_;

--- a/util/fibers/uring_proactor.cc
+++ b/util/fibers/uring_proactor.cc
@@ -871,6 +871,7 @@ void UringProactor::MainLoop(detail::Scheduler* scheduler) {
           break;
         }
       } while (task_queue_.try_dequeue(task));
+      task = {};  // clean up resources associated with the task.
       stats_.num_task_runs += cnt;
       DVLOG(2) << "Tasks runs " << stats_.num_task_runs;
 

--- a/util/proactor_pool.h
+++ b/util/proactor_pool.h
@@ -100,12 +100,11 @@ class ProactorPool {
    */
   template <typename Func, AcceptArgsCheck<Func, ProactorBase*> = 0> void Await(Func&& func) {
     fb2::FiberBlockingCounter bc(size());
-    auto cb = [func = std::forward<Func>(func), bc](ProactorBase* context) mutable {
+    DispatchBrief([func = std::forward<Func>(func), bc](ProactorBase* context) mutable {
       func(context);
-      bc->Dec();
-    };
-    DispatchBrief(std::move(cb));
-    bc->Wait();
+      std::move(bc).Release();
+    });
+    bc.Wait();
   }
 
   /**
@@ -116,14 +115,12 @@ class ProactorPool {
   template <typename Func, AcceptArgsCheck<Func, unsigned, ProactorBase*> = 0>
   void AwaitBrief(Func&& func) {
     fb2::FiberBlockingCounter bc(size());
-    auto cb = [func = std::forward<Func>(func), bc](unsigned index, ProactorBase* p) mutable {
+    DispatchBrief([func = std::forward<Func>(func), bc](unsigned index, ProactorBase* p) mutable {
       func(index, p);
-      bc->Dec();
-    };
-    DispatchBrief(std::move(cb));
-    bc->Wait();
+      std::move(bc).Release();
+    });
+    bc.Wait();
   }
-
 
   template <typename Func, AcceptArgsCheck<Func, unsigned, ProactorBase*> = 0>
   [[deprecated]] void Await(Func&& func) {
@@ -171,12 +168,11 @@ class ProactorPool {
   template <typename Func, AcceptArgsCheck<Func, unsigned, ProactorBase*> = 0>
   void AwaitFiberOnAll(Func&& func) {
     fb2::FiberBlockingCounter bc(size());
-    auto cb = [func = std::forward<Func>(func), bc](unsigned i, ProactorBase* context) mutable {
+    DispatchOnAll([func = std::forward<Func>(func), bc](unsigned i, ProactorBase* context) mutable {
       func(i, context);
-      bc->Dec();
-    };
-    DispatchOnAll(std::move(cb));
-    bc->Wait();
+      std::move(bc).Release();
+    });
+    bc.Wait();
   }
 
   /**
@@ -190,12 +186,11 @@ class ProactorPool {
   template <typename Func, AcceptArgsCheck<Func, ProactorBase*> = 0>
   void AwaitFiberOnAll(Func&& func) {
     fb2::FiberBlockingCounter bc(size());
-    auto cb = [func = std::forward<Func>(func), bc](ProactorBase* context) mutable {
+    DispatchOnAll([func = std::forward<Func>(func), bc](ProactorBase* context) mutable {
       func(context);
-      bc->Dec();
-    };
-    DispatchOnAll(std::move(cb));
-    bc->Wait();
+      std::move(bc).Release();
+    });
+    bc.Wait();
   }
 
   // Returns vector of proactor thread indiced pinned to cpu_id.


### PR DESCRIPTION
## Summary
- add consumable FiberBlockingCounter::Release() for callback-held copies
- update ProactorPool await helpers to use Release() instead of pointer-style Dec()
- clear cached proactor Tasklets after execution and add a refcount regression test

## Test
- pre-commit run --files util/fibers/epoll_proactor.cc util/fibers/fibers_test.cc util/fibers/synchronization.cc util/fibers/synchronization.h util/fibers/uring_proactor.cc util/proactor_pool.h
- ./fibers_test --gtest_filter=FiberTest.ProactorPoolRunDoesNotRetainMainFiberRef --logtostderr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of fiber/task resources after work completes, reducing the chance of lingering references.
  * Updated fiber synchronization so waiting and completion handling are more explicit and reliable.
  * Added coverage for proactor pool behavior to verify fibers are not retained after running or stopping.
  * Kept existing task dispatch behavior the same while tightening internal resource release timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->