### PR TITLE
Azure: retain matching connection endpoint

### DIFF
--- a/examples/gcs_demo.cc
+++ b/examples/gcs_demo.cc
@@ -26,6 +26,9 @@ ABSL_FLAG(uint32_t, read, 0, "If read > 0, then read this many files from GCS");
 ABSL_FLAG(uint32_t, connect_ms, 2000, "");
 ABSL_FLAG(bool, epoll, false, "Whether to use epoll instead of io_uring");
 ABSL_FLAG(bool, azure, false, "Whether to use Azure instead of GCS");
+ABSL_FLAG(string, azure_account, "",
+          "URI-provided Azure storage account name. When set, it overrides the account name "
+          "otherwise derived from the connection string/environment.");
 
 static io::Result<string> ReadToString(io::ReadonlyFile* file) {
   string res_str;
@@ -120,7 +123,7 @@ void Run(SSL_CTX* ctx) {
 }
 
 void RunAzure(SSL_CTX* ctx) {
-  cloud::azure::Credentials provider;
+  cloud::azure::Credentials provider(GetFlag(FLAGS_azure_account));
   cloud::azure::Storage storage(&provider);
 
   error_code ec = provider.Init(1000);

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -97,6 +97,20 @@ def az_env() -> dict:
     return env
 
 
+@pytest.fixture(scope="module")
+def az_env_uri_account() -> dict:
+    """Environment with discrete (non-connection-string) Azurite credentials, plus a
+    mismatched AZURE_STORAGE_ACCOUNT and a custom AZURE_STORAGE_BLOB_ENDPOINT. Used to
+    verify that a URI-provided account name overrides the environment account while the
+    custom endpoint override is still honored."""
+    env = os.environ.copy()
+    env.pop("AZURE_STORAGE_CONNECTION_STRING", None)
+    env["AZURE_STORAGE_ACCOUNT"] = "not-the-real-account"
+    env["AZURE_STORAGE_KEY"] = AZURITE_KEY
+    env["AZURE_STORAGE_BLOB_ENDPOINT"] = f"http://127.0.0.1:{AZURITE_PORT}/{AZURITE_ACCOUNT}/"
+    return env
+
+
 @pytest.fixture(scope="module", autouse=True)
 def az_client(azurite):
     """Azure SDK client for independently verifying objects written by Helio."""
@@ -147,6 +161,36 @@ def test_write_read(gcs_demo, az_env):
         f"--prefix={prefix}_0",
         "--read=1",
         env=az_env,
+    )
+    assert result.returncode == 0, f"read failed:\n{result.stderr}"
+    assert "Read" in result.stderr, result.stderr
+
+
+def test_uri_account_overrides_env_with_custom_endpoint(gcs_demo, az_client, az_env_uri_account):
+    """A URI-provided account name should take precedence over AZURE_STORAGE_ACCOUNT while
+    the AZURE_STORAGE_BLOB_ENDPOINT override (Azurite) is still honored for connectivity."""
+    prefix = "helio-ci/uri-account"
+    result = _run(
+        gcs_demo,
+        f"--bucket={CONTAINER}",
+        f"--prefix={prefix}",
+        f"--azure_account={AZURITE_ACCOUNT}",
+        "--write=1",
+        env=az_env_uri_account,
+    )
+    assert result.returncode == 0, f"write failed:\n{result.stderr}"
+    assert "Written" in result.stderr, result.stderr
+
+    blob = az_client.get_blob_client(container=CONTAINER, blob=f"{prefix}_0")
+    assert blob.get_blob_properties().size > 0
+
+    result = _run(
+        gcs_demo,
+        f"--bucket={CONTAINER}",
+        f"--prefix={prefix}_0",
+        f"--azure_account={AZURITE_ACCOUNT}",
+        "--read=1",
+        env=az_env_uri_account,
     )
     assert result.returncode == 0, f"read failed:\n{result.stderr}"
     assert "Read" in result.stderr, result.stderr

--- a/util/cloud/azure/azure.cc
+++ b/util/cloud/azure/azure.cc
@@ -395,8 +395,7 @@ error_code Credentials::TryEnvSharedKey() {
     info = AccountInfoFromUri();
   }
 
-  error_code ep_ec =
-      requested_account_name_.empty() ? ResolveServiceEndpointFromEnv(&info) : error_code{};
+  error_code ep_ec = ResolveServiceEndpointFromEnv(&info);
 
   if (!key.empty()) {
     if (info.account_name.empty() || ep_ec) {
@@ -421,10 +420,10 @@ error_code Credentials::TryManagedIdentity() {
   AccountInfo info;
   if (requested_account_name_.empty()) {
     info.account_name = GetEnvOrEmpty("AZURE_STORAGE_ACCOUNT");
-    RETURN_ERROR(ResolveServiceEndpointFromEnv(&info));
   } else {
     info = AccountInfoFromUri();
   }
+  RETURN_ERROR(ResolveServiceEndpointFromEnv(&info));
 
   fb2::ProactorBase* pb = fb2::ProactorBase::me();
   CHECK(pb);

--- a/util/cloud/azure/azure_creds_provider_test.cc
+++ b/util/cloud/azure/azure_creds_provider_test.cc
@@ -89,6 +89,20 @@ TEST_F(AzureCredentialsTest, ConnectionStringSupportsHttpPathStyleEndpoint) {
   EXPECT_EQ(provider.GetPathPrefix(), "/devstoreaccount1");
 }
 
+TEST_F(AzureCredentialsTest, UriAccountUsesEndpointOverride) {
+  setenv("AZURE_STORAGE_ACCOUNT", "otheraccount", 1);
+  setenv("AZURE_STORAGE_KEY", "test-key", 1);
+  setenv("AZURE_STORAGE_BLOB_ENDPOINT", "http://127.0.0.1:10000/devstoreaccount1/", 1);
+
+  Credentials provider{"devstoreaccount1"};
+  ASSERT_FALSE(provider.Init(1));
+  EXPECT_EQ(provider.account_name(), "devstoreaccount1");
+  EXPECT_EQ(provider.account_key(), "test-key");
+  EXPECT_EQ(provider.ServiceEndpoint(), "127.0.0.1:10000");
+  EXPECT_FALSE(provider.IsHttps());
+  EXPECT_EQ(provider.GetPathPrefix(), "/devstoreaccount1");
+}
+
 TEST_F(AzureCredentialsTest, BlobEndpointTakesPrecedenceOverAccountUrl) {
   setenv("AZURE_STORAGE_ACCOUNT", "environmentaccount", 1);
   setenv("AZURE_STORAGE_KEY", "environment-key", 1);


### PR DESCRIPTION
Use the URI as the Azure account identity while retaining `AZURE_STORAGE_BLOB_ENDPOINT` for custom transport endpoints.

This allows canonical Azure Blob URLs to select an account without `AZURE_STORAGE_ACCOUNT`, including path-style emulator endpoints such as Azurite. Add focused coverage with a deliberately conflicting environment account, both as a unit test and as an Azurite-backed integration test (`tests/test_azure.py`) driven through a new `--azure_account` flag on `gcs_demo`.