### PR TITLE
feat(cmake): add retrying downloader for deps

### DIFF
--- a/cmake/download_retry.cmake
+++ b/cmake/download_retry.cmake
@@ -1,0 +1,213 @@
+# Reusable, retrying downloader for third-party URL/tarball dependencies. This
+# script should be used during build time.
+#
+# ExternalProject_Add has no configurable retry count for URL downloads, and a
+# single transient network flake fails the whole build. This script is meant to
+# be used as a custom DOWNLOAD_COMMAND (or invoked directly at configure time)
+# so that every URL/tarball dependency shares one retry policy instead of each
+# dependency re-implementing its own.
+#
+# Invoke via:
+#   cmake -DURL=<url> [-DURL_FALLBACK=<url>] -DDEST=<file>
+#         [-DEXPECTED_HASH=<sha256>] [-DEXTRACT_DIR=<dir>]
+#         [-DMIN_SIZE=<bytes>] [-DRETRIES=<n>]
+#         [-DBACKOFF=<seconds>] [-DBACKOFF_MAX=<seconds>]
+#         -P download_retry.cmake
+#
+# Parameters:
+#   URL           (required) URL to download from.
+#   DEST          (required) Path where the downloaded file is written.
+#   URL_FALLBACK  (optional) Single fallback URL tried after URL on each attempt.
+#   EXPECTED_HASH (optional) Expected SHA256 of the download, as a raw hex digest
+#                            or an "SHA256=<hex>" string. A mismatch is retried.
+#   EXTRACT_DIR   (optional) If set, the archive is extracted here (stripping a
+#                            single leading directory) after a successful download.
+#   MIN_SIZE      (optional) Minimum acceptable download size in bytes; a smaller
+#                            file is treated as a failure and retried.
+#   RETRIES       (optional) Maximum number of download attempts. Default 10.
+#   BACKOFF       (optional) Initial sleep in seconds between attempts. Default 5.
+#   BACKOFF_MAX   (optional) Upper bound in seconds for the backoff sleep, which
+#                            doubles after each failed attempt. Default 60.
+#
+# Behavior:
+#   * Retries the download up to RETRIES times (default 10). Between attempts it
+#     sleeps with exponential backoff starting at BACKOFF seconds (default 5) and
+#     doubling up to BACKOFF_MAX seconds (default 60): 5, 10, 20, 40, 60, 60...
+#     After the last attempt it fails with a clear error.
+#   * On each attempt URL is tried first, then URL_FALLBACK (if given).
+#   * If EXPECTED_HASH is set, the SHA256 is verified and a mismatch is retried.
+#   * If MIN_SIZE is set, a smaller download is treated as a failure and retried
+#     (guards against truncated/placeholder responses).
+#   * If EXTRACT_DIR is set, the archive is extracted into it, stripping a single
+#     leading directory (mirroring ExternalProject's own extraction) so callers
+#     that override DOWNLOAD_COMMAND still get a ready-to-build source tree.
+#
+# Examples: 
+#  1) From another Cmake file:
+#  wire it into an ExternalProject_Add as a custom DOWNLOAD_COMMAND
+# (this is the intended usage; ${HELIO_CMAKE_DIR} points at this script's dir):
+#
+#   ExternalProject_Add(mimalloc2_project
+#     DOWNLOAD_COMMAND ${CMAKE_COMMAND}
+#         -DURL=https://github.com/microsoft/mimalloc/archive/refs/tags/v2.2.4.tar.gz
+#         -DDEST=${THIRD_PARTY_DIR}/mimalloc2-src-archive
+#         -DEXTRACT_DIR=${THIRD_PARTY_DIR}/mimalloc2
+#         -DEXPECTED_HASH=754a98de5e2912fddbeaf24830f982b4540992f1bab4a0a8796ee118e0752bda
+#         -P ${HELIO_CMAKE_DIR}/download_retry.cmake
+#      .. <rest of ExternalProject_Add args> ..)
+#
+# 2) From a shell (assuming in the same folder where this script resides):
+#   cmake -DURL=https://github.com/microsoft/mimalloc/archive/refs/tags/v2.2.4.tar.gz \
+#         -DDEST=/tmp/mimalloc.tar.gz \
+#         -DEXTRACT_DIR=/tmp/mimalloc-src \
+#         -DEXPECTED_HASH=754a98de5e2912fddbeaf24830f982b4540992f1bab4a0a8796ee118e0752bda \
+#         -P download_retry.cmake
+
+cmake_minimum_required(VERSION 3.10)
+
+# Prefix used in all log/error messages emitted by this script.
+set(MODULE_NAME "download_retry")
+
+# Check input
+if(NOT DEFINED URL OR URL STREQUAL "")
+  message(FATAL_ERROR "${MODULE_NAME}: URL must be provided")
+endif()
+if(NOT DEFINED DEST OR DEST STREQUAL "")
+  message(FATAL_ERROR "${MODULE_NAME}: DEST must be provided")
+endif()
+if(NOT DEFINED RETRIES OR RETRIES LESS 1)
+  set(RETRIES 10)
+endif()
+if(NOT DEFINED BACKOFF OR BACKOFF STREQUAL "")
+  set(BACKOFF 5)
+endif()
+if(NOT DEFINED BACKOFF_MAX OR BACKOFF_MAX STREQUAL "")
+  set(BACKOFF_MAX 60)
+endif()
+
+# Ordered list of URLs tried on every attempt (primary first, then fallback).
+set(_urls "${URL}")
+if(DEFINED URL_FALLBACK AND NOT URL_FALLBACK STREQUAL "")
+  list(APPEND _urls "${URL_FALLBACK}")
+endif()
+
+# Optional SHA256 verification. We verify manually (rather than via
+# file(DOWNLOAD EXPECTED_HASH)) because file(DOWNLOAD) aborts the whole script
+# on a hash mismatch; verifying ourselves lets a corrupt/partial download be
+# retried like any other failure.
+set(_expected_hash "")
+if(DEFINED EXPECTED_HASH AND NOT EXPECTED_HASH STREQUAL "")
+  string(TOLOWER "${EXPECTED_HASH}" _expected_hash)
+  # Accept either a raw hex digest or an "SHA256=<hex>" form (as in URL_HASH).
+  if(_expected_hash MATCHES "^sha256=(.*)$")
+    set(_expected_hash "${CMAKE_MATCH_1}")
+  endif()
+endif()
+
+# Start downloading all URLs with retries
+set(_downloaded FALSE)
+set(_sleep ${BACKOFF})
+foreach(_attempt RANGE 1 ${RETRIES})
+  foreach(_url IN LISTS _urls)
+    message(STATUS "${MODULE_NAME}: attempt ${_attempt}/${RETRIES} from ${_url}")
+    file(DOWNLOAD "${_url}" "${DEST}"
+         STATUS _status
+         LOG _log
+         INACTIVITY_TIMEOUT 60
+         TIMEOUT 600)
+    list(GET _status 0 _code)
+    list(GET _status 1 _msg)
+
+    if(_code EQUAL 0 AND DEFINED MIN_SIZE AND NOT MIN_SIZE STREQUAL "")
+      file(SIZE "${DEST}" _size)
+      if(_size LESS MIN_SIZE)
+        set(_code 99)
+        set(_msg "downloaded file too small (${_size} bytes < ${MIN_SIZE})")
+      endif()
+    endif()
+
+    if(_code EQUAL 0 AND NOT _expected_hash STREQUAL "")
+      file(SHA256 "${DEST}" _actual_hash)
+      if(NOT _actual_hash STREQUAL _expected_hash)
+        set(_code 98)
+        set(_msg "SHA256 mismatch (expected ${_expected_hash}, got ${_actual_hash})")
+      endif()
+    endif()
+
+    if(_code EQUAL 0)
+      set(_downloaded TRUE)
+      break()
+    endif()
+
+    message(WARNING "${MODULE_NAME}: attempt ${_attempt} from ${_url} failed (code ${_code}: ${_msg})")
+    file(REMOVE "${DEST}")
+  endforeach()
+
+  if(_downloaded)
+    break()
+  endif()
+
+  if(_attempt LESS RETRIES)
+    message(STATUS "${MODULE_NAME}: sleeping ${_sleep}s before next attempt")
+    execute_process(COMMAND "${CMAKE_COMMAND}" -E sleep "${_sleep}")
+    # Exponential backoff, capped at BACKOFF_MAX.
+    math(EXPR _sleep "${_sleep} * 2")
+    if(_sleep GREATER BACKOFF_MAX)
+      set(_sleep ${BACKOFF_MAX})
+    endif()
+  endif()
+endforeach()
+
+if(NOT _downloaded)
+  message(FATAL_ERROR "${MODULE_NAME}: download failed after ${RETRIES} attempts: ${URL}")
+endif()
+
+message(STATUS "${MODULE_NAME}: downloaded ${DEST}")
+
+if(NOT DEFINED EXTRACT_DIR OR EXTRACT_DIR STREQUAL "")
+  return()
+endif()
+
+# Extraction
+# mirrors CMake's ExternalProject extractfile.cmake logic
+get_filename_component(_dest_abs "${DEST}" ABSOLUTE)
+get_filename_component(_extract_abs "${EXTRACT_DIR}" ABSOLUTE)
+get_filename_component(_parent_dir "${_extract_abs}/.." ABSOLUTE)
+
+# Extract into a unique sibling temp dir, then move into place. The name hashes
+# the source/target paths (so parallel extractions of different deps never
+# collide) plus a random suffix, avoiding a shared incrementing-counter race.
+string(SHA256 _uniq "${_dest_abs}:${_extract_abs}")
+string(SUBSTRING "${_uniq}" 0 12 _uniq)
+string(RANDOM LENGTH 8 _rand)
+set(_tmp_dir "${_parent_dir}/df-dl-ex-${_uniq}-${_rand}")
+while(EXISTS "${_tmp_dir}")
+  string(RANDOM LENGTH 8 _rand)
+  set(_tmp_dir "${_parent_dir}/df-dl-ex-${_uniq}-${_rand}")
+endwhile()
+file(MAKE_DIRECTORY "${_tmp_dir}")
+
+message(STATUS "${MODULE_NAME}: extracting ${_dest_abs} -> ${_extract_abs}")
+execute_process(COMMAND "${CMAKE_COMMAND}" -E tar xf "${_dest_abs}"
+                WORKING_DIRECTORY "${_tmp_dir}"
+                RESULT_VARIABLE _extract_rv)
+if(NOT _extract_rv EQUAL 0)
+  file(REMOVE_RECURSE "${_tmp_dir}")
+  message(FATAL_ERROR "${MODULE_NAME}: extraction of ${_dest_abs} failed")
+endif()
+
+# If the archive contains exactly one top-level directory, strip it so the
+# source lands directly in EXTRACT_DIR (as ExternalProject would do).
+file(GLOB _contents "${_tmp_dir}/*")
+list(REMOVE_ITEM _contents "${_tmp_dir}/.DS_Store")
+list(LENGTH _contents _n)
+if(NOT _n EQUAL 1 OR NOT IS_DIRECTORY "${_contents}")
+  set(_contents "${_tmp_dir}")
+endif()
+get_filename_component(_contents "${_contents}" ABSOLUTE)
+
+file(REMOVE_RECURSE "${_extract_abs}")
+file(RENAME "${_contents}" "${_extract_abs}")
+file(REMOVE_RECURSE "${_tmp_dir}")
+
+message(STATUS "${MODULE_NAME}: extraction done")

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -4,6 +4,8 @@ if(HELIO_THIRD_PARTY_INCLUDED)
 endif()
 set(HELIO_THIRD_PARTY_INCLUDED TRUE)
 
+set(HELIO_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL "helio cmake module dir")
+
 # Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
  cmake_policy(SET CMP0135 NEW)
@@ -63,7 +65,7 @@ find_package(Threads REQUIRED)
 
 function(add_third_party name)
   set(options SHARED)
-  set(oneValueArgs CMAKE_PASS_FLAGS)
+  set(oneValueArgs CMAKE_PASS_FLAGS URL URL_HASH)
   set(multiValArgs BUILD_COMMAND INSTALL_COMMAND LIB)
   CMAKE_PARSE_ARGUMENTS(parsed "${options}" "${oneValueArgs}" "${multiValArgs}" ${ARGN})
 
@@ -81,6 +83,25 @@ function(add_third_party name)
 
   set(_DIR ${THIRD_PARTY_DIR}/${name})
   set(INSTALL_ROOT ${THIRD_PARTY_LIB_DIR}/${name})
+
+  # For URL/tarball dependencies, route the download through the shared retry
+  # policy (download_retry.cmake). ExternalProject's built-in URL download is
+  # single-shot, so a transient network flake fails the build; the retry policy
+  # retries with backoff instead. Git-based dependencies are left untouched.
+  set(_download_args "")
+  if (parsed_URL)
+    set(_hash_arg "")
+    if (parsed_URL_HASH)
+      set(_hash_arg -DEXPECTED_HASH=${parsed_URL_HASH})
+    endif()
+    set(_download_args
+      DOWNLOAD_COMMAND ${CMAKE_COMMAND}
+        -DURL=${parsed_URL}
+        -DDEST=${_DIR}-src-archive
+        -DEXTRACT_DIR=${_DIR}
+        ${_hash_arg}
+        -P ${HELIO_CMAKE_DIR}/download_retry.cmake)
+  endif()
 
   if (parsed_LIB)
     set(LIB_FILES "")
@@ -110,10 +131,13 @@ function(add_third_party name)
   endif()
 
   ExternalProject_Add(${name}_project
-    DOWNLOAD_DIR ${_DIR}
+    # DOWNLOAD_DIR must differ from SOURCE_DIR (=_DIR): the downloader removes
+    # EXTRACT_DIR (=_DIR) while the step runs with DOWNLOAD_DIR as its CWD.
+    DOWNLOAD_DIR ${THIRD_PARTY_DIR}
     SOURCE_DIR ${_DIR}
     INSTALL_DIR ${INSTALL_ROOT}
     UPDATE_COMMAND ""
+    ${_download_args}
 
     BUILD_COMMAND ${parsed_BUILD_COMMAND}
 
@@ -172,38 +196,44 @@ function(add_third_party name)
   endif()
 endfunction()
 
+# Download a tarball via download_retry.cmake into a local file for FetchContent
+# to consume, giving FetchContent deps the same retry/backoff as add_third_party.
+# Optional 4th argument is a fallback URL.
+function(fetch_tarball_with_retry name url dest)
+  # Reuse a cached tarball only if it passes MIN_SIZE; otherwise treat it as
+  # truncated/partial (e.g. interrupted run), remove it, and re-download.
+  if(EXISTS "${dest}")
+    file(SIZE "${dest}" _existing_size)
+    if(NOT _existing_size LESS 102400)
+      return()
+    endif()
+    file(REMOVE "${dest}")
+  endif()
+  set(_fallback_arg "")
+  if(ARGC GREATER 3)
+    set(_fallback_arg -DURL_FALLBACK=${ARGV3})
+  endif()
+  execute_process(
+    COMMAND ${CMAKE_COMMAND}
+      -DURL=${url}
+      ${_fallback_arg}
+      -DDEST=${dest}
+      -DMIN_SIZE=102400
+      -P ${HELIO_CMAKE_DIR}/download_retry.cmake
+    RESULT_VARIABLE _rc)
+  if(NOT _rc EQUAL 0)
+    file(REMOVE "${dest}")
+    message(FATAL_ERROR "fetch_tarball_with_retry: failed to download ${name} from ${url}")
+  endif()
+endfunction()
+
 set(GTEST_VERSION 1.17.0)
 set(GTEST_RELEASE_URL "https://github.com/google/googletest/releases/download/v${GTEST_VERSION}/googletest-${GTEST_VERSION}.tar.gz")
 set(GTEST_ARCHIVE_URL "https://github.com/google/googletest/archive/v${GTEST_VERSION}.tar.gz")
 set(GTEST_TARBALL "${CMAKE_BINARY_DIR}/googletest-${GTEST_VERSION}.tar.gz")
 
-function(download_and_validate url file out_status)
-  file(DOWNLOAD "${url}" "${file}" STATUS st)
-  list(GET st 0 rc)
-  if(rc EQUAL 0)
-    file(SIZE "${file}" sz)
-    if(sz LESS 102400) # Check if file is < 100KB
-      set(st "1;File too small (${sz} bytes)") # set error and error message
-    endif()
-  endif()
-  set(${out_status} "${st}" PARENT_SCOPE)
-endfunction()
-
-if(NOT EXISTS "${GTEST_TARBALL}")
-  download_and_validate("${GTEST_RELEASE_URL}" "${GTEST_TARBALL}" st1)
-  list(GET st1 0 rc1)
-  if(NOT rc1 EQUAL 0)
-    file(REMOVE "${GTEST_TARBALL}")
-    message(STATUS "Primary download failed: ${st1}. Trying archive URL...")
-    download_and_validate("${GTEST_ARCHIVE_URL}" "${GTEST_TARBALL}" st2)
-    list(GET st2 0 rc2)
-    if(NOT rc2 EQUAL 0)
-      file(REMOVE "${GTEST_TARBALL}")
-      message(FATAL_ERROR "Failed to download googletest.\nRelease: ${st1}\nArchive: ${st2}")
-    endif()
-  endif()
-endif()
-
+# Fetch googletest with retry policy (with archive URL fallback).
+fetch_tarball_with_retry(googletest "${GTEST_RELEASE_URL}" "${GTEST_TARBALL}" "${GTEST_ARCHIVE_URL}")
 FetchContent_Declare(
   gtest
   URL "${GTEST_TARBALL}"
@@ -215,9 +245,14 @@ if (NOT gtest_POPULATED)
     add_subdirectory(${gtest_SOURCE_DIR} ${gtest_BINARY_DIR})
 endif ()
 
+# Fetch benchmark with retry policy
+set(BENCHMARK_URL https://github.com/google/benchmark/archive/v1.9.5.tar.gz)
+set(BENCHMARK_TARBALL "${CMAKE_BINARY_DIR}/benchmark-1.9.5.tar.gz")
+fetch_tarball_with_retry(benchmark "${BENCHMARK_URL}" "${BENCHMARK_TARBALL}")
+
 FetchContent_Declare(
   benchmark
-  URL https://github.com/google/benchmark/archive/v1.9.5.tar.gz
+  URL "${BENCHMARK_TARBALL}"
 )
 
 FetchContent_GetProperties(benchmark)
@@ -233,10 +268,14 @@ if (NOT benchmark_POPULATED)
     add_subdirectory(${benchmark_SOURCE_DIR} ${benchmark_BINARY_DIR})
 endif ()
 
+# Fetch abseil with retry policy
+set(ABSEIL_URL https://github.com/abseil/abseil-cpp/releases/download/20250512.1/abseil-cpp-20250512.1.tar.gz)
+set(ABSEIL_TARBALL "${CMAKE_BINARY_DIR}/abseil-cpp-20250512.1.tar.gz")
+fetch_tarball_with_retry(abseil-cpp "${ABSEIL_URL}" "${ABSEIL_TARBALL}")
 
 FetchContent_Declare(
   abseil_cpp
-  URL https://github.com/abseil/abseil-cpp/releases/download/20250512.1/abseil-cpp-20250512.1.tar.gz
+  URL "${ABSEIL_TARBALL}"
   PATCH_COMMAND patch -p1 < "${CMAKE_CURRENT_LIST_DIR}/../patches/abseil-20250512.1.patch"
   COMMAND patch -p1 < "${CMAKE_CURRENT_LIST_DIR}/../patches/abseil-gcc-undefined-sanitizer-compilation-fix.patch"
 )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -20,8 +20,11 @@ if (WITH_AWS_CLOUD)
   endif()
 endif()
 
-add_executable(gcs_demo gcs_demo.cc)
-cxx_link(gcs_demo gcp_lib azure_lib)
+# gcs_demo links gcp_lib, which is only built when WITH_GCP is ON.
+if (WITH_GCP)
+  add_executable(gcs_demo gcs_demo.cc)
+  cxx_link(gcs_demo gcp_lib azure_lib)
+endif()
 
 add_executable(https_client_cli https_client_cli.cc)
 cxx_link(https_client_cli base fibers2 http_client_lib tls_lib)


### PR DESCRIPTION
Add download_retry.cmake: a reusable downloader with retries, exponential backoff, optional SHA256 and min-size checks, URL fallback, and tarball extraction.

Wire it into add_third_party as a DOWNLOAD_COMMAND for URL-based deps. Add a fetch_tarball_with_retry helper and route the FetchContent tarball deps (googletest, benchmark, abseil) through it, replacing the ad-hoc download_and_validate helper.

Also, fix a build issue: build gcs_demo only when WITH_GCP is ON.
