### PR TITLE
AWS: refresh expired IRSA S3 credentials

### DIFF
--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -178,17 +178,25 @@ def test_endpoint_flag_override(minio):
     )
 
 
-def _make_failing_upload_handler(*, connection_close: bool = False, end_of_stream: bool = False):
+def _make_failing_upload_handler(
+    *,
+    connection_close: bool = False,
+    end_of_stream: bool = False,
+    expired_token_once: bool = False,
+):
     """Build an http handler that accepts CreateMultipartUpload.
     If `end_of_stream=True`, drops the connection on the first PUT request
     (UploadPart), then succeeds with 200 OK and ETag on subsequent PUTs,
     and supports completing the upload.
     Otherwise, answers every UploadPart with 507 (out of capacity).
-    `connection_close=True` mirrors MinIO's storage full response."""
+    `connection_close=True` mirrors MinIO's storage full response. With
+    `expired_token_once=True`, the first multipart-create request returns S3's
+    HTTP 400 ExpiredToken error, then all requests succeed."""
 
     class Handler(http.server.BaseHTTPRequestHandler):
         protocol_version = "HTTP/1.1"
         put_count = 0
+        create_count = 0
 
         def log_message(self, *args, **kwargs):
             pass
@@ -211,6 +219,15 @@ def _make_failing_upload_handler(*, connection_close: bool = False, end_of_strea
         def do_POST(self):
             query = parse_qs(urlparse(self.path).query, keep_blank_values=True)
             if "uploads" in query:
+                Handler.create_count += 1
+                if expired_token_once and Handler.create_count == 1:
+                    body = (
+                        b'<?xml version="1.0" encoding="UTF-8"?>'
+                        b"<Error><Code>ExpiredToken</Code>"
+                        b"<Message>The provided token has expired.</Message></Error>"
+                    )
+                    self._send(400, body, close=False)
+                    return
                 body = (
                     b'<?xml version="1.0" encoding="UTF-8"?>'
                     b"<InitiateMultipartUploadResult>"
@@ -220,7 +237,7 @@ def _make_failing_upload_handler(*, connection_close: bool = False, end_of_strea
                 )
                 self._send(200, body, close=False)
                 return
-            elif "uploadId" in query and end_of_stream:
+            elif "uploadId" in query and (end_of_stream or expired_token_once):
                 body = (
                     b'<?xml version="1.0" encoding="UTF-8"?>'
                     b"<CompleteMultipartUploadResult>"
@@ -237,9 +254,9 @@ def _make_failing_upload_handler(*, connection_close: bool = False, end_of_strea
             if content_len:
                 self.rfile.read(content_len)
 
-            if end_of_stream:
+            if end_of_stream or expired_token_once:
                 Handler.put_count += 1
-                if Handler.put_count == 1:
+                if end_of_stream and Handler.put_count == 1:
                     self.close_connection = True
                     return
                 self._send(200, b"", close=False, headers={"ETag": '"fake-etag"'})
@@ -292,6 +309,18 @@ def failing_s3_endpoint_keepalive():
 def end_of_stream_s3_endpoint():
     """Fake S3 that drops the first UploadPart request completely (end of stream)."""
     server, thread, url = _start_fake_s3(_make_failing_upload_handler(end_of_stream=True))
+    try:
+        yield url
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.fixture()
+def expired_token_s3_endpoint():
+    """Fake S3 that returns S3's 400 ExpiredToken response once."""
+    server, thread, url = _start_fake_s3(_make_failing_upload_handler(expired_token_once=True))
     try:
         yield url
     finally:
@@ -383,6 +412,20 @@ def test_upload_part_end_of_stream_retry(end_of_stream_s3_endpoint):
     )
     assert "put-object done; bytes=" in result.stderr, (
         f"expected successful put-object completion, got:\n{result.stderr}"
+    )
+
+
+def test_expired_token_refresh_retry(expired_token_s3_endpoint):
+    """S3 reports expired STS credentials as HTTP 400 ExpiredToken, not 401/403.
+    RobustSender must refresh and retry the request."""
+    result = _put_object_against(expired_token_s3_endpoint, "--v=1")
+
+    assert result.returncode == 0, f"put-object failed:\n{result.stderr}"
+    assert "Refreshing token" in result.stderr, (
+        f"expected ExpiredToken to trigger credential refresh:\n{result.stderr}"
+    )
+    assert "put-object done; bytes=" in result.stderr, (
+        f"expected successful retry after refresh, got:\n{result.stderr}"
     )
 
 

