### PR TITLE
fibers: Add lifeycle hook to fiber

### DIFF
--- a/util/fibers/detail/fiber_interface.cc
+++ b/util/fibers/detail/fiber_interface.cc
@@ -433,6 +433,7 @@ void FiberInterface::AttachScheduler() {
 ctx::fiber_context FiberInterface::SwitchTo() {
   DCHECK(entry_) << name();
   FiberInterface* prev = SwitchSetup();
+  FiberSwitchHook resume_hook = switch_hook_;
 
   // pass pointer to the context that resumes `this`
   void* fake_stack_save = nullptr;
@@ -440,7 +441,7 @@ ctx::fiber_context FiberInterface::SwitchTo() {
   __sanitizer_start_switch_fiber(&fake_stack_save, stack_bottom_, stack_size_);
 #endif
 
-  return std::move(entry_).resume_with([prev, fake_stack_save](ctx::fiber_context&& c) {
+  return std::move(entry_).resume_with([prev, resume_hook, fake_stack_save](ctx::fiber_context&& c) {
     DCHECK(!prev->entry_);
 
 #if ABSL_HAVE_ADDRESS_SANITIZER
@@ -449,12 +450,14 @@ ctx::fiber_context FiberInterface::SwitchTo() {
     (void)fake_stack_save;
 #endif
     prev->entry_ = std::move(c);  // update the return address in the context we just switch from.
+    resume_hook.Run(FiberSwitchHookEvent::RESUME);
     return ctx::fiber_context{};
   });
 }
 
 void FiberInterface::SwitchToAndExecute(std::function<void()> fn) {
   FiberInterface* prev = SwitchSetup();
+  FiberSwitchHook resume_hook = switch_hook_;
 
   void* fake_stack_save = nullptr;
 #if ABSL_HAVE_ADDRESS_SANITIZER
@@ -462,7 +465,7 @@ void FiberInterface::SwitchToAndExecute(std::function<void()> fn) {
 #endif
 
   // pass pointer to the context that resumes `this`
-  std::move(entry_).resume_with([prev, fn = std::move(fn),
+  std::move(entry_).resume_with([prev, resume_hook, fn = std::move(fn),
                                  fake_stack_save](ctx::fiber_context&& c) {
     DCHECK(!prev->entry_ && c);
 #if ABSL_HAVE_ADDRESS_SANITIZER
@@ -471,6 +474,7 @@ void FiberInterface::SwitchToAndExecute(std::function<void()> fn) {
     (void)fake_stack_save;
 #endif
     prev->entry_ = std::move(c);  // update the return address in the context we just switch from.
+    resume_hook.Run(FiberSwitchHookEvent::RESUME);
     fn();
 
     return ctx::fiber_context{};
@@ -521,6 +525,7 @@ FiberInterface* FiberInterface::SwitchSetup() {
 
   // switch the active fiber and set to_suspend to the previously active fiber.
   FiberInterface* to_suspend = fb_initializer.active;
+  to_suspend->switch_hook_.Run(FiberSwitchHookEvent::SUSPEND);
   fb_initializer.active = this;
 
 #if RECORD_FIBER_NAMES
@@ -599,6 +604,15 @@ void ActivateSameThread(FiberInterface* active, FiberInterface* other) {
 }
 
 }  // namespace detail
+
+void FiberSwitchHook::Run(FiberSwitchHookEvent e) const noexcept {
+  if (!callback)
+    return;
+
+  detail::EnterFiberAtomicSection();
+  callback(e);
+  detail::LeaveFiberAtomicSection();
+}
 
 void SetCustomDispatcher(DispatchPolicy* policy) {
   detail::TL_FiberInitializer& fb_init = detail::FbInitializer();

--- a/util/fibers/detail/fiber_interface.h
+++ b/util/fibers/detail/fiber_interface.h
@@ -9,6 +9,7 @@
 #include <boost/intrusive/list.hpp>
 #include <boost/intrusive/set.hpp>
 #include <chrono>
+#include <utility>
 
 #include "base/cycle_clock.h"
 #include "base/mpsc_intrusive_queue.h"
@@ -32,6 +33,24 @@ enum class FiberPriority : uint8_t {
   NORMAL = 0,      // default priority
   BACKGROUND = 1,  // background priority, runs when no NORMAL fibers are ready.
   HIGH = 2,       // High priority, activated earlier than other fibers.
+};
+
+enum class FiberSwitchHookEvent : uint8_t {
+  SUSPEND,
+  RESUME,
+};
+
+// Runs inside the fiber context switch path. The callback must not preempt.
+struct FiberSwitchHook {
+  using Callback = void (*)(FiberSwitchHookEvent) noexcept;
+
+  Callback callback = nullptr;
+
+  explicit operator bool() const noexcept {
+    return callback != nullptr;
+  }
+
+  void Run(FiberSwitchHookEvent e) const noexcept;
 };
 
 // based on boost::context::fixedsize_stack but uses pmr::memory_resource for allocation.
@@ -235,6 +254,10 @@ class FiberInterface {
     return preempt_cnt_;
   }
 
+  FiberSwitchHook SetSwitchHook(FiberSwitchHook hook) noexcept {
+    return std::exchange(switch_hook_, hook);
+  }
+
   // Assigns a print callback that is called by Scheduler::PrintAllFiberStackTraces.
   // Please note that there can be at most one callback at any time during the lifetime of fiber.
   void SetPrintStacktraceCb(std::function<std::string()> cb) {
@@ -308,6 +331,8 @@ class FiberInterface {
 
   // number of times this fiber was preempted.
   uint64_t preempt_cnt_ = 0;
+
+  FiberSwitchHook switch_hook_;
 
   // used for sleeping with a timeout. Specifies the time when this fiber should be woken up.
   std::chrono::steady_clock::time_point tp_;

--- a/util/fibers/fibers.h
+++ b/util/fibers/fibers.h
@@ -220,6 +220,11 @@ inline uint64_t GetPreemptCount() {
   return fb2::detail::FiberActive()->preempt_cnt();
 }
 
+// Installs a hook on the active fiber.
+inline fb2::FiberSwitchHook SetSwitchHook(fb2::FiberSwitchHook hook) noexcept {
+  return fb2::detail::FiberActive()->SetSwitchHook(hook);
+}
+
 class PrintLocalsCallback {
  public:
   template <typename Fn> PrintLocalsCallback(Fn&& fn) {

--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -69,7 +69,6 @@ unsigned my_gettid() {
 #endif
 
 constexpr uint32_t kRingDepth = 16;
-
 class FiberTest : public testing::Test {
  public:
 };
@@ -251,6 +250,35 @@ TEST_F(FiberTest, Basic) {
   Fiber fb3("test3", [](int i) {}, 1);
   fb3.Join();
   EXPECT_EQ(preempt_cnt_start + 2, ThisFiber::GetPreemptCount());
+}
+
+namespace {
+
+std::vector<FiberSwitchHookEvent> switch_hook_events;
+
+void RecordSwitchHookEvent(FiberSwitchHookEvent event) noexcept {
+  switch_hook_events.push_back(event);
+}
+
+}  // namespace
+
+TEST_F(FiberTest, SwitchHook) {
+  switch_hook_events.clear();
+  Fiber fb("switch-hook", [&] {
+    const FiberSwitchHook original = ThisFiber::SetSwitchHook({RecordSwitchHookEvent});
+    EXPECT_FALSE(original);
+
+    ThisFiber::Yield();
+
+    FiberSwitchHook installed = ThisFiber::SetSwitchHook(original);
+    EXPECT_EQ(RecordSwitchHookEvent, installed.callback);
+  });
+
+  fb.Join();
+
+  ASSERT_EQ(2u, switch_hook_events.size());
+  EXPECT_EQ(FiberSwitchHookEvent::SUSPEND, switch_hook_events[0]);
+  EXPECT_EQ(FiberSwitchHookEvent::RESUME, switch_hook_events[1]);
 }
 
 TEST_F(FiberTest, Stack) {


### PR DESCRIPTION
An optional hook is added. It is simply a function pointer. If it is set, then it is called on fiber suspend and resume, with the appropriate event.

Sample example of usage pattern: https://github.com/dragonflydb/dragonfly/pull/7794/changes/608612841ea0be09324893cb05eecf35f999fd73