### PR TITLE
feat(tls): Split TryRecv EAGAIN vs EBUSY; park reads behind bg writes

### DIFF
--- a/util/tls/tls_socket.cc
+++ b/util/tls/tls_socket.cc
@@ -193,8 +193,9 @@ auto TlsSocket::Close() -> error_code {
 
   if (state_ & (WRITE_IN_PROGRESS | READ_IN_PROGRESS | SHUTDOWN_IN_PROGRESS)) {
     fb2::NoOpLock lk;
-    block_concurrent_cv_.wait(
-        lk, [this] { return (state_ & (WRITE_IN_PROGRESS | READ_IN_PROGRESS | SHUTDOWN_IN_PROGRESS)) == 0; });
+    block_concurrent_cv_.wait(lk, [this] {
+      return (state_ & (WRITE_IN_PROGRESS | READ_IN_PROGRESS | SHUTDOWN_IN_PROGRESS)) == 0;
+    });
   }
 
   return res;
@@ -390,6 +391,19 @@ auto TlsSocket::MaybeSendOutput() -> error_code {
   return HandleUpstreamWrite();
 }
 
+void TlsSocket::ClearInProgressAndNotify(uint8_t bit) {
+  // Only the two bits other fibers actually wait on should go through here.
+  DCHECK(bit == WRITE_IN_PROGRESS || bit == READ_IN_PROGRESS);
+  // Clearing a bit that was not set means the caller lost track of state - treat it as a bug.
+  DCHECK(state_ & bit);
+  state_ &= ~bit;
+  // Why notify_all: more than one fiber can be parked here on different predicates.
+  // notify_one could wake a fiber whose predicate is still false while leaving another
+  // whose predicate is now true asleep. Every waiter uses wait(lock, pred), so the extra wakeups
+  // are just re-checked and harmless.
+  block_concurrent_cv_.notify_all();
+}
+
 auto TlsSocket::HandleUpstreamRead() -> error_code {
   if (engine_->OutputPending() != 0) {
     // Normally output is flushed before the read path needs upstream data, or a concurrent
@@ -416,10 +430,7 @@ auto TlsSocket::HandleUpstreamRead() -> error_code {
 
   auto mut_buf = engine_->PeekInputBuf();
   state_ |= READ_IN_PROGRESS;
-  auto guard = absl::MakeCleanup([this] {
-    state_ &= ~READ_IN_PROGRESS;
-    block_concurrent_cv_.notify_one();
-  });
+  auto guard = absl::MakeCleanup([this] { ClearInProgressAndNotify(READ_IN_PROGRESS); });
 
   io::Result<size_t> esz = next_sock_->Recv(mut_buf, 0);
   if (!esz) {
@@ -471,8 +482,7 @@ error_code TlsSocket::HandleUpstreamWrite() {
 
   DCHECK(engine_->OutputPending() == 0 || ec);
 
-  state_ &= ~WRITE_IN_PROGRESS;
-  block_concurrent_cv_.notify_one();
+  ClearInProgressAndNotify(WRITE_IN_PROGRESS);
 
   return ec;
 }
@@ -517,6 +527,9 @@ void TlsSocket::CancelOnErrorCb() {
 
 void TlsSocket::RegisterOnRecv(OnRecvCb cb) {
   DCHECK(cb);
+  // Keep a copy so a recv-path engine-output drain completion (StartDrainEngineOutput) can wake the
+  // reader on its own, without waiting for new next_sock_ activity.
+  on_recv_cb_ = cb;
   next_sock_->RegisterOnRecv(
       [recv_cb = std::move(cb), this](const RecvNotification& rn) { OnRecv(rn, recv_cb); });
 }
@@ -549,6 +562,39 @@ void TlsSocket::OnRecv(const RecvNotification& rn, const OnRecvCb& recv_cb) {
     return;
   }
   LOG(FATAL) << "Unhandled type in RecvNotification::read_result variant";
+}
+
+void TlsSocket::StartAsyncWrite(io::AsyncProgressCb async_write_cb) {
+  // Hard CHECK: overwriting a live async_write_req_ would free an AsyncReq still referenced by
+  // in-flight AsyncWriteSome callbacks (use-after-free). Callers guarantee no write is in flight
+  // (TrySend/TryRecv bail out early on WRITE_IN_PROGRESS), so this never fires in correct runs.
+  CHECK(!async_write_req_);
+  DCHECK_GT(engine_->OutputPending(), 0u);
+  // (vec, len) = (nullptr, 0): no new user bytes, we only send what the engine already buffered.
+  // AsyncRoleBasedAction treats a WRITER with vec_ == nullptr as output-only and ends when drained.
+  async_write_req_ =
+      std::make_unique<AsyncReq>(this, std::move(async_write_cb), nullptr, 0, AsyncReq::WRITER);
+  async_write_req_->StartUpstreamWrite();
+}
+
+void TlsSocket::StartDrainEngineOutput() {
+  // Preconditions (no write in flight, output pending) are checked by StartAsyncWrite.
+  // Mark the recv-path engine-output drain as in flight before it starts: while it holds
+  // WRITE_IN_PROGRESS, TryRecv must surface EAGAIN (a wake IS coming via on_recv_cb_) rather than
+  // EBUSY. Cleared below when the write completes.
+  state_ |= RECV_DRAIN_ENGINE_IN_FLIGHT;
+  StartAsyncWrite([this](io::Result<size_t> res) {
+    state_ &= ~RECV_DRAIN_ENGINE_IN_FLIGHT;
+    if (!on_recv_cb_) {
+      // No recv callback registered (blocking Recv() path, or a TryRecv() caller that retries on
+      // its own) - nobody to wake. This is fine, not an error.
+      return;
+    }
+    if (res)
+      on_recv_cb_(RecvNotification{RecvNotification::RecvCompletion{true}});
+    else
+      on_recv_cb_(RecvNotification{res.error()});
+  });
 }
 
 io::Result<size_t> TlsSocket::TrySend(io::Bytes buf) {
@@ -697,14 +743,10 @@ io::Result<size_t> TlsSocket::TrySend(const iovec* v, uint32_t len) {
       DVSOCK(3) << "TrySend success but OutputPending=" << engine_output_pending
                 << ". Offloading TLS engine's flush to background.";
 
-      // Create a "Detached" AsyncReq with nullptr vec (no user data). We only want to flush the
-      // engine's output buffer in the background.
-      auto dummy_cb = [](io::Result<size_t>) {};
-      auto req =
-          std::make_unique<AsyncReq>(this, std::move(dummy_cb), nullptr, 0, AsyncReq::WRITER);
-      DCHECK(!async_write_req_);
-      async_write_req_ = std::move(req);
-      async_write_req_->StartUpstreamWrite();
+      // Background write: the user treats a full write as done and may not call us again, so drain
+      // the engine output in the background. No reader is waiting on this write, so it needs no
+      // wake.
+      StartAsyncWrite([](io::Result<size_t>) {});
     }
 
     return total_bytes_sent;
@@ -746,18 +788,25 @@ io::Result<size_t> TlsSocket::TryRecv(io::MutableBytes buf) {
     } else if ((read_result == Engine::NEED_READ_AND_MAYBE_WRITE) ||
                (read_result == Engine::NEED_WRITE)) {  // case 2: Handle NEED_READ/WRITE
       ///////////////////////////////////////////////////////////////
-      // 1. Check for a write conflict:
+      // Check for a write conflict:
       // Write conflicts are expected: The TLS state machine (e.g., renegotiation) may trigger
       // writes during a read operation.
       if (write_in_progress) {
-        // Another fiber is handling TLS writes (handshake/renegotiation);
-        // we cannot safely proceed without blocking this read fiber.
-        // Return partial data if available, or signal retry (EAGAIN) to caller.
-        returned_status = make_error_code(errc::resource_unavailable_try_again);
+        if (state_ & RECV_DRAIN_ENGINE_IN_FLIGHT) {
+          // The in-flight write is THIS socket's own recv-path engine-output drain, so a wake IS
+          // coming: surface EAGAIN, not EBUSY. See TryRecv's result-code contract in tls_socket.h.
+          returned_status = make_error_code(errc::resource_unavailable_try_again);
+        } else {
+          // A genuinely concurrent, non-waking write from another context is using the socket, so
+          // we could not read this time and NO wake is coming: return EBUSY so the caller keeps
+          // expecting input and retries on a later pass. See TryRecv's result-code contract in
+          // tls_socket.h.
+          returned_status = make_error_code(errc::device_or_resource_busy);
+        }
         break;
       }
       ///////////////////////////////////////////////////////////////
-      // 2. Handle Pending Output from TLs engine to upstream socket (write_in_progress is false)
+      // Handle Pending Output from TLS engine to upstream socket (write_in_progress is false)
       // If the engine generated TLS data (handshake/alerts), flush it now.
       // Otherwise, skip to reading.
       size_t output_pending_bytes{engine_->OutputPending()};
@@ -767,18 +816,32 @@ io::Result<size_t> TlsSocket::TryRecv(io::MutableBytes buf) {
         auto output_buf{engine_->PeekOutputBuf()};
         auto send_result{next_sock_->TrySend(output_buf)};
         if (!send_result) {
-          // Write failed (EAGAIN or Error).
-
-          returned_status = send_result.error();
+          // Nothing was sent, so we never got to the actual read.
+          auto send_ec = send_result.error();
+          if (send_ec == errc::resource_unavailable_try_again ||
+              send_ec == errc::operation_would_block) {
+            // Send buffer is full: drain this engine's output in a background write and return
+            // EAGAIN. That write's completion re-arms the read via the recv callback, so a wake IS
+            // coming - the caller may clear its pending-input flag and park. See TryRecv's
+            // result-code contract in tls_socket.h.
+            StartDrainEngineOutput();
+            returned_status = make_error_code(errc::resource_unavailable_try_again);
+          } else {
+            returned_status = send_ec;
+          }
           break;
         }
         engine_->ConsumeOutputBuf(*send_result);
 
-        // If we couldn't send everything, we can't proceed safely.
+        // Partial send: the buffer filled mid-write, so the rest of our output is still stuck and
+        // we never reached the read. Same handling as the full-block case above - trigger a
+        // background write and return EAGAIN (a wake is coming via the recv callback). Log at debug
+        // only - this is normal backpressure, not an error.
         if ((*send_result) < output_buf.size()) {
+          StartDrainEngineOutput();
           returned_status = make_error_code(errc::resource_unavailable_try_again);
-          LOG(WARNING) << "TlsSocket::TrySend: partial next_sock_->TrySend: sent" << (*send_result)
-                       << " out of " << output_buf.size() << " bytes. breaking...";
+          DVSOCK(1) << "TlsSocket::TryRecv: partial upstream send " << (*send_result) << "/"
+                    << output_buf.size() << " bytes; started background engine-output drain";
           break;
         }
 
@@ -789,12 +852,15 @@ io::Result<size_t> TlsSocket::TryRecv(io::MutableBytes buf) {
       ///////////////////////////////////////////////////////////////
 
       ///////////////////////////////////////////////////////////////
-      // 3. Handle Pending Reads From Upstream Socket
+      // Handle Pending Reads From Upstream Socket
       // An internal read (blocking) might be in progress from another fiber (e.g. during a
       // write). This is not a user error, but a temporary resource contention.
       if ((state_ & READ_IN_PROGRESS) != 0) {
-        DVSOCK(3) << "TryRecv conflict with internal read in progress, returning EAGAIN";
-        returned_status = make_error_code(errc::resource_unavailable_try_again);
+        // A read is using the socket, so we could not read this call. The reason does not matter:
+        // data may still be waiting, so return EBUSY and the caller keeps expecting input. See
+        // TryRecv's result-code contract in tls_socket.h.
+        DVSOCK(3) << "TryRecv conflict with internal read in progress, returning busy";
+        returned_status = make_error_code(errc::device_or_resource_busy);
         break;
       }
       ///////////////////////////////////////////////////////////////
@@ -818,8 +884,12 @@ io::Result<size_t> TlsSocket::TryRecv(io::MutableBytes buf) {
         break;
       }
 
-      // recv_result has an error (e.g. EAGAIN)
-      returned_status = recv_result.error();
+      // Kernel read failed. Normalize would-block to EAGAIN (the contract's single "drained, stop
+      // expecting input" code, see tls_socket.h); any other error is fatal - propagate as-is.
+      auto recv_ec = recv_result.error();
+      if (recv_ec == errc::operation_would_block)
+        recv_ec = make_error_code(errc::resource_unavailable_try_again);
+      returned_status = recv_ec;
       break;
     } else if (read_result == Engine::EOF_ABRUPT) {  // case 3: Abrupt EOF
       // The engine detected an abrupt/dirty EOF (no close_notify) from peer.
@@ -893,7 +963,7 @@ void TlsSocket::AsyncReq::MaybeSendOutputAsyncWithRead() {
 }
 
 void TlsSocket::AsyncReq::AsyncReadProgressCb(io::Result<size_t> read_result) {
-  owner_->state_ &= ~READ_IN_PROGRESS;
+  owner_->ClearInProgressAndNotify(READ_IN_PROGRESS);
   RunPending();
   if (!read_result) {
     // Erronous path. Apply the completion callback and exit.
@@ -996,7 +1066,7 @@ void TlsSocket::AsyncReadSome(const iovec* v, uint32_t len, io::AsyncProgressCb 
 
 void TlsSocket::AsyncReq::AsyncWriteProgressCb(io::Result<size_t> write_result) {
   if (!write_result) {
-    owner_->state_ &= ~WRITE_IN_PROGRESS;
+    owner_->ClearInProgressAndNotify(WRITE_IN_PROGRESS);
 
     // broken_pipe - happens when the other side closes the connection. do not log this.
     if (write_result.error() != errc::broken_pipe) {
@@ -1034,7 +1104,7 @@ void TlsSocket::AsyncReq::AsyncWriteProgressCb(io::Result<size_t> write_result) 
                 << " bytes. Async short write detected";
   }
 
-  owner_->state_ &= ~WRITE_IN_PROGRESS;
+  owner_->ClearInProgressAndNotify(WRITE_IN_PROGRESS);
   RunPending();
 
   // We are done with the write, check if we also need to read because we are

--- a/util/tls/tls_socket.cc
+++ b/util/tls/tls_socket.cc
@@ -397,7 +397,7 @@ void TlsSocket::ClearInProgressAndNotify(uint8_t mask) {
   // Clearing a mask that was not set means the caller lost track of state - treat it as a bug.
   DCHECK(state_ & mask);
   state_ &= ~mask;
-  // Why notify_all: more than one fiber can be parked here on different predicates.
+  // Why notify_all: more than one fiber can be parked on on block_concurrent_cv_ in different places and on different predicates.
   // notify_one could wake a fiber whose predicate is still false while leaving another
   // whose predicate is now true asleep. Every waiter uses wait(lock, pred), so the extra wakeups
   // are just re-checked and harmless.
@@ -536,6 +536,11 @@ void TlsSocket::RegisterOnRecv(OnRecvCb cb) {
 }
 
 void TlsSocket::OnRecv(const RecvNotification& rn, const OnRecvCb& recv_cb) {
+  // The recv hook can fire once more after ResetOnRecvHook() has cleared on_recv_cb_, if a
+  // notification from next_sock_ was already in flight
+  if (!recv_cb) {
+    return;
+  }
   if ((std::holds_alternative<RecvNotification::RecvCompletion>(rn.read_result)) ||
       (std::holds_alternative<std::error_code>(rn.read_result))) {
     recv_cb(rn);

--- a/util/tls/tls_socket.cc
+++ b/util/tls/tls_socket.cc
@@ -391,12 +391,12 @@ auto TlsSocket::MaybeSendOutput() -> error_code {
   return HandleUpstreamWrite();
 }
 
-void TlsSocket::ClearInProgressAndNotify(uint8_t bit) {
-  // Only the two bits other fibers actually wait on should go through here.
-  DCHECK(bit == WRITE_IN_PROGRESS || bit == READ_IN_PROGRESS);
-  // Clearing a bit that was not set means the caller lost track of state - treat it as a bug.
-  DCHECK(state_ & bit);
-  state_ &= ~bit;
+void TlsSocket::ClearInProgressAndNotify(uint8_t mask) {
+  // Only the two masks other fibers actually wait on should go through here.
+  DCHECK(mask == WRITE_IN_PROGRESS || mask == READ_IN_PROGRESS);
+  // Clearing a mask that was not set means the caller lost track of state - treat it as a bug.
+  DCHECK(state_ & mask);
+  state_ &= ~mask;
   // Why notify_all: more than one fiber can be parked here on different predicates.
   // notify_one could wake a fiber whose predicate is still false while leaving another
   // whose predicate is now true asleep. Every waiter uses wait(lock, pred), so the extra wakeups
@@ -527,11 +527,12 @@ void TlsSocket::CancelOnErrorCb() {
 
 void TlsSocket::RegisterOnRecv(OnRecvCb cb) {
   DCHECK(cb);
-  // Keep a copy so a recv-path engine-output drain completion (StartDrainEngineOutput) can wake the
-  // reader on its own, without waiting for new next_sock_ activity.
-  on_recv_cb_ = cb;
-  next_sock_->RegisterOnRecv(
-      [recv_cb = std::move(cb), this](const RecvNotification& rn) { OnRecv(rn, recv_cb); });
+  // Note: It is vital to store the callback only once (avoid copy!). Both wake paths - the
+  // next_sock_ recv hook (via OnRecv) and a recv-path engine-output drain completion
+  // (StartDrainEngineOutput) - invoke this single copy, so a callback that carries state by value
+  // cannot diverge between two independent copies.
+  on_recv_cb_ = std::move(cb);
+  next_sock_->RegisterOnRecv([this](const RecvNotification& rn) { OnRecv(rn, on_recv_cb_); });
 }
 
 void TlsSocket::OnRecv(const RecvNotification& rn, const OnRecvCb& recv_cb) {

--- a/util/tls/tls_socket.h
+++ b/util/tls/tls_socket.h
@@ -175,10 +175,10 @@ class TlsSocket final : public FiberSocketBase {
   // read-retry RecvCompletion on success, the error on failure), which re-arms the deferred read.
   void StartDrainEngineOutput();
 
-  // Clears an in-progress bit (WRITE_IN_PROGRESS or READ_IN_PROGRESS) and wakes any fiber waiting
-  // for it in block_concurrent_cv_, so an async completion can't leave a sync waiter stuck. Bits
+  // Clears an in-progress mask (WRITE_IN_PROGRESS or READ_IN_PROGRESS) and wakes any fiber waiting
+  // for it in block_concurrent_cv_, so an async completion can't leave a sync waiter stuck. Masks
   // nobody waits on are cleared directly.
-  void ClearInProgressAndNotify(uint8_t bit);
+  void ClearInProgressAndNotify(uint8_t mask);
 
   std::unique_ptr<FiberSocketBase> next_sock_;
   std::unique_ptr<Engine> engine_;

--- a/util/tls/tls_socket.h
+++ b/util/tls/tls_socket.h
@@ -90,9 +90,30 @@ class TlsSocket final : public FiberSocketBase {
 
   virtual void RegisterOnRecv(OnRecvCb cb) override;
   virtual void ResetOnRecvHook() override {
+    on_recv_cb_ = {};
     next_sock_->ResetOnRecvHook();
   }
 
+  // Result-code contract for the non-blocking TrySend / TryRecv. A returned code describes the
+  // socket's state, not what the caller must do. One correctness rule matters for reads: TryRecv
+  // can report a short-read or EBUSY WITHOUT reaching the kernel, so unread bytes may still be
+  // buffered out of the caller's sight - it must keep expecting input and retry until it gets a
+  // clean EAGAIN, otherwise it may hang waiting for a reply that is never read.
+  //   * >0: progress this call, but possibly short and NOT a completion signal - more data/room
+  //     may still be pending (in the kernel or the TLS engine). Keep the operation live and retry
+  //     later, even without a new readiness notification.
+  //   * resource_unavailable_try_again (EAGAIN):
+  //     - TryRecv: nothing to read now, but a wake IS coming - safe to stop expecting input and
+  //     park (only if a recv callback was registered via RegisterOnRecv; otherwise poll-retry).
+  //     Covers both a drained kernel and output that TryRecv had to defer to a background write.
+  //     - TrySend: generic "would block, retry later" (full send buffer, or local TLS concurrency).
+  //   * device_or_resource_busy (EBUSY): TryRecv only - a genuinely concurrent, non-waking
+  //     context (another fiber's in-progress write or read) holds the socket, so the kernel was
+  //     not consulted and, unlike EAGAIN, NO wake is coming. This holds unconditionally: the
+  //     socket's OWN recv-path engine-output drain is NOT reported here - its completion re-arms
+  //     the read via the recv callback, so that write surfaces EAGAIN above. Keep expecting input
+  //     and retry on a later pass (not a tight loop); do not park.
+  //   * connection_reset / broken_pipe / etc.: fatal - the connection is gone - propagate.
   io::Result<size_t> TrySend(io::Bytes buf) override;
   io::Result<size_t> TrySend(const iovec* v, uint32_t len) override;
   io::Result<size_t> TryRecv(io::MutableBytes buf) override;
@@ -143,9 +164,29 @@ class TlsSocket final : public FiberSocketBase {
 
   void OnRecv(const RecvNotification& rn, const OnRecvCb& recv_cb);
 
+  // Starts a background write that sends the engine's already-buffered output to next_sock_ and
+  // calls `async_write_cb` when it finishes (or errors). Used by TrySend and TryRecv to drain
+  // output they could not send inline. Precondition: no async write is already in flight.
+  void StartAsyncWrite(io::AsyncProgressCb async_write_cb);
+
+  // Called from TryRecv when the engine's output it had to send first did not fit in the socket
+  // buffer. Starts a background write (via StartAsyncWrite) to drain that engine output; TryRecv
+  // itself returns EAGAIN. When the write finishes it wakes the reader through on_recv_cb_ (a
+  // read-retry RecvCompletion on success, the error on failure), which re-arms the deferred read.
+  void StartDrainEngineOutput();
+
+  // Clears an in-progress bit (WRITE_IN_PROGRESS or READ_IN_PROGRESS) and wakes any fiber waiting
+  // for it in block_concurrent_cv_, so an async completion can't leave a sync waiter stuck. Bits
+  // nobody waits on are cleared directly.
+  void ClearInProgressAndNotify(uint8_t bit);
+
   std::unique_ptr<FiberSocketBase> next_sock_;
   std::unique_ptr<Engine> engine_;
   size_t upstream_write_ = 0;
+
+  // Stored recv callback (from RegisterOnRecv) so a recv-path engine-output drain completion can
+  // trigger a read-retry or error notification.
+  OnRecvCb on_recv_cb_;
 
   enum {
     WRITE_IN_PROGRESS = 1,
@@ -153,6 +194,8 @@ class TlsSocket final : public FiberSocketBase {
     SHUTDOWN_IN_PROGRESS = 1 << 2,
     SHUTDOWN_DONE = 1 << 3,
     USER_RECV_IN_PROGRESS = 1 << 4,
+    // A recv-path background write draining the engine's output is in flight.
+    RECV_DRAIN_ENGINE_IN_FLIGHT = 1 << 5,
   };
   uint8_t state_{0};
 

--- a/util/tls/tls_socket_test.cc
+++ b/util/tls/tls_socket_test.cc
@@ -24,8 +24,12 @@
 
 #ifdef __linux__
 #include <fcntl.h>
+#include <netinet/tcp.h>
 #include <sys/socket.h>
 #include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
 
 #include "util/fibers/uring_proactor.h"
 #include "util/fibers/uring_socket.h"
@@ -89,6 +93,13 @@ class TlsSocketTest : public testing::TestWithParam<string_view> {
   void SetUp() final;
   void TearDown() final;
   void CreateClientSocket(std::unique_ptr<tls::TlsSocket>& client_sock);
+
+#if defined(__linux__)
+  // Returns true when kTLS is available. If false, the caller should GTEST_SKIP() the kTLS test.
+  // Before returning false (unavailable) it performs some required operations so the caller can
+  // skip without TearDown() hanging. Usage: if (!KTlsAvailable()) GTEST_SKIP() << "...";
+  bool KTlsAvailable();
+#endif
 
   using IoResult = int;
 
@@ -157,7 +168,15 @@ void TlsSocketTest::SetUp() {
     ssl_ctx_ = CreateSslCntx(SERVER);
     server_socket_->InitSSL(ssl_ctx_);
     auto tls_accept = server_socket_->Accept();
-    CHECK(tls_accept) << "Tls Accept error: " << tls_accept.error();
+    if (!tls_accept) {
+      // A client can legitimately drop the connection mid-handshake (e.g. the
+      // KtlsClientFdApiFeasibility test tears down its raw client when kTLS is unavailable). Record
+      // the error and exit the fiber instead of CHECK. tests that need the server socket will then
+      // fail their own assertions gracefully.
+      accept_ec_ = tls_accept.error();
+      LOG(WARNING) << "Tls Accept error: " << tls_accept.error();
+      return;
+    }
   });
 }
 
@@ -165,7 +184,8 @@ void TlsSocketTest::TearDown() {
   VLOG(1) << "TearDown";
 
   proactor_->Await([&] {
-    std::ignore = listen_socket_->Shutdown(SHUT_RDWR);
+    if (listen_socket_->IsOpen())
+      std::ignore = listen_socket_->Shutdown(SHUT_RDWR);
     if (server_socket_) {
       server_socket_->CancelOnErrorCb();
       std::ignore = server_socket_->Shutdown(SHUT_RDWR);
@@ -198,8 +218,72 @@ void TlsSocketTest::CreateClientSocket(std::unique_ptr<tls::TlsSocket>& client_s
 }
 
 #if defined(__linux__)
-// Requires ktls module support, can be checked with `modinfo tls` and `lsmod | grep tls`.
+// Detects whether kernel-TLS (kTLS) is usable, without opening a live connection.
+// The KtlsClientFdApiFeasibility test below needs kTLS. Some environments lack it (e.g. a dev
+// laptop whose kernel has no `tls` module), so that test skips instead of hard-failing there.
+static bool IsKernelTlsAvailable() {
+#if defined(OPENSSL_NO_KTLS)
+  // OpenSSL was built without kTLS, so it can never be used here -> not available.
+  return false;
+#elif defined(TCP_ULP)
+  int fd = ::socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP);
+  if (fd < 0)
+    return false;  // Can't even create a probe socket -> treat kTLS as unavailable.
+
+  // Try to attach the "tls" ULP on an unconnected socket: rc == 0 or ENOTCONN => the kernel
+  // `tls` module is present; ENOENT/EOPNOTSUPP => it is absent.
+  int rc = ::setsockopt(fd, IPPROTO_TCP, TCP_ULP, "tls", sizeof("tls"));
+  int err = errno;
+  ::close(fd);
+
+  bool ktls_module_loaded = (rc == 0) || (err == ENOTCONN);
+  return ktls_module_loaded;  // true => kTLS present, false => kTLS absent.
+#else
+  // No TCP_ULP in the headers -> this platform can't use/probe kTLS -> not available.
+  return false;
+#endif
+}
+
+bool TlsSocketTest::KTlsAvailable() {
+  if (IsKernelTlsAvailable())
+    return true;  // kTLS is present: do not skip.
+
+  // kTLS unavailable -> caller GTEST_SKIP()s. SetUp() parked accept_fb_ in Accept() and on uring
+  // TearDown()'s Shutdown() won't cancel that poll, so release it here: connect a throwaway client
+  // (AcceptFb accepts it, its handshake fails, the fiber exits), then join. If the probe can't
+  // connect, force-close the listener (closing the fd cancels the accept) so teardown can't hang.
+  int probe_fd = ::socket(listen_ep_.protocol().family(), SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP);
+  int probe_err = errno;  // socket() error, if it failed
+  bool released = false;
+  if (probe_fd >= 0) {
+    released = ::connect(probe_fd, reinterpret_cast<const sockaddr*>(listen_ep_.data()),
+                         listen_ep_.size()) == 0;
+    probe_err = errno;  // capture connect()'s errno before close() can overwrite it
+    ::close(probe_fd);
+  }
+  if (!released) {
+    // force-close the listener so the parked accept_fb_ is released and teardown cannot hang.
+    LOG(WARNING) << "kTLS-skip probe failed to connect (" << strerror(probe_err)
+                 << "); force-closing the listener to release accept_fb_.";
+    proactor_->Await([&] { std::ignore = listen_socket_->Close(); });
+  }
+  accept_fb_.JoinIfNeeded();
+
+  return false;  // caller should GTEST_SKIP().
+}
+
+// Note for user - if you want to check whether a machine has kTLS yourself, run these shell
+// commands:
+// - `modinfo tls`      -> shows info if the `tls` kernel module exists on the system.
+// - `lsmod | grep tls` -> shows whether that module is currently loaded.
+// The test itself detects kTLS at runtime via IsKernelTlsAvailable().
 TEST_P(TlsSocketTest, KtlsClientFdApiFeasibility) {
+  // Skip (rather than fail) where kTLS can't work; on supporting envs the assertions below run.
+  if (!KTlsAvailable()) {
+    GTEST_SKIP() << "Kernel TLS (kTLS) not available in this environment; "
+                 << "skipping the kTLS feasibility test.";
+  }
+
   SSL_CTX* client_ctx = CreateSslCntx(CLIENT);
   auto client_ctx_guard = absl::MakeCleanup([&] { SSL_CTX_free(client_ctx); });
   SSL_CTX_set_options(client_ctx, SSL_OP_ENABLE_KTLS);
@@ -213,7 +297,10 @@ TEST_P(TlsSocketTest, KtlsClientFdApiFeasibility) {
   ASSERT_EQ(rc, 0) << "connect() failed: " << strerror(errno);
 
   SSL* ssl = SSL_new(client_ctx);
-  auto ssl_guard = absl::MakeCleanup([&] { std::ignore = SSL_shutdown(ssl); SSL_free(ssl); });
+  auto ssl_guard = absl::MakeCleanup([&] {
+    std::ignore = SSL_shutdown(ssl);
+    SSL_free(ssl);
+  });
   ASSERT_NE(ssl, nullptr);
   ASSERT_EQ(SSL_set_fd(ssl, client_fd), 1);
 
@@ -251,7 +338,6 @@ TEST_P(TlsSocketTest, KtlsClientFdApiFeasibility) {
   rc = SSL_read(ssl, client_buf.data(), client_buf.size());
   ASSERT_GT(rc, 0);
   ASSERT_EQ(string_view(client_buf.data(), rc), server_msg);
-
 }
 
 // Reproduces SSL_ERROR_WANT_WRITE on the read path while WRITE_IN_PROGRESS is set.
@@ -277,8 +363,8 @@ TEST_P(TlsSocketTest, Tls13KeyUpdateNeedWrite) {
   ASSERT_GE(fd, 0);
   auto fd_guard = absl::MakeCleanup([&] { ::close(fd); });
 
-  ASSERT_EQ(
-      0, ::connect(fd, reinterpret_cast<const sockaddr*>(listen_ep_.data()), listen_ep_.size()));
+  ASSERT_EQ(0,
+            ::connect(fd, reinterpret_cast<const sockaddr*>(listen_ep_.data()), listen_ep_.size()));
 
   SSL_CTX* ctx = SSL_CTX_new(TLS_client_method());
   auto ctx_guard = absl::MakeCleanup([&] { SSL_CTX_free(ctx); });
@@ -289,7 +375,10 @@ TEST_P(TlsSocketTest, Tls13KeyUpdateNeedWrite) {
   SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nullptr);
 
   SSL* ssl = SSL_new(ctx);
-  auto ssl_guard = absl::MakeCleanup([&] { SSL_shutdown(ssl); SSL_free(ssl); });
+  auto ssl_guard = absl::MakeCleanup([&] {
+    SSL_shutdown(ssl);
+    SSL_free(ssl);
+  });
   SSL_set_fd(ssl, fd);
 
   // Blocking handshake on the test thread; the proactor thread handles the server side.
@@ -358,7 +447,7 @@ TEST_P(TlsSocketTest, Tls13KeyUpdateNeedWrite) {
   LOG(INFO) << "Closing client connection";
   { auto _ = std::move(ssl_guard); }  // SSL_shutdown + SSL_free (non-blocking, may be EAGAIN)
   LOG(INFO) << "ssl_guard destroyed, closing fd";
-  { auto _ = std::move(fd_guard); }   // close() → RST due to unread data
+  { auto _ = std::move(fd_guard); }  // close() → RST due to unread data
   LOG(INFO) << "fd_guard destroyed (RST sent), waiting for server fibers";
 
   // Watchdog: if the server fibers don't unblock within 10s, dump all fiber stacks and abort.
@@ -379,7 +468,7 @@ TEST_P(TlsSocketTest, Tls13KeyUpdateNeedWrite) {
   watchdog_done.Notify();
   watchdog_fb.Join();
 }
-#endif
+#endif  // #if defined(__linux__)
 
 TEST_P(TlsSocketTest, ShortWrite) {
   std::unique_ptr<tls::TlsSocket> client_sock;
@@ -874,7 +963,7 @@ class AsyncTlsSocketNeedWrite : public AsyncTlsSocketTest {
 };
 
 #if 0
-// TODO once we fix epoll AsyncRead from blocking to nonblocking investiage why it fails on mac,
+// TODO once we fix epoll AsyncRead from blocking to nonblocking investigate why it fails on mac,
 // For now also disable this on mac altogether.
 #ifdef __linux__
 
@@ -939,7 +1028,7 @@ TEST_P(AsyncTlsSocketNeedWrite, AsyncReadNeedWrite) {
 }
 
 #endif
-#endif
+#endif  // #if 0
 
 class AsyncTlsSocketTestPartialRW : public AsyncTlsSocketTest {
  protected:
@@ -1100,7 +1189,7 @@ TEST_P(AsyncTlsSocketRenegotiate, Renegotiate) {
       opts);
 }
 
-#endif
+#endif  // #ifdef __linux__
 
 }  // namespace fb2
 }  // namespace util
@@ -1180,7 +1269,10 @@ struct TryRecvScenario {
   std::string test_name;
 
   // Initial Conditions
-  uint32_t initial_state{};  // e.g., TlsSocket::WRITE_IN_PROGRESS
+  // e.g., TlsSocket::WRITE_IN_PROGRESS, or WRITE_IN_PROGRESS | RECV_DRAIN_ENGINE_IN_FLIGHT to model
+  // the socket's OWN recv-path engine-output drain (whose completion wakes the reader via
+  // on_recv_cb_, so TryRecv must surface EAGAIN instead of EBUSY).
+  uint32_t initial_state{};
 
   // Engine Behavior
   Engine::OpResult engine_read_ret;  // What engine_->Read() returns
@@ -1270,7 +1362,6 @@ TEST_P(MockTlsSocketTest, HandshakeThenWrite) {
     // Execution
     ASSERT_TRUE(sock_->Accept());
     ASSERT_FALSE(sock_->Write(io::Bytes(buf, sizeof(buf))));
-
   });
 }
 
@@ -1407,10 +1498,31 @@ INSTANTIATE_TEST_SUITE_P(
         // Case 0: Write Conflict
         // Scenario: A write operation (e.g., handshake) is already in progress on another fiber.
         // The Engine requests a read/write op, but we cannot proceed safely due to concurrency.
-        // Expected: Should back off immediately and return EAGAIN (resource_unavailable_try_again).
+        // We never looked at the kernel, so unread data may still be pending there.
+        // Expected: Back off immediately and return device_or_resource_busy (NOT
+        // resource_unavailable_try_again/EAGAIN) so the caller keeps its pending-input latch and
+        // retries once the write completes.
         TryRecvScenario{
-            .test_name = "WriteConflict_ReturnsTryAgain",
+            .test_name = "WriteConflict_ReturnsBusy",
             .initial_state = TestDelegator::GetWriteInProgress(),
+            .engine_read_ret = Engine::NEED_READ_AND_MAYBE_WRITE,
+            .sock_send_ret = std::nullopt,
+            .sock_recv_ret = std::nullopt,
+            .expected_error = std::make_error_code(std::errc::device_or_resource_busy),
+        },
+
+        // Case 0b: Own Recv-Path Engine-Output Drain In Flight
+        // Scenario: WRITE_IN_PROGRESS is set, but the in-flight write is THIS socket's own
+        // recv-path engine-output drain (started by a prior TryRecv to flush engine output). Unlike
+        // a genuinely concurrent writer, its completion invokes on_recv_cb_, so a wake IS coming.
+        // Expected: resource_unavailable_try_again (EAGAIN), NOT device_or_resource_busy/EBUSY -
+        // this is the ONLY WRITE_IN_PROGRESS case that guarantees a wake, so the caller may drop
+        // its pending-input latch and park instead of busy-retrying (which would otherwise spin the
+        // V2 IO loop, since the loop must yield for the background write to complete).
+        TryRecvScenario{
+            .test_name = "OwnRecvDrainEngine_ReturnsTryAgain",
+            .initial_state = TestDelegator::GetWriteInProgress() |
+                             TestDelegator::GetDrainEngineInFlightBit(),
             .engine_read_ret = Engine::NEED_READ_AND_MAYBE_WRITE,
             .sock_send_ret = std::nullopt,
             .sock_recv_ret = std::nullopt,
@@ -1420,9 +1532,12 @@ INSTANTIATE_TEST_SUITE_P(
         // Case 1: Engine Needs Write -> Socket EAGAIN
         // Scenario: The TLS Engine generated data (e.g. renegotiation) and requests a flush.
         // We attempt to write to the underlying socket, but it returns EAGAIN (socket buffer full).
-        // Expected: We must propagate the EAGAIN to the caller so they can retry later.
+        // We never reached the kernel read, so there might still be data waiting.
+        // Expected: resource_unavailable_try_again (EAGAIN), NOT device_or_resource_busy/EBUSY -
+        // TryRecv started a background write to flush that output and its completion re-arms the
+        // read via the recv callback, so a wake is coming and the caller may drop its latch/park.
         TryRecvScenario{
-            .test_name = "EngineNeedWrite_SocketEagain",
+            .test_name = "EngineNeedWrite_SocketEagain_ReturnsTryAgain",
             .initial_state = 0,
             .engine_read_ret = Engine::NEED_WRITE,
             .engine_output_pending = 100,
@@ -1434,10 +1549,12 @@ INSTANTIATE_TEST_SUITE_P(
 
         // Case 2: Engine Needs Write -> Socket Short Write
         // Scenario: The TLS Engine has 100 bytes pending. The underlying socket only accepts 50.
-        // Since we haven't flushed the full TLS record, we cannot proceed to the read phase safely.
-        // Expected: Return EAGAIN to the caller to indicate the operation is incomplete.
+        // We never reached the kernel read, so there might still be data waiting.
+        // Expected: resource_unavailable_try_again (EAGAIN), NOT device_or_resource_busy/EBUSY -
+        // TryRecv started a background write to flush the remainder and its completion re-arms the
+        // read via the recv callback, so a wake is coming and the caller may drop its latch/park.
         TryRecvScenario{
-            .test_name = "EngineNeedWrite_ShortWrite",
+            .test_name = "EngineNeedWrite_ShortWrite_ReturnsTryAgain",
             .initial_state = 0,
             .engine_read_ret = Engine::NEED_WRITE,
             .engine_output_pending = 100,
@@ -1476,6 +1593,23 @@ INSTANTIATE_TEST_SUITE_P(
             .expected_error = std::make_error_code(std::errc::connection_reset),
         },
 
+        // Case 4b: Engine Needs Read -> Socket EAGAIN (genuinely drained kernel)
+        // Scenario: The engine needs more ciphertext, we reach the real kernel read, and it returns
+        // EAGAIN. The socket is genuinely empty - nothing is pending.
+        // Expected: Stay resource_unavailable_try_again (NOT device_or_resource_busy/EBUSY). This
+        // is the counterpart to Case 0: it is the ONLY path that actually consulted the kernel, so
+        // the caller is allowed to drop its pending-input latch here.
+        TryRecvScenario{
+            .test_name = "UpstreamSocketEagain_ReturnsTryAgain",
+            .initial_state = 0,
+            .engine_read_ret = Engine::NEED_READ_AND_MAYBE_WRITE,
+            .engine_output_pending = 0,
+            .sock_send_ret = std::nullopt,
+            .sock_recv_ret = io::Result<size_t>(nonstd::make_unexpected(
+                std::make_error_code(std::errc::resource_unavailable_try_again))),
+            .expected_error = std::make_error_code(std::errc::resource_unavailable_try_again),
+        },
+
         // Case 5: Abrupt Stream EOF from Engine
         // Scenario: The TLS Engine itself detects a fatal error (e.g. bad MAC, protocol violation)
         // or an abrupt closure and returns EOF_ABRUPT.
@@ -1493,15 +1627,12 @@ INSTANTIATE_TEST_SUITE_P(
         // Case 6: Graceful Stream EOF from Engine
         // Scenario: The TLS Engine receives a "close_notify" alert.
         // Expected: Return success with 0 bytes to indicate a clean EOF.
-        TryRecvScenario{
-            .test_name = "EngineEOFGraceful_ReturnsZero",
-            .initial_state = 0,
-            .engine_read_ret = Engine::EOF_GRACEFUL,
-            .engine_output_pending = 0,
-            .sock_send_ret = std::nullopt,
-            .sock_recv_ret = std::nullopt,
-            .expected_error = std::error_code{},  // Default generic error_code = Success (0)
-            .expected_bytes = 0                   // Standard EOF return
+        TryRecvScenario {
+          .test_name = "EngineEOFGraceful_ReturnsZero", .initial_state = 0,
+          .engine_read_ret = Engine::EOF_GRACEFUL, .engine_output_pending = 0,
+          .sock_send_ret = std::nullopt, .sock_recv_ret = std::nullopt,
+          .expected_error = std::error_code{},  // Default generic error_code = Success (0)
+              .expected_bytes = 0               // Standard EOF return
         }
 
 #if defined(NDEBUG) && !defined(DCHECK_ALWAYS_ON)
@@ -1509,15 +1640,17 @@ INSTANTIATE_TEST_SUITE_P(
         // Scenario: A read operation is already in progress. In Release builds
         // (where DCHECK is compiled out), the code must not crash but instead handle the
         // concurrency error gracefully.
-        // Expected: The runtime check should detect the conflict and return EAGAIN.
+        // Expected: The runtime check should detect the conflict and return device_or_resource_busy
+        // (a concurrent read holds the socket, so data may still be pending - same "busy" contract
+        // as the write-conflict case).
         ,  // <-- Comma to continue the list
         TryRecvScenario{
-            .test_name = "ReadConflict_ReturnsTryAgain",
+            .test_name = "ReadConflict_ReturnsBusy",
             .initial_state = TestDelegator::GetReadInProgress(),
             .engine_read_ret = Engine::NEED_READ_AND_MAYBE_WRITE,
             .sock_send_ret = std::nullopt,
             .sock_recv_ret = std::nullopt,
-            .expected_error = std::make_error_code(std::errc::resource_unavailable_try_again),
+            .expected_error = std::make_error_code(std::errc::device_or_resource_busy),
         }
 #endif
         ));
@@ -1894,8 +2027,13 @@ TEST_P(TrySendAsyncFlushTest, OffloadsStrandedDataToAsync) {
       EXPECT_CALL(*mock_engine_, ConsumeOutputBuf(50));
 
       // E. Offload Trigger Check
-      // Loop breaks. Code checks if pending > 0 to decide on offload to an async write.
-      EXPECT_CALL(*mock_engine_, OutputPending()).WillOnce(testing::Return(50));
+      // Loop breaks. Code checks if pending > 0 to decide on offload to an async write. TrySend
+      // reads OutputPending() once here, and StartAsyncWrite() reads it again in a debug-only
+      // DCHECK_GT - so allow >=1 calls, otherwise DCHECK builds over-saturate this WillOnce and the
+      // mock returns the default 0, tripping the DCHECK.
+      EXPECT_CALL(*mock_engine_, OutputPending())
+          .Times(testing::AtLeast(1))
+          .WillRepeatedly(testing::Return(50));
 
       // F. Async Preparation
       // Code Peeks buffer *before* calling AsyncWriteSome
@@ -2052,6 +2190,217 @@ TEST_F(TlsSocketShutdownTest, ShutdownRaceCrash) {
 
     // Join the shutdown fiber to ensure all work is done before test exit.
     shutdown_fiber.Join();
+  });
+}
+
+// Regression (Mock) tests: the TLS read path must never force its caller into a hot loop.
+//
+// Why this can happen (the bug these guard against):
+//   TryRecv() sometimes has to SEND before it can read. While decrypting an incoming record the
+//   TLS engine can produce outbound control bytes (a TLS 1.3 KeyUpdate ack, a renegotiation
+//   record, an alert). TryRecv first tries to push that output with a non-blocking
+//   next_sock_->TrySend(). If the kernel send buffer is full, that send returns EAGAIN, so TryRecv
+//   cannot read this call.
+//
+//   If TryRecv just reported "try again" and did nothing else, a caller that retries would spin at
+//   100% CPU: nobody is waiting for the socket to become writable, so every retry repeats the same
+//   failed send. Instead TlsSocket sends the stuck output on its own background write (the same
+//   AsyncReq(WRITER) / MaybeSendOutputAsync machinery TrySend already uses) and returns EAGAIN,
+//   which tells the caller "a wake is coming - you may park": when that write completes it WAKES
+//   the read path through the RegisterOnRecv notification.
+//
+// These tests validate that contract:
+//   1. A read that must send its output first (but the send buffer is full) returns EAGAIN and
+//      starts exactly ONE background write; an immediate retry, with that same engine-output drain
+//      still in flight, ALSO returns EAGAIN (its completion re-arms the read via the recv callback,
+//      so a wake IS coming) - not EBUSY - so a retrying caller keeps parking for the wake instead
+//      of spinning, and no second write is started. (EBUSY is reserved for a genuinely concurrent
+//      writer that does NOT wake the reader - see the WriteConflict_ReturnsBusy mock scenario.)
+//   2. When the background write completes, the reader is woken with a read-retry notification.
+//   3. When the background write fails, the reader is woken with the ERROR - not a fake "readable".
+//   4. A recv with NO recv callback still completes cleanly when the drain write finishes - no
+//      crash, the background write drains the engine output, and the wake is simply dropped.
+class TlsSocketRecvDrainEngineOutputTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    proactor_ = std::make_unique<fb2::EpollProactor>();
+    thread_ = std::thread{[this] {
+      fb2::InitProactor(proactor_.get());
+      proactor_->Run();
+    }};
+    proactor_->Await([&] {
+      auto next = std::make_unique<testing::NiceMock<MockFiberSocket>>();
+      next_ = next.get();
+      // under test: sock_ is a tls socket wrapping next
+      sock_ = std::make_unique<TlsSocket>(std::move(next));
+      auto eng = std::make_unique<testing::NiceMock<MockEngine>>();
+      engine_ = eng.get();
+      TestDelegator::SetEngine(sock_.get(), std::move(eng));  // inject the fake engine
+
+      // All four tests start from the same state - a read that must send its output first but
+      // whose send buffer is full - so set it up once here. The background write's completion is
+      // captured into drain_engine_output_completed_cb_ for the tests that complete it.
+      SetupRecvDrainEngineOutput();
+    });
+  }
+
+  void TearDown() override {
+    proactor_->Await([&] {
+      TestDelegator::SetState(sock_.get(), 0);  // clear flags so ~TlsSocket's DCHECK passes
+      std::ignore = sock_->Close();
+    });
+    proactor_->Stop();
+    if (thread_.joinable())
+      thread_.join();
+  }
+
+  // Sets up the mocks so the next TryRecv() must drain the engine output via a background write:
+  // the engine wants to send kPending bytes first (NEED_WRITE), the synchronous TrySend() is full
+  // (EAGAIN), and the background AsyncWriteSome() is captured into
+  // drain_engine_output_completed_cb_ so a test can complete it later. Engine output is modeled
+  // statefully (ConsumeOutputBuf shrinks it), so once the captured write drains it, PeekOutputBuf()
+  // is empty and the background write finishes without restarting.
+  void SetupRecvDrainEngineOutput() {
+    pending_bytes_ = kPending;
+
+    EXPECT_CALL(*engine_, Read(testing::_, testing::_))
+        .WillRepeatedly(testing::Return(Engine::NEED_WRITE));
+    ON_CALL(*engine_, OutputPending()).WillByDefault(testing::Invoke([this] {
+      return pending_bytes_;
+    }));
+    ON_CALL(*engine_, PeekOutputBuf()).WillByDefault(testing::Invoke([this] {
+      return pending_bytes_ > 0 ? Engine::Buffer(out_, pending_bytes_) : Engine::Buffer(nullptr, 0);
+    }));
+    ON_CALL(*engine_, ConsumeOutputBuf(testing::_))
+        .WillByDefault(testing::Invoke([this](unsigned n) {
+          ASSERT_LE(n, pending_bytes_);
+          pending_bytes_ -= n;
+        }));
+
+    // Sync send inside TryRecv fails: send buffer full. Times(1) also pins that the retry does NOT
+    // re-drive this send (it returns EBUSY at the WRITE_IN_PROGRESS check first).
+    EXPECT_CALL(*next_, TrySend(testing::_))
+        .Times(1)
+        .WillOnce(testing::Return(io::Result<size_t>(nonstd::make_unexpected(
+            std::make_error_code(std::errc::resource_unavailable_try_again)))));
+
+    // The stuck output goes to a background write; capture its completion cb so a test can simulate
+    // "socket became writable" later.
+    EXPECT_CALL(*next_, AsyncWriteSome(testing::_, testing::_, testing::_))
+        .Times(1)
+        .WillOnce(testing::Invoke([this](const iovec*, uint32_t, io::AsyncProgressCb cb) {
+          drain_engine_output_completed_cb_ = std::move(cb);
+        }));
+  }
+
+  static constexpr size_t kPending = 100;
+  static constexpr size_t kOutBufSize = 512;
+
+  std::unique_ptr<fb2::ProactorBase> proactor_;
+  std::thread thread_;
+  std::unique_ptr<TlsSocket> sock_;
+  MockEngine* engine_ = nullptr;
+  MockFiberSocket* next_ = nullptr;
+  size_t pending_bytes_ = 0;
+  uint8_t out_[kOutBufSize] = {};
+  io::AsyncProgressCb drain_engine_output_completed_cb_;  // completion cb of the background write
+};
+
+// (1) A read that must send first (send buffer full) returns EAGAIN and starts exactly one
+// background write. An immediate retry, while that same engine-output drain is in flight, ALSO
+// returns EAGAIN (its completion re-arms the read via the recv callback, so a wake IS coming) - not
+// EBUSY - and no second write is driven. This is what prevents the busy loop: a retrying caller
+// keeps getting "a wake is coming / park" rather than "busy / keep retrying". (EBUSY is reserved
+// for a genuinely concurrent writer that does not wake the reader - see WriteConflict_ReturnsBusy
+// in the mock scenarios above.)
+TEST_F(TlsSocketRecvDrainEngineOutputTest, StartsOneBackgroundWriteThenRetryIsTryAgain) {
+  proactor_->Await([&] {
+    uint8_t buf[128];
+    // First call can't read (must send first, send is full) -> EAGAIN (a wake is coming when the
+    // background write it starts completes), and starts exactly one background write.
+    auto r1 = sock_->TryRecv(io::MutableBytes(buf, sizeof(buf)));
+    ASSERT_FALSE(r1);
+    EXPECT_EQ(r1.error(), std::errc::resource_unavailable_try_again);
+
+    // Retry while that same engine-output drain is still in flight: its completion will wake the
+    // reader, so this call also gets EAGAIN (not EBUSY), and no second write is started
+    // (AsyncWriteSome is Times(1)).
+    auto r2 = sock_->TryRecv(io::MutableBytes(buf, sizeof(buf)));
+    ASSERT_FALSE(r2);
+    EXPECT_EQ(r2.error(), std::errc::resource_unavailable_try_again);
+  });
+}
+
+// (2) When the background write completes, the reader is woken with a read-retry notification.
+TEST_F(TlsSocketRecvDrainEngineOutputTest, BackgroundWriteCompletionWakesReader) {
+  proactor_->Await([&] {
+    std::optional<bool> got_data_wake;       // set on a RecvCompletion (read-retry) notification
+    std::optional<std::error_code> got_err;  // set on an error notification
+    sock_->RegisterOnRecv([&](const FiberSocketBase::RecvNotification& n) {
+      if (std::holds_alternative<FiberSocketBase::RecvNotification::RecvCompletion>(n.read_result))
+        got_data_wake = std::get<FiberSocketBase::RecvNotification::RecvCompletion>(n.read_result);
+      else if (auto* ec = std::get_if<std::error_code>(&n.read_result))
+        got_err = *ec;
+    });
+
+    uint8_t buf[128];
+    // Starts the background write, returns EAGAIN (a wake is coming on its completion).
+    ASSERT_FALSE(sock_->TryRecv(io::MutableBytes(buf, sizeof(buf))));
+    ASSERT_TRUE(drain_engine_output_completed_cb_) << "no background write was started";
+
+    // Simulating the kernel reporting the background write finished: the write drains all kPending
+    // bytes; the stateful mock then reports empty output, so it completes.
+    drain_engine_output_completed_cb_(io::Result<size_t>(kPending));
+
+    // Success must produce a READ-RETRY wake so the caller re-drives the read.
+    EXPECT_TRUE(got_data_wake.has_value()) << "reader was not woken after the background write";
+    EXPECT_FALSE(got_err.has_value());
+  });
+}
+
+// (3) When the background write fails, the failure is delivered as an error - not a fake readable.
+TEST_F(TlsSocketRecvDrainEngineOutputTest, BackgroundWriteFailureReportsErrorNotFakeReadable) {
+  proactor_->Await([&] {
+    std::optional<bool> got_data_wake;       // set on a RecvCompletion (read-retry) notification
+    std::optional<std::error_code> got_err;  // set on an error notification
+    sock_->RegisterOnRecv([&](const FiberSocketBase::RecvNotification& n) {
+      if (std::holds_alternative<FiberSocketBase::RecvNotification::RecvCompletion>(n.read_result))
+        got_data_wake = std::get<FiberSocketBase::RecvNotification::RecvCompletion>(n.read_result);
+      else if (auto* ec = std::get_if<std::error_code>(&n.read_result))
+        got_err = *ec;
+    });
+
+    uint8_t buf[128];
+    // Starts the background write, returns EAGAIN (a wake is coming on its completion).
+    ASSERT_FALSE(sock_->TryRecv(io::MutableBytes(buf, sizeof(buf))));
+    ASSERT_TRUE(drain_engine_output_completed_cb_);
+
+    // Simulating the kernel reporting the background write finished:
+    // In this case the background write failed (peer reset). The reader must learn the ERROR, not a
+    // fake "readable" event that would send it back to decrypt data that never arrived.
+    drain_engine_output_completed_cb_(io::Result<size_t>(
+        nonstd::make_unexpected(std::make_error_code(std::errc::connection_reset))));
+
+    ASSERT_TRUE(got_err.has_value()) << "background write error was not surfaced to the reader";
+    EXPECT_EQ(*got_err, std::errc::connection_reset);
+    EXPECT_FALSE(got_data_wake.has_value()) << "an error must not masquerade as a readable event";
+  });
+}
+
+// (4) A recv with NO recv callback still completes cleanly when the drain write finishes: no crash
+// and the engine output is drained. The wake is just dropped (a legitimate raw-TryRecv use).
+TEST_F(TlsSocketRecvDrainEngineOutputTest, WithoutRecvHookCompletesCleanly) {
+  proactor_->Await([&] {
+    // Intentionally do NOT call RegisterOnRecv(): there is no on_recv_cb_ to notify.
+    uint8_t buf[128];
+    // Starts the background write, returns EAGAIN.
+    ASSERT_FALSE(sock_->TryRecv(io::MutableBytes(buf, sizeof(buf))));
+    ASSERT_TRUE(drain_engine_output_completed_cb_) << "no background write was started";
+
+    // Completing the background write must run to completion without crashing, even with no recv
+    // callback registered - the wake is simply dropped. It drains the engine's pending output.
+    drain_engine_output_completed_cb_(io::Result<size_t>(kPending));
+    EXPECT_EQ(pending_bytes_, 0u);
   });
 }
 

--- a/util/tls/tls_socket_test.cc
+++ b/util/tls/tls_socket_test.cc
@@ -251,7 +251,7 @@ bool TlsSocketTest::KTlsAvailable() {
   // kTLS unavailable -> caller GTEST_SKIP()s. SetUp() parked accept_fb_ in Accept() and on uring
   // TearDown()'s Shutdown() won't cancel that poll, so release it here: connect a throwaway client
   // (AcceptFb accepts it, its handshake fails, the fiber exits), then join. If the probe can't
-  // connect, force-close the listener (closing the fd cancels the accept) so teardown can't hang.
+  // connect, shut the listener down (Shutdown wakes the parked Accept) so teardown can't hang.
   int probe_fd = ::socket(listen_ep_.protocol().family(), SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP);
   int probe_err = errno;  // socket() error, if it failed
   bool released = false;
@@ -262,10 +262,17 @@ bool TlsSocketTest::KTlsAvailable() {
     ::close(probe_fd);
   }
   if (!released) {
-    // force-close the listener so the parked accept_fb_ is released and teardown cannot hang.
+    // The probe could not connect, so no client will unblock accept_fb_. Shut the listener down to
+    // release it: Shutdown() sets IS_SHUTDOWN and wakes the fiber parked in the synchronous
+    // Accept() (EpollSocket::Close() alone cancels only async requests, so it would NOT wake a
+    // synchronous Accept() and JoinIfNeeded() below could hang). Then close the fd.
     LOG(WARNING) << "kTLS-skip probe failed to connect (" << strerror(probe_err)
-                 << "); force-closing the listener to release accept_fb_.";
-    proactor_->Await([&] { std::ignore = listen_socket_->Close(); });
+                 << "); shutting down the listener to release accept_fb_.";
+    proactor_->Await([&] {
+      if (listen_socket_->IsOpen())
+        std::ignore = listen_socket_->Shutdown(SHUT_RDWR);
+      std::ignore = listen_socket_->Close();
+    });
   }
   accept_fb_.JoinIfNeeded();
 
@@ -1626,13 +1633,12 @@ INSTANTIATE_TEST_SUITE_P(
 
         // Case 6: Graceful Stream EOF from Engine
         // Scenario: The TLS Engine receives a "close_notify" alert.
-        // Expected: Return success with 0 bytes to indicate a clean EOF.
+        // Expected: Return success with 0 bytes to indicate a clean EOF (empty error_code == 0).
         TryRecvScenario {
           .test_name = "EngineEOFGraceful_ReturnsZero", .initial_state = 0,
           .engine_read_ret = Engine::EOF_GRACEFUL, .engine_output_pending = 0,
           .sock_send_ret = std::nullopt, .sock_recv_ret = std::nullopt,
-          .expected_error = std::error_code{},  // Default generic error_code = Success (0)
-              .expected_bytes = 0               // Standard EOF return
+          .expected_error = std::error_code{}, .expected_bytes = 0,
         }
 
 #if defined(NDEBUG) && !defined(DCHECK_ALWAYS_ON)

--- a/util/tls/tls_test_infra.h
+++ b/util/tls/tls_test_infra.h
@@ -33,6 +33,9 @@ class TestDelegator {
   static constexpr uint32_t GetReadInProgress() {
     return TlsSocket::READ_IN_PROGRESS;
   }
+  static constexpr uint32_t GetDrainEngineInFlightBit() {
+    return TlsSocket::RECV_DRAIN_ENGINE_IN_FLIGHT;
+  }
   static void SetSsl(Engine& engine, SSL* ssl) {
     engine.ssl_ = ssl;
   }


### PR DESCRIPTION
TryRecv returned EAGAIN for every "not now" case, so the caller could
not tell an empty socket from one busy behind another fiber. Give each
case a code that answers one question - will you be woken?

- EAGAIN: not readable now, but a wake IS coming, so the caller may
  drop pending input and park. Covers an empty kernel read, and the
  case where TryRecv must flush engine output first but the send buffer
  is full - it starts a background write whose completion re-arms the
  read via the recv callback. A retry while that drain is still in
  flight (RECV_DRAIN_ENGINE_IN_FLIGHT) also gets EAGAIN, since it too
  will wake the reader.
- EBUSY: a genuinely concurrent, non-waking context (another fiber's
  write or read) holds the socket and no wake is coming. The caller
  keeps expecting input and retries later, not in a tight loop.

This split also fixes a possible hang/busy-loop: the stuck output is
now flushed on a background write instead of being dropped, and the
RECV_DRAIN_ENGINE_IN_FLIGHT bit makes a re-entrant TryRecv park for the
completion wake instead of spinning.

Tests: add TlsSocketRecvDrainEngineOutputTest covering the drain path
(EAGAIN on read and retry, a wake on write success, an error wake on
failure, clean finish with no recv callback), and update the TryRecv
scenario tests for the EAGAIN/EBUSY split.

Signed-off-by: Gil Levkovich <69595609+glevkovich@users.noreply.github.com>