### PR TITLE
tls: fix missing return in TlsSocket::OnRecv MutableBytes branch

### DIFF
--- a/util/tls/tls_socket.cc
+++ b/util/tls/tls_socket.cc
@@ -546,6 +546,7 @@ void TlsSocket::OnRecv(const RecvNotification& rn, const OnRecvCb& recv_cb) {
     std::memcpy(input_buf.data(), buf->data(), buf->size());
     engine_->CommitInput(buf->size());
     recv_cb({RecvNotification::RecvCompletion{true}});
+    return;
   }
   LOG(FATAL) << "Unhandled type in RecvNotification::read_result variant";
 }


### PR DESCRIPTION
Add the missing return at the end of the io::MutableBytes block: without it, it will fall through to LOG(FATAL).

This path is unreachable today (multishot is disabled for TLS) but would crash if ever enabled.