### PR TITLE
Azure: support URI-provided account

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,12 @@
 2.  **Implement:** Adhere strictly to Fiber Safety rules. Use smart pointers (`std::unique_ptr`) and RAII (`absl::Cleanup`).
 3.  **Verify:** Always run related tests and `ctest -L CI`.
 
+## 🐍 Python Integration Tests
+
+Before configuring or running tests under `tests/`, read and follow
+[`tests/README.md`](tests/README.md). It documents required binaries, Python dependencies, and the
+local Azurite setup used by the Azure integration tests.
+
 ## 📝 Git Commit Guidelines
 
 *   **Commit Title:** Maximum 70 characters. Use format: `Component: brief description`

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,53 @@
+# Python integration tests
+
+Run these commands from the repository root. Build the test binaries first:
+
+```bash
+ninja -C build-dbg echo_server gcs_demo
+```
+
+Install the Python dependencies used by the Azure tests:
+
+```bash
+python3 -m pip install pytest azure-storage-blob
+```
+
+## Azure tests
+
+The Azure tests use the Azurite Blob Storage emulator. Install it with the same command used in CI:
+
+```bash
+npm install -g azurite
+```
+
+Start Azurite in a separate terminal:
+
+```bash
+azurite-blob --blobHost 0.0.0.0 --skipApiVersionCheck
+```
+
+It listens on `http://127.0.0.1:10000`. Confirm it is ready before testing:
+
+```bash
+curl -sf http://127.0.0.1:10000/ ||
+  test "$(curl -so /dev/null -w '%{http_code}' http://127.0.0.1:10000/)" = 400
+```
+
+Run the Azure tests:
+
+```bash
+python3 -m pytest -q -s tests/test_azure.py
+```
+
+`test_azure.py` also starts and stops Azurite itself when `azurite-blob` is on `PATH`. Starting it
+manually is useful for inspecting emulator logs and matches the CI setup.
+
+## Running the full Python suite
+
+```bash
+python3 -m pytest -q -s tests
+```
+
+Tests that require an unavailable binary, service, or credentials skip themselves. Set
+`HELIO_BIN_DIR` to a directory containing built binaries when they are not under `build/` or
+`build-dbg/`.

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -98,14 +98,20 @@ def az_env() -> dict:
 
 
 @pytest.fixture(scope="module", autouse=True)
-def create_container(azurite, az_env):
-    """Ensure the test container exists in Azurite."""
-    from azure.core.exceptions import ResourceExistsError
+def az_client(azurite):
+    """Azure SDK client for independently verifying objects written by Helio."""
     from azure.storage.blob import BlobServiceClient
 
-    client = BlobServiceClient.from_connection_string(AZURITE_CONN_STR)
+    return BlobServiceClient.from_connection_string(AZURITE_CONN_STR)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def create_container(az_client):
+    """Ensure the test container exists in Azurite."""
+    from azure.core.exceptions import ResourceExistsError
+
     try:
-        client.create_container(CONTAINER)
+        az_client.create_container(CONTAINER)
     except ResourceExistsError:
         pass
 
@@ -139,6 +145,40 @@ def test_write_read(gcs_demo, az_env):
         gcs_demo,
         f"--bucket={CONTAINER}",
         f"--prefix={prefix}_0",
+        "--read=1",
+        env=az_env,
+    )
+    assert result.returncode == 0, f"read failed:\n{result.stderr}"
+    assert "Read" in result.stderr, result.stderr
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "space key",
+        "percent%key",
+        "query?key",
+        "fragment#key",
+        "r\u00e9sum\u00e9/\u65e5\u672c",
+        "repeated//slash///key",
+    ],
+)
+def test_write_read_escaped_object_key(gcs_demo, az_client, az_env, prefix):
+    """Read and write object keys whose path segments require URL encoding."""
+    object_key = f"{prefix}_0"
+    result = _run(
+        gcs_demo, f"--bucket={CONTAINER}", f"--prefix={prefix}", "--write=1", env=az_env
+    )
+    assert result.returncode == 0, f"write failed:\n{result.stderr}"
+    assert "Written" in result.stderr, result.stderr
+
+    blob = az_client.get_blob_client(container=CONTAINER, blob=object_key)
+    assert blob.get_blob_properties().size > 0
+
+    result = _run(
+        gcs_demo,
+        f"--bucket={CONTAINER}",
+        f"--prefix={object_key}",
         "--read=1",
         env=az_env,
     )

--- a/util/cloud/azure/CMakeLists.txt
+++ b/util/cloud/azure/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_library(azure_lib azure.cc storage.cc)
 cxx_link(azure_lib cloud_lib http_client_lib strings_lib TRDP::pugixml TRDP::rapidjson)
+helio_cxx_test(azure_creds_provider_test azure_lib LABELS CI)

--- a/util/cloud/azure/azure.cc
+++ b/util/cloud/azure/azure.cc
@@ -363,6 +363,12 @@ error_code Credentials::TryConnectionString() {
   if (info.account_name.empty()) {
     return make_error_code(errc::bad_message);
   }
+  if (!HasMatchingAccount(info.account_name)) {
+    return make_error_code(errc::invalid_argument);
+  }
+  if (!requested_account_name_.empty()) {
+    info = AccountInfoFromUri();
+  }
 
   if (!account_key.empty()) {
     SetSharedKey(CredSource::kConnectionString, std::move(info), std::move(account_key));
@@ -382,8 +388,15 @@ error_code Credentials::TryEnvSharedKey() {
   string sas = NormalizeSasQuery(GetEnvOrEmpty("AZURE_STORAGE_SAS_TOKEN"));
 
   AccountInfo info;
-  info.account_name = GetEnvOrEmpty("AZURE_STORAGE_ACCOUNT");
-  error_code ep_ec = ResolveServiceEndpointFromEnv(&info);
+
+  if (requested_account_name_.empty()) {
+    info.account_name = GetEnvOrEmpty("AZURE_STORAGE_ACCOUNT");
+  } else {
+    info = AccountInfoFromUri();
+  }
+
+  error_code ep_ec =
+      requested_account_name_.empty() ? ResolveServiceEndpointFromEnv(&info) : error_code{};
 
   if (!key.empty()) {
     if (info.account_name.empty() || ep_ec) {
@@ -406,8 +419,12 @@ error_code Credentials::TryEnvSharedKey() {
 
 error_code Credentials::TryManagedIdentity() {
   AccountInfo info;
-  info.account_name = GetEnvOrEmpty("AZURE_STORAGE_ACCOUNT");
-  RETURN_ERROR(ResolveServiceEndpointFromEnv(&info));
+  if (requested_account_name_.empty()) {
+    info.account_name = GetEnvOrEmpty("AZURE_STORAGE_ACCOUNT");
+    RETURN_ERROR(ResolveServiceEndpointFromEnv(&info));
+  } else {
+    info = AccountInfoFromUri();
+  }
 
   fb2::ProactorBase* pb = fb2::ProactorBase::me();
   CHECK(pb);
@@ -485,6 +502,19 @@ void Credentials::SetBearer(AccountInfo info, string token, unsigned ttl) {
   }
   const time_t now = time(nullptr);
   expire_time_.store(now + (ttl > 60 ? ttl - 60 : ttl), std::memory_order_release);
+}
+
+AccountInfo Credentials::AccountInfoFromUri() const {
+  return {
+      .service_endpoint = absl::StrCat(requested_account_name_, ".blob.", kDefaultEndpointSuffix),
+      .account_name = requested_account_name_,
+      .path_prefix = {},
+      .is_https = true};
+}
+
+bool Credentials::HasMatchingAccount(string_view account_name) const {
+  return requested_account_name_.empty() || account_name.empty() ||
+         absl::EqualsIgnoreCase(account_name, requested_account_name_);
 }
 
 string Credentials::NormalizeSasQuery(string_view query) {

--- a/util/cloud/azure/azure_creds_provider_test.cc
+++ b/util/cloud/azure/azure_creds_provider_test.cc
@@ -1,0 +1,146 @@
+// Copyright 2026, DragonflyDB authors.  All rights reserved.
+// See LICENSE for licensing terms.
+
+#include <gmock/gmock.h>
+
+#include <cstdlib>
+#include <optional>
+#include <string>
+
+#include "base/gtest.h"
+#include "util/cloud/azure/creds_provider.h"
+
+namespace util::cloud::azure {
+namespace {
+
+class ScopedEnv {
+ public:
+  explicit ScopedEnv(const char* name) : name_(name) {
+    if (const char* value = getenv(name); value) {
+      original_ = value;
+    }
+    unsetenv(name);
+  }
+
+  ~ScopedEnv() {
+    if (original_) {
+      setenv(name_, original_->c_str(), 1);
+    } else {
+      unsetenv(name_);
+    }
+  }
+
+ private:
+  const char* name_;
+  std::optional<std::string> original_;
+};
+
+}  // namespace
+
+class AzureCredentialsTest : public testing::Test {
+ protected:
+  ScopedEnv connection_string_{"AZURE_STORAGE_CONNECTION_STRING"};
+  ScopedEnv account_{"AZURE_STORAGE_ACCOUNT"};
+  ScopedEnv endpoint_{"AZURE_STORAGE_BLOB_ENDPOINT"};
+  ScopedEnv account_url_{"AZURE_STORAGE_ACCOUNT_URL"};
+  ScopedEnv sas_{"AZURE_STORAGE_SAS_TOKEN"};
+  ScopedEnv key_{"AZURE_STORAGE_KEY"};
+};
+
+TEST_F(AzureCredentialsTest, UsesUriAccountInsteadOfEnvironmentAccount) {
+  setenv("AZURE_STORAGE_KEY", "test-key", 1);
+  setenv("AZURE_STORAGE_ACCOUNT", "otheraccount", 1);
+
+  Credentials provider{"snapshotaccount"};
+  EXPECT_FALSE(provider.Init(1));
+  EXPECT_EQ(provider.account_name(), "snapshotaccount");
+  EXPECT_EQ(provider.ServiceEndpoint(), "snapshotaccount.blob.core.windows.net");
+}
+
+TEST_F(AzureCredentialsTest, ConnectionStringTakesPrecedenceOverEnvironmentCredentials) {
+  setenv("AZURE_STORAGE_CONNECTION_STRING",
+         " AccountName = connectionaccount ; AccountKey = connection-key ; "
+         "EndpointSuffix = private.example.test ",
+         1);
+  setenv("AZURE_STORAGE_ACCOUNT", "environmentaccount", 1);
+  setenv("AZURE_STORAGE_KEY", "environment-key", 1);
+
+  Credentials provider;
+  EXPECT_FALSE(provider.Init(1));
+  EXPECT_EQ(provider.account_name(), "connectionaccount");
+  EXPECT_EQ(provider.account_key(), "connection-key");
+  EXPECT_EQ(provider.ServiceEndpoint(), "connectionaccount.blob.private.example.test");
+  EXPECT_TRUE(provider.IsHttps());
+  EXPECT_TRUE(provider.GetPathPrefix().empty());
+}
+
+TEST_F(AzureCredentialsTest, ConnectionStringSupportsHttpPathStyleEndpoint) {
+  setenv("AZURE_STORAGE_CONNECTION_STRING",
+         "AccountName=devstoreaccount1;AccountKey=test-key;"
+         "BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1/",
+         1);
+
+  Credentials provider;
+  ASSERT_FALSE(provider.Init(1));
+  EXPECT_EQ(provider.account_name(), "devstoreaccount1");
+  EXPECT_EQ(provider.account_key(), "test-key");
+  EXPECT_EQ(provider.ServiceEndpoint(), "127.0.0.1:10000");
+  EXPECT_FALSE(provider.IsHttps());
+  EXPECT_EQ(provider.GetPathPrefix(), "/devstoreaccount1");
+}
+
+TEST_F(AzureCredentialsTest, BlobEndpointTakesPrecedenceOverAccountUrl) {
+  setenv("AZURE_STORAGE_ACCOUNT", "environmentaccount", 1);
+  setenv("AZURE_STORAGE_KEY", "environment-key", 1);
+  setenv("AZURE_STORAGE_BLOB_ENDPOINT", "https://blob.example.test:8443/blob-path/", 1);
+  setenv("AZURE_STORAGE_ACCOUNT_URL", "https://account-url.example.test/account-path", 1);
+
+  Credentials provider;
+  ASSERT_FALSE(provider.Init(1));
+  EXPECT_EQ(provider.account_name(), "environmentaccount");
+  EXPECT_EQ(provider.account_key(), "environment-key");
+  EXPECT_EQ(provider.ServiceEndpoint(), "blob.example.test:8443");
+  EXPECT_TRUE(provider.IsHttps());
+  EXPECT_EQ(provider.GetPathPrefix(), "/blob-path");
+}
+
+TEST_F(AzureCredentialsTest, AccountUrlIsUsedWhenBlobEndpointIsUnset) {
+  setenv("AZURE_STORAGE_ACCOUNT", "environmentaccount", 1);
+  setenv("AZURE_STORAGE_KEY", "environment-key", 1);
+  setenv("AZURE_STORAGE_ACCOUNT_URL", "https://account-url.example.test/account-path", 1);
+
+  Credentials provider;
+  ASSERT_FALSE(provider.Init(1));
+  EXPECT_EQ(provider.account_name(), "environmentaccount");
+  EXPECT_EQ(provider.account_key(), "environment-key");
+  EXPECT_EQ(provider.ServiceEndpoint(), "account-url.example.test");
+  EXPECT_TRUE(provider.IsHttps());
+  EXPECT_EQ(provider.GetPathPrefix(), "/account-path");
+}
+
+TEST_F(AzureCredentialsTest, SasTokenIsAppendedUnlessRequestAlreadyHasSignature) {
+  setenv("AZURE_STORAGE_ACCOUNT", "sasaccount", 1);
+  setenv("AZURE_STORAGE_SAS_TOKEN", " ?sv=2025-01-05&sig=token-signature ", 1);
+
+  Credentials provider;
+  ASSERT_FALSE(provider.Init(1));
+  EXPECT_EQ(provider.account_name(), "sasaccount");
+  EXPECT_TRUE(provider.account_key().empty());
+
+  detail::EmptyRequestImpl request{boost::beast::http::verb::get, "/container/blob?comp=list"};
+  provider.Sign(&request);
+  EXPECT_EQ(request.GetTarget(), "/container/blob?comp=list&sv=2025-01-05&sig=token-signature");
+  auto has_header = [](std::string_view name) {
+    return testing::Truly([name](const auto& header) { return header.name_string() == name; });
+  };
+  EXPECT_THAT(request.GetHeaders(), testing::Contains(has_header("x-ms-date")));
+  EXPECT_THAT(request.GetHeaders(), testing::Contains(has_header("x-ms-version")));
+  EXPECT_THAT(request.GetHeaders(), testing::Not(testing::Contains(has_header("Authorization"))));
+
+  detail::EmptyRequestImpl signed_request{boost::beast::http::verb::get,
+                                          "/container/blob?sig=existing-signature"};
+  provider.Sign(&signed_request);
+  EXPECT_EQ(signed_request.GetTarget(), "/container/blob?sig=existing-signature");
+}
+
+}  // namespace util::cloud::azure

--- a/util/cloud/azure/creds_provider.h
+++ b/util/cloud/azure/creds_provider.h
@@ -24,6 +24,10 @@ struct AccountInfo {
 
 class Credentials : public CredentialsProvider {
  public:
+  explicit Credentials(std::string account_name = {})
+      : requested_account_name_(std::move(account_name)) {
+  }
+
   enum class AuthMode { kNone, kSharedKey, kSas, kBearer };
 
   std::error_code Init(unsigned) final;
@@ -65,6 +69,9 @@ class Credentials : public CredentialsProvider {
   void SetSas(CredSource src, AccountInfo info, std::string sas);
   void SetBearer(AccountInfo info, std::string token, unsigned ttl);
 
+  AccountInfo AccountInfoFromUri() const;
+
+  bool HasMatchingAccount(std::string_view account_name) const;
   static std::string NormalizeSasQuery(std::string_view query);
 
   // Immutable after Init() — read by Sign() without locking.
@@ -73,6 +80,7 @@ class Credentials : public CredentialsProvider {
   AccountInfo account_info_;
   std::string account_key_;
   std::string sas_query_;
+  std::string requested_account_name_;
 
   // Mutable at runtime — protected by lock_ / atomic.
   mutable folly::RWSpinLock lock_;

--- a/util/cloud/azure/storage.cc
+++ b/util/cloud/azure/storage.cc
@@ -163,6 +163,27 @@ unique_ptr<http::ClientPool> CreatePool(const string& endpoint, SSL_CTX* ctx,
   return pool;
 }
 
+void AppendUrlEncodedPath(string_view path, string* dest) {
+  while (true) {
+    size_t separator = path.find('/');
+    strings::AppendUrlEncoded(path.substr(0, separator), dest);
+    if (separator == string_view::npos) {
+      return;
+    }
+    dest->push_back('/');
+    path.remove_prefix(separator + 1);
+  }
+}
+
+string BuildObjectUrl(string_view path_prefix, string_view container, string_view key) {
+  string url(path_prefix);
+  url += '/';
+  strings::AppendUrlEncoded(container, &url);
+  url += '/';
+  AppendUrlEncodedPath(key, &url);
+  return url;
+}
+
 detail::EmptyRequestImpl FillRequest(string_view endpoint, string_view url,
                                      CredentialsProvider* provider) {
   detail::EmptyRequestImpl req(h2::verb::get, url);
@@ -319,7 +340,7 @@ WriteFile::WriteFile(string_view path_prefix, string_view container, string_view
     : detail::AbstractStorageFile(key, 1UL << 23), opts_(std::move(opts)) {
   string endpoint = opts_.creds_provider->ServiceEndpoint();
   pool_ = CreatePool(endpoint, opts_.ssl_cntx, fb2::ProactorBase::me());
-  target_ = absl::StrCat(path_prefix, "/", container, "/", key);
+  target_ = BuildObjectUrl(path_prefix, container, key);
 }
 
 WriteFile::~WriteFile() {
@@ -485,14 +506,10 @@ error_code Storage::List(string_view container, std::string_view prefix, bool re
   return {};
 }
 
-string BuildGetObjUrl(string_view path_prefix, const string& container, const string& key) {
-  return absl::StrCat(path_prefix, "/", container, "/", key);
-}
-
 io::Result<io::ReadonlyFile*> OpenReadFile(const std::string& container, const std::string& key,
                                            const ReadFileOptions& opts) {
   DCHECK(opts.creds_provider);
-  string url = BuildGetObjUrl(opts.creds_provider->GetPathPrefix(), container, key);
+  string url = BuildObjectUrl(opts.creds_provider->GetPathPrefix(), container, key);
   return new ReadFile(url, opts);
 }
 


### PR DESCRIPTION
Allow Azure callers to provide the target account independently of `AZURE_STORAGE_ACCOUNT`.

- Resolve the endpoint and signing account from a caller-provided account name.
- Escape normalized Azure container/blob names in HTTP request targets.
- Cover URI-account credential precedence with a focused unit test.
