### PR TITLE
fix(epoll): bound completion batches to prevent scheduler starvation

### DIFF
--- a/util/fibers/epoll_proactor.cc
+++ b/util/fibers/epoll_proactor.cc
@@ -62,7 +62,7 @@ int EpollWait(int epoll_fd, EventsBatch* batch, int timeout) {
   return epoll_wait(epoll_fd, batch->cqe, kEvBatchSize, timeout);
 }
 
-void EpollDel(int epoll_fd, int fd) {
+void EpollDel(int epoll_fd, int fd, uint32_t /*event_mask*/) {
   CHECK_EQ(0, epoll_ctl(epoll_fd, EPOLL_CTL_DEL, fd, NULL));
 }
 
@@ -89,20 +89,24 @@ int EpollCreate() {
 }
 
 int EpollWait(int epoll_fd, EventsBatch* batch, int tm_ms) {
-  struct timespec ts {
-    .tv_sec = tm_ms / 1000, .tv_nsec = (tm_ms % 1000) * 1000000
-  };
+  struct timespec ts{.tv_sec = tm_ms / 1000, .tv_nsec = (tm_ms % 1000) * 1000000};
 
   int epoll_res = kevent(epoll_fd, NULL, 0, batch->cqe, kEvBatchSize, tm_ms < 0 ? NULL : &ts);
   return epoll_res;
 }
 
-void EpollDel(int epoll_fd, int fd) {
-  struct kevent kev[2];
+void EpollDel(int epoll_fd, int fd, uint32_t event_mask) {
+  if (event_mask & EpollProactor::EPOLL_IN) {
+    struct kevent kev;
+    EV_SET(&kev, fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);
+    CHECK_EQ(0, kevent(epoll_fd, &kev, 1, NULL, 0, NULL));
+  }
 
-  EV_SET(&kev[0], fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);
-  EV_SET(&kev[1], fd, EVFILT_WRITE, EV_DELETE, 0, 0, NULL);
-  CHECK_EQ(0, kevent(epoll_fd, kev, 2, NULL, 0, NULL));
+  if (event_mask & EpollProactor::EPOLL_OUT) {
+    struct kevent kev;
+    EV_SET(&kev, fd, EVFILT_WRITE, EV_DELETE, 0, 0, NULL);
+    CHECK_EQ(0, kevent(epoll_fd, &kev, 1, NULL, 0, NULL));
+  }
 }
 
 uint32_t KevMask(const struct kevent& kev) {
@@ -281,10 +285,23 @@ void EpollProactor::MainLoop(detail::Scheduler* scheduler) {
     if (cqe_count) {
       ++stats_.completions_fetches;
 
-      while (true) {
+      constexpr unsigned kMaxCompletionBatches = 3;
+
+      // Level-triggered FDs stay ready until a scheduled fiber consumes them, therefore
+      // we can not iterate endlessly without yielding to the scheduler.
+      // Break in two cases: a) we iterated kMaxCompletionBatches times,
+      // b) we got less than kEvBatchSize completions as an indication that we drained the queue.
+
+      // (b) by itself is not enough because there could be many level-triggered events
+      // that will fill ev_batch in full and we will never break.
+      for (unsigned batch = 0; batch < kMaxCompletionBatches; ++batch) {
         VPRO(2) << "Fetched " << cqe_count << " cqes";
         DispatchCompletions(&ev_batch, cqe_count);
         stats_.num_completions += cqe_count;
+
+        if (cqe_count < kEvBatchSize || batch + 1 == kMaxCompletionBatches) {
+          break;
+        }
 
         epoll_res = EpollWait(epoll_fd_, &ev_batch, 0);
         if (epoll_res <= 0) {
@@ -292,7 +309,7 @@ void EpollProactor::MainLoop(detail::Scheduler* scheduler) {
         }
         cqe_count = epoll_res;
         ++stats_.completions_fetches;
-      };
+      }
     }
 
     RunL2Tasks(scheduler);
@@ -333,8 +350,15 @@ unsigned EpollProactor::Arm(int fd, CbType cb, uint32_t event_mask) {
 
   next_free_ce_ = e.index;
   e.cb = std::move(cb);
+#if !defined(__linux__)
+  e.event_mask = event_mask;
+#endif
   e.index = -1;
 
+// TODO: we have inconsistent behavior on Linux and FreeBsd.
+// On Linux we pass the event mask potentially allowing level-triggered events
+// to be reported multiple times until the fiber consumes them.
+// On FreeBsd we use EV_CLEAR which means that the event is reported once and then cleared.
 #ifdef __linux__
   epoll_event ev;
   ev.events = event_mask;
@@ -368,7 +392,11 @@ void EpollProactor::Disarm(int fd, unsigned arm_index) {
   centries_[arm_index].index = next_free_ce_;
 
   next_free_ce_ = arm_index;
-  EpollDel(epoll_fd_, fd);
+#if defined(__linux__)
+  EpollDel(epoll_fd_, fd, 0);
+#else
+  EpollDel(epoll_fd_, fd, centries_[arm_index].event_mask);
+#endif
 }
 
 LinuxSocketBase* EpollProactor::CreateSocket() {

--- a/util/fibers/epoll_proactor.h
+++ b/util/fibers/epoll_proactor.h
@@ -57,6 +57,9 @@ class EpollProactor : public ProactorBase {
   // friend class EpollFiberAlgo;
   struct CompletionEntry {
     CbType cb;
+#if !defined(__linux__)
+    uint32_t event_mask = 0;
+#endif
 
     // serves for linked list management when unused. Also can store an additional payload
     // field when in flight.

--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -27,6 +27,7 @@
 #include "util/fibers/synchronization.h"
 
 #ifdef __linux__
+#include <sys/epoll.h>
 #include <sys/syscall.h>
 
 #include "util/fibers/uring_proactor.h"
@@ -247,8 +248,7 @@ TEST_F(FiberTest, Basic) {
   EXPECT_EQ(2, run);
   EXPECT_LT(epoch, FiberSwitchEpoch());
 
-  Fiber fb3(
-      "test3", [](int i) {}, 1);
+  Fiber fb3("test3", [](int i) {}, 1);
   fb3.Join();
   EXPECT_EQ(preempt_cnt_start + 2, ThisFiber::GetPreemptCount());
 }
@@ -280,9 +280,7 @@ TEST_F(FiberTest, Stack) {
 
   // Test with moveable only arguments.
   unique_ptr<int> pass(new int(42));
-  Fiber(
-      "test3", [](unique_ptr<int> p) { EXPECT_EQ(42, *p); }, std::move(pass))
-      .Detach();
+  Fiber("test3", [](unique_ptr<int> p) { EXPECT_EQ(42, *p); }, std::move(pass)).Detach();
 }
 
 TEST_F(FiberTest, Remote) {
@@ -1128,6 +1126,89 @@ TEST_P(ProactorTest, FiberFile) {
     unique_ptr<io::WriteFile> file(std::move(res.value()));
     std::ignore = file->Close();
   });
+}
+
+TEST_P(ProactorTest, ReadyFdsDoNotStarveScheduler) {
+  if (GetProactorType() == "uring") {
+    GTEST_SKIP() << "Skipped FiberSocketTest.ReadyFdsDoNotStarveScheduler test on uring";
+  }
+
+  EpollProactor* epoll_proactor = static_cast<EpollProactor*>(proactor());
+  constexpr size_t kEvBatchSize = 128;
+  auto run_case = [&](size_t ready_fd_count, uint32_t event_mask,
+                      size_t callbacks_before_draining) {
+    vector<int> event_fds(ready_fd_count);
+    vector<int> write_fds(ready_fd_count);
+    for (size_t i = 0; i < event_fds.size(); ++i) {
+      int pipe_fds[2];
+      ASSERT_EQ(0, pipe(pipe_fds)) << "pipe failed: " << strerror(errno);
+      event_fds[i] = pipe_fds[0];
+      write_fds[i] = pipe_fds[1];
+    }
+
+    Done fiber_finished;
+    atomic_bool cancelled{false};
+    atomic_uint completion_count{0};
+    vector<unsigned> arm_indices(ready_fd_count);
+
+    epoll_proactor->AwaitBrief([&] {
+      for (size_t i = 0; i < event_fds.size(); ++i) {
+        arm_indices[i] = epoll_proactor->Arm(
+            event_fds[i],
+            [&](uint32_t, int, EpollProactor*) {
+              completion_count.fetch_add(1, memory_order_relaxed);
+            },
+            event_mask);
+      }
+
+      Fiber("ReadyFdDrainFb", [&] {
+        while (completion_count.load(memory_order_relaxed) < callbacks_before_draining &&
+               !cancelled.load(memory_order_acquire)) {
+          ThisFiber::SleepFor(1ms);
+        }
+
+        if (!cancelled.load(memory_order_acquire)) {
+          uint64_t val = 0;
+          for (size_t i = 0; i < event_fds.size(); ++i) {
+            EXPECT_EQ(sizeof(val), read(event_fds[i], &val, sizeof(val)));
+            epoll_proactor->Disarm(event_fds[i], arm_indices[i]);
+          }
+        }
+        fiber_finished.Notify();
+      }).Detach();
+
+      uint64_t val = 1;
+      for (int fd : write_fds) {
+        EXPECT_EQ(sizeof(val), write(fd, &val, sizeof(val)));
+      }
+    });
+
+    bool success = fiber_finished.WaitFor(chrono::seconds(1));
+    if (!success) {
+      cancelled.store(true, memory_order_release);
+      ASSERT_TRUE(fiber_finished.WaitFor(chrono::seconds(1)));
+    }
+
+    for (int fd : event_fds) {
+      close(fd);
+    }
+    for (int fd : write_fds) {
+      close(fd);
+    }
+
+    ASSERT_TRUE(success) << "epoll completion loop starved scheduler";
+  };
+
+  // Level-triggered epoll repeatedly reports unread pipes until the drain fiber runs.
+  run_case(kEvBatchSize, EpollProactor::EPOLL_IN, 1);
+
+  // An edge-triggered fourth batch must remain queued for the next loop iteration. If the
+  // bounded drain polls it after the third batch without dispatching it, this fiber cannot drain.
+  uint32_t edge_mask = EpollProactor::EPOLL_IN;
+#ifdef __linux__
+  edge_mask |= EPOLLET;
+#endif
+  run_case(4 * kEvBatchSize, edge_mask, 4 * kEvBatchSize);
 }
 
 // Stress test for SimpleChannel::Pop() TOCTOU race.

--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -1130,7 +1130,7 @@ TEST_P(ProactorTest, FiberFile) {
 
 TEST_P(ProactorTest, ReadyFdsDoNotStarveScheduler) {
   if (GetProactorType() == "uring") {
-    GTEST_SKIP() << "Skipped FiberSocketTest.ReadyFdsDoNotStarveScheduler test on uring";
+    GTEST_SKIP() << "Skipped test on uring";
   }
 
   EpollProactor* epoll_proactor = static_cast<EpollProactor*>(proactor());

--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -667,6 +667,12 @@ TEST_P(ProactorTest, AsyncCall) {
 
   auto next = chrono::steady_clock::now() + 1s;
   EXPECT_EQ(std::cv_status::no_timeout, ec.await_until([&] { return signal; }, next));
+
+  // await_until can return as soon as it observes `signal`, which may be *before* ec.notify()
+  // finishes executing on the proactor thread. Drain the proactor once more so the notify task
+  // completes before `ec`/`signal` leave scope; otherwise the proactor dereferences a destroyed
+  // stack EventCount (use-after-scope).
+  proactor()->AwaitBrief([] {});
 }
 
 TEST_P(ProactorTest, DispatchLocalBrief) {


### PR DESCRIPTION
## Summary
Fixes the regression that was introduced by #603.

Process at most `kMaxCompletionBatches`  full epoll batches before yielding to the scheduler, preventing level-triggered FDs from starving the fibers that consume them.

## Changes
- Bound nonblocking epoll completion draining to kMaxCompletionBatches full batches.
- Document the level-triggered readiness livelock scenario.
- Add a 128-eventfd regression in `ProactorTest` that requires multiple batches and scheduler progress.
- Fix MacOs epoll behavior that was broken unrelated to #603.