--- a/util/cloud/aws/aws_creds_provider.cc
+++ b/util/cloud/aws/aws_creds_provider.cc
@@ -16,6 +16,7 @@
 
 #include <boost/beast/http/empty_body.hpp>
 #include <boost/beast/http/string_body.hpp>
+#include <chrono>
 #include <pugixml.hpp>
 
 #include "base/logging.h"
@@ -37,6 +38,8 @@ namespace {
 // SHA256("") — used as payload hash for all GET requests.
 constexpr string_view kEmptyBodyHash =
     "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+constexpr auto kRefreshWaitTimeout = chrono::seconds(30);
+constexpr auto kRefreshWaitInterval = chrono::milliseconds(100);
 
 string HexEncode(const uint8_t* data, size_t len) {
   static const char kHex[] = "0123456789abcdef";
@@ -259,6 +262,7 @@ AwsCredsProvider::~AwsCredsProvider() {
 }
 
 SSL_CTX* AwsCredsProvider::GetSslCtx() {
+  folly::RWSpinLock::WriteHolder lock(lock_);
   if (!ssl_ctx_)
     ssl_ctx_ = http::TlsClient::CreateSslContext();
   return ssl_ctx_;
@@ -338,8 +342,8 @@ error_code AwsCredsProvider::TryEnvironment() {
   {
     folly::RWSpinLock::WriteHolder lock(lock_);
     creds_ = std::move(creds);
+    source_ = CredSource::kEnv;
   }
-  source_ = CredSource::kEnv;
   LOG_FIRST_N(INFO, 1) << "aws: loaded credentials; provider=environment";
   return {};
 }
@@ -382,8 +386,8 @@ error_code AwsCredsProvider::TryProfileFile() {
   {
     folly::RWSpinLock::WriteHolder lock(lock_);
     creds_ = std::move(creds);
+    source_ = CredSource::kProfile;
   }
-  source_ = CredSource::kProfile;
   LOG_FIRST_N(INFO, 1) << "aws: loaded credentials; provider=profile file";
   return {};
 }
@@ -420,10 +424,8 @@ error_code AwsCredsProvider::TryWebIdentity() {
   {
     folly::RWSpinLock::WriteHolder lock(lock_);
     creds_ = std::move(creds);
+    source_ = CredSource::kWebIdentity;
   }
-  role_arn_ = role_arn;
-  web_identity_token_file_ = token_file;
-  source_ = CredSource::kWebIdentity;
   LOG_FIRST_N(INFO, 1) << "aws: loaded credentials; provider=web-identity";
   return {};
 }
@@ -452,8 +454,6 @@ error_code AwsCredsProvider::TryContainerCreds() {
     }
   }
 
-  container_uri_ = uri;
-
   // Determine if http or https.
   vector<pair<string, string>> headers;
   if (!auth_token.empty()) {
@@ -472,8 +472,8 @@ error_code AwsCredsProvider::TryContainerCreds() {
   {
     folly::RWSpinLock::WriteHolder lock(lock_);
     creds_ = std::move(creds);
+    source_ = CredSource::kContainer;
   }
-  source_ = CredSource::kContainer;
   LOG_FIRST_N(INFO, 1) << "aws: loaded credentials; provider=container-credentials";
   return {};
 }
@@ -495,17 +495,16 @@ error_code AwsCredsProvider::TryIMDS() {
                h2::verb::get, token_hdr, "", connect_ms_, nullptr);
   if (!role_name_res)
     return role_name_res.error();
-  string role_name_raw = std::move(*role_name_res);
+  string imds_role(absl::StripAsciiWhitespace(*role_name_res));
 
-  imds_role_ = string(absl::StripAsciiWhitespace(role_name_raw));
-  if (imds_role_.empty()) {
+  if (imds_role.empty()) {
     LOG(WARNING) << "aws: IMDS returned empty role name";
     return make_error_code(errc::not_supported);
   }
 
   // Get the credentials for the role.
   auto json = FetchUrl("169.254.169.254", "80",
-                       absl::StrCat("/latest/meta-data/iam/security-credentials/", imds_role_),
+                       absl::StrCat("/latest/meta-data/iam/security-credentials/", imds_role),
                        h2::verb::get, token_hdr, "", connect_ms_, nullptr);
   if (!json)
     return json.error();
@@ -516,14 +515,40 @@ error_code AwsCredsProvider::TryIMDS() {
   {
     folly::RWSpinLock::WriteHolder lock(lock_);
     creds_ = std::move(creds);
+    source_ = CredSource::kIMDS;
   }
-  source_ = CredSource::kIMDS;
-  LOG_FIRST_N(INFO, 1) << "aws: loaded credentials; provider=ec2-metadata; role=" << imds_role_;
+  LOG_FIRST_N(INFO, 1) << "aws: loaded credentials; provider=ec2-metadata; role=" << imds_role;
   return {};
 }
 
 error_code AwsCredsProvider::RefreshToken() {
-  switch (source_) {
+  bool expected = false;
+  if (is_refreshing_.compare_exchange_strong(expected, true, memory_order_acq_rel)) {
+    error_code ec = RefreshTokenImpl();
+    is_refreshing_.store(false, memory_order_release);
+    return ec;
+  }
+
+  // Someone else is already refreshing; wait for it to finish.
+  auto deadline = chrono::steady_clock::now() + kRefreshWaitTimeout;
+  while (is_refreshing_.load(memory_order_acquire)) {
+    if (chrono::steady_clock::now() >= deadline) {
+      return make_error_code(errc::timed_out);
+    }
+    ThisFiber::SleepFor(kRefreshWaitInterval);
+  }
+
+  return {};
+}
+
+error_code AwsCredsProvider::RefreshTokenImpl() {
+  CredSource source;
+  {
+    folly::RWSpinLock::ReadHolder lock(lock_);
+    source = source_;
+  }
+
+  switch (source) {
     case CredSource::kEnv:
     case CredSource::kProfile:
       return {};  // static credentials never expire
@@ -534,7 +559,7 @@ error_code AwsCredsProvider::RefreshToken() {
     case CredSource::kIMDS:
       return TryIMDS();
     case CredSource::kNone:
-      break;
+      return make_error_code(errc::permission_denied);
   }
   return make_error_code(errc::permission_denied);
 }
@@ -637,9 +662,29 @@ void AwsCredsProvider::Sign(detail::HttpRequestBase* req) const {
   req->SetHeader(h2::field::authorization, auth);
 }
 
-bool AwsCredsProvider::IsExpired() const {
-  folly::RWSpinLock::ReadHolder lock(lock_);
-  return creds_.IsExpired();
+io::Result<bool> AwsCredsProvider::RefreshIfExpiring() {
+  auto deadline = chrono::steady_clock::now() + kRefreshWaitTimeout;
+  while (true) {
+    {
+      folly::RWSpinLock::ReadHolder creds_lock(lock_);
+      if (!creds_.IsExpiring())
+        return false;
+    }
+
+    bool expected = false;
+    if (is_refreshing_.compare_exchange_strong(expected, true, memory_order_acq_rel)) {
+      error_code ec = RefreshTokenImpl();
+      is_refreshing_.store(false, memory_order_release);
+      if (ec)
+        return nonstd::make_unexpected(ec);
+      return true;
+    }
+
+    if (chrono::steady_clock::now() >= deadline) {
+      return nonstd::make_unexpected(make_error_code(errc::timed_out));
+    }
+    ThisFiber::SleepFor(kRefreshWaitInterval);
+  }
 }
 
 bool AwsCredsProvider::ShouldRefreshToken(

--- a/util/cloud/aws/aws_creds_provider.cc
+++ b/util/cloud/aws/aws_creds_provider.cc
@@ -569,9 +569,8 @@ void AwsCredsProvider::Sign(detail::HttpRequestBase* req) const {
   // otherwise default to SHA256("") for unsigned GET requests.
   const auto& headers = req->GetHeaders();
   auto hash_it = headers.find("x-amz-content-sha256");
-  string payload_hash = (hash_it != headers.end())
-                            ? string(detail::FromBoostSV(hash_it->value()))
-                            : string(kEmptyBodyHash);
+  string payload_hash = (hash_it != headers.end()) ? string(detail::FromBoostSV(hash_it->value()))
+                                                   : string(kEmptyBodyHash);
 
   req->SetHeader("x-amz-date", datetime);
   req->SetHeader("x-amz-content-sha256", payload_hash);
@@ -609,13 +608,10 @@ void AwsCredsProvider::Sign(detail::HttpRequestBase* req) const {
 
   // Build canonical request.
   string_view method_str = detail::FromBoostSV(h2::to_string(req->GetMethod()));
-  string canonical_request = absl::StrCat(
-      method_str, "\n",
-      canonical_uri, "\n",
-      canonical_qs, "\n",
-      canonical_headers, "\n",  // canonical_headers already ends with \n; this adds blank line
-      signed_headers_str, "\n",
-      payload_hash);
+  string canonical_request =
+      absl::StrCat(method_str, "\n", canonical_uri, "\n", canonical_qs, "\n", canonical_headers,
+                   "\n",  // canonical_headers already ends with \n; this adds blank line
+                   signed_headers_str, "\n", payload_hash);
 
   // Credential scope and string to sign.
   string credential_scope = absl::StrCat(date, "/", region_, "/s3/aws4_request");
@@ -639,6 +635,27 @@ void AwsCredsProvider::Sign(detail::HttpRequestBase* req) const {
       absl::StrCat("AWS4-HMAC-SHA256 Credential=", creds.access_key_id, "/", credential_scope,
                    ", SignedHeaders=", signed_headers_str, ", Signature=", signature);
   req->SetHeader(h2::field::authorization, auth);
+}
+
+bool AwsCredsProvider::IsExpired() const {
+  folly::RWSpinLock::ReadHolder lock(lock_);
+  return creds_.IsExpired();
+}
+
+bool AwsCredsProvider::ShouldRefreshToken(
+    const boost::beast::http::response<boost::beast::http::string_body>& response) const {
+  if (CredentialsProvider::ShouldRefreshToken(response)) {
+    return true;
+  }
+
+  if (response.result() != boost::beast::http::status::bad_request) {
+    return false;
+  }
+
+  // S3 reports expired temporary credentials as HTTP 400 rather than 401/403.
+  // InvalidToken can result from a web-identity token rotation race.
+  return absl::StrContains(response.body(), "<Code>ExpiredToken</Code>") ||
+         absl::StrContains(response.body(), "<Code>InvalidToken</Code>");
 }
 
 }  // namespace cloud::aws

--- a/util/cloud/aws/aws_creds_provider.h
+++ b/util/cloud/aws/aws_creds_provider.h
@@ -62,7 +62,9 @@ class AwsCredsProvider : public CredentialsProvider {
   explicit AwsCredsProvider(std::string region = {}, std::string endpoint_override = {});
   ~AwsCredsProvider();
 
-  unsigned connect_ms() const { return connect_ms_; }
+  unsigned connect_ms() const {
+    return connect_ms_;
+  }
 
   std::error_code Init(unsigned connect_ms) final;
 
@@ -73,6 +75,11 @@ class AwsCredsProvider : public CredentialsProvider {
 
   // Computes AWS SigV4 and sets x-amz-date, x-amz-security-token, Authorization headers.
   void Sign(detail::HttpRequestBase* req) const final;
+
+  bool IsExpired() const final;
+
+  bool ShouldRefreshToken(
+      const boost::beast::http::response<boost::beast::http::string_body>& response) const final;
 
   std::error_code RefreshToken() final;
 

--- a/util/cloud/aws/aws_creds_provider.h
+++ b/util/cloud/aws/aws_creds_provider.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "base/RWSpinLock.h"
 #include "util/cloud/utils.h"
 
@@ -21,7 +23,7 @@ struct AwsCredentials {
     return access_key_id.empty() || secret_access_key.empty();
   }
 
-  bool IsExpired() const {
+  bool IsExpiring() const {
     return expiry > 0 && time(nullptr) + 30 >= expiry;
   }
 };
@@ -47,7 +49,7 @@ std::string StsEndpoint(std::string_view region);
 //
 // Sign() computes AWS Signature Version 4 on every call.
 // RefreshToken() re-fetches from whichever source originally succeeded.
-// Thread-safe: RWSpinLock guards creds_.
+// Thread-safe: RWSpinLock guards credential and refresh-source state.
 class AwsCredsProvider : public CredentialsProvider {
   AwsCredsProvider(const AwsCredsProvider&) = delete;
   AwsCredsProvider& operator=(const AwsCredsProvider&) = delete;
@@ -76,7 +78,7 @@ class AwsCredsProvider : public CredentialsProvider {
   // Computes AWS SigV4 and sets x-amz-date, x-amz-security-token, Authorization headers.
   void Sign(detail::HttpRequestBase* req) const final;
 
-  bool IsExpired() const final;
+  io::Result<bool> RefreshIfExpiring() final;
 
   bool ShouldRefreshToken(
       const boost::beast::http::response<boost::beast::http::string_body>& response) const final;
@@ -95,6 +97,7 @@ class AwsCredsProvider : public CredentialsProvider {
   std::error_code TryWebIdentity();
   std::error_code TryContainerCreds();
   std::error_code TryIMDS();
+  std::error_code RefreshTokenImpl();
 
   std::string region_;
   std::string endpoint_override_;
@@ -103,14 +106,10 @@ class AwsCredsProvider : public CredentialsProvider {
   enum class CredSource { kNone, kEnv, kProfile, kWebIdentity, kContainer, kIMDS };
   CredSource source_ = CredSource::kNone;
 
-  // Saved for RefreshToken():
-  std::string role_arn_, web_identity_token_file_;
-  std::string container_uri_;
-  std::string imds_role_;
-
   SSL_CTX* ssl_ctx_ = nullptr;
   mutable folly::RWSpinLock lock_;
   AwsCredentials creds_;
+  std::atomic_bool is_refreshing_ = false;
 };
 
 }  // namespace cloud::aws

--- a/util/cloud/utils.cc
+++ b/util/cloud/utils.cc
@@ -142,6 +142,11 @@ error_code AbstractStorageFile::FillBuf(const uint8_t* buffer, size_t length) {
 
 }  // namespace detail
 
+bool CredentialsProvider::ShouldRefreshToken(
+    const h2::response<h2::string_body>& response) const {
+  return IsUnauthorized(response);
+}
+
 RobustSender::SenderResult::~SenderResult() {
   if (client_handle && !reuse_connection) {
     client_handle->Shutdown();
@@ -173,6 +178,12 @@ ParsedHttpUrl ParseHttpUrl(string_view uri) {
 error_code RobustSender::Send(unsigned num_iterations, detail::HttpRequestBase* req,
                               SenderResult* result) {
   error_code ec;
+  if (provider_->IsExpired()) {
+    VLOG(1) << "Refreshing expired token before sending request";
+    RETURN_ERROR(provider_->RefreshToken());
+    provider_->Sign(req);
+  }
+
   for (unsigned i = 0; i < num_iterations; ++i) {  // Iterate for possible token refresh.
     auto res = pool_->GetHandle();
     if (!res)
@@ -235,7 +246,7 @@ error_code RobustSender::Send(unsigned num_iterations, detail::HttpRequestBase* 
       continue;
     }
 
-    if (IsUnauthorized(msg)) {
+    if (provider_->ShouldRefreshToken(msg)) {
       VLOG(1) << "Refreshing token";
       RETURN_ERROR(provider_->RefreshToken());
       provider_->Sign(req);

--- a/util/cloud/utils.cc
+++ b/util/cloud/utils.cc
@@ -142,8 +142,7 @@ error_code AbstractStorageFile::FillBuf(const uint8_t* buffer, size_t length) {
 
 }  // namespace detail
 
-bool CredentialsProvider::ShouldRefreshToken(
-    const h2::response<h2::string_body>& response) const {
+bool CredentialsProvider::ShouldRefreshToken(const h2::response<h2::string_body>& response) const {
   return IsUnauthorized(response);
 }
 
@@ -178,9 +177,13 @@ ParsedHttpUrl ParseHttpUrl(string_view uri) {
 error_code RobustSender::Send(unsigned num_iterations, detail::HttpRequestBase* req,
                               SenderResult* result) {
   error_code ec;
-  if (provider_->IsExpired()) {
-    VLOG(1) << "Refreshing expired token before sending request";
-    RETURN_ERROR(provider_->RefreshToken());
+  auto refreshed = provider_->RefreshIfExpiring();
+  if (!refreshed) {
+    return refreshed.error();
+  }
+
+  if (*refreshed) {
+    VLOG(1) << "Refreshed expiring token before sending request";
     provider_->Sign(req);
   }
 

--- a/util/cloud/utils.h
+++ b/util/cloud/utils.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <string_view>
+
 #include <absl/functional/function_ref.h>
 
 #include <boost/beast/http/dynamic_body.hpp>
@@ -181,6 +183,8 @@ class AbstractStorageFile : public io::WriteFile {
 
 }  // namespace detail
 
+// Thread-safe interface for fetching credentials and signing requests.
+// Implementations may cache credentials and refresh them as needed.
 class CredentialsProvider {
  public:
   virtual ~CredentialsProvider() = default;
@@ -190,9 +194,9 @@ class CredentialsProvider {
   virtual std::string ServiceEndpoint() const = 0;
 
   virtual void Sign(detail::HttpRequestBase* req) const = 0;
-  // Returns true when the currently cached credentials should be refreshed
-  // before signing another request.
-  virtual bool IsExpired() const {
+
+  // Refreshes expiring credentials. Returns true if credentials were updated.
+  ABSL_MUST_USE_RESULT virtual io::Result<bool> RefreshIfExpiring() {
     return false;
   }
 
@@ -201,7 +205,7 @@ class CredentialsProvider {
   virtual bool ShouldRefreshToken(
       const boost::beast::http::response<boost::beast::http::string_body>& response) const;
 
-  virtual std::error_code RefreshToken() = 0;
+  ABSL_MUST_USE_RESULT virtual std::error_code RefreshToken() = 0;
 };
 
 struct StorageListItem {

--- a/util/cloud/utils.h
+++ b/util/cloud/utils.h
@@ -3,16 +3,16 @@
 
 #pragma once
 
-#include <string_view>
-
 #include <absl/functional/function_ref.h>
+
 #include <boost/beast/http/dynamic_body.hpp>
 #include <boost/beast/http/empty_body.hpp>
 #include <boost/beast/http/parser.hpp>
+#include <boost/beast/http/string_body.hpp>
 
+#include "io/file.h"
 #include "util/http/http_client.h"
 #include "util/http/https_client_pool.h"
-#include "io/file.h"
 
 #define RETURN_ERROR(x)                                          \
   do {                                                           \
@@ -190,6 +190,17 @@ class CredentialsProvider {
   virtual std::string ServiceEndpoint() const = 0;
 
   virtual void Sign(detail::HttpRequestBase* req) const = 0;
+  // Returns true when the currently cached credentials should be refreshed
+  // before signing another request.
+  virtual bool IsExpired() const {
+    return false;
+  }
+
+  // Returns true if the provider can refresh credentials to retry `response`.
+  // The default recognizes standard HTTP authentication challenges.
+  virtual bool ShouldRefreshToken(
+      const boost::beast::http::response<boost::beast::http::string_body>& response) const;
+
   virtual std::error_code RefreshToken() = 0;
 };
 


### PR DESCRIPTION
## Summary

- Refresh expired temporary AWS credentials before signing S3 requests.
- Serialize credential refreshes with a bounded, fiber-yielding wait and re-sign requests when credentials change.
- Treat S3 HTTP 400 `ExpiredToken` and `InvalidToken` as AWS-provider refresh-and-retry conditions.
- Add fake-S3 coverage for the expired-token retry path.

Fixes https://github.com/dragonflydb/dragonfly/issues/7666

## Tests

- `build-dbg/aws_creds_provider_test --logtostderr`
- `pytest -q tests/test_s3.py -k "upload_part or expired_token"`
