### PR TITLE
refactor(tls): cleanup pass before real refactor

### DIFF
--- a/util/tls/tls_socket.cc
+++ b/util/tls/tls_socket.cc
@@ -70,21 +70,21 @@ auto TlsSocket::Shutdown(int how) -> error_code {
   Engine::OpResult op_result = engine_->Shutdown();
 
   // TODO: this flow is hacky and should be reworked.
-  // 1. If we are blocked on writes, then MaybeSendOutput() will block as well and shutdown
-  // might deadlock. but if we do not call MaybeSendOutput, then the peer will not get
+  // 1. If we are blocked on writes, then MaybeSendEngineOutput() will block as well and shutdown
+  // might deadlock. but if we do not call MaybeSendEngineOutput, then the peer will not get
   // the close_notify message.
   // Furthermore, the call `next_sock_->Shutdown` below can race with sending close_notify
   // message.
-  // For now we just try to call MaybeSendOutput only if there is no ongoing write.
+  // For now we just try to call MaybeSendEngineOutput only if there is no ongoing write.
   if (op_result && (state_ & WRITE_IN_PROGRESS) == 0) {
     // engine_ could send notification messages to the peer.
-    std::ignore = MaybeSendOutput();
+    std::ignore = MaybeSendEngineOutput();
   }
 
   // In any case we should also shutdown the underlying TCP socket without relying on the
   // the peer. This unblocks any sync operations (like Recv) that are waiting for data. It could be
-  // that when we are in the middle of MaybeSendOutput, and the other fiber calls Close() on this
-  // socket. In this case next_sock_ will be closed by the time we reach this line, so we omit
+  // that when we are in the middle of MaybeSendEngineOutput, and the other fiber calls Close() on
+  // this socket. In this case next_sock_ will be closed by the time we reach this line, so we omit
   // calling Shutdown(). It's not the best behavior, but it's also not disastrous either, because
   // such interaction happens only during the server shutdown.
   error_code res;
@@ -117,9 +117,9 @@ auto TlsSocket::Accept() -> AcceptResult {
     }
 
     // it is important to send output (protocol errors) before we return from this function.
-    error_code ec = MaybeSendOutput();
+    error_code ec = MaybeSendEngineOutput();
     if (ec) {
-      VSOCK(1) << "MaybeSendOutput failed " << ec;
+      VSOCK(1) << "MaybeSendEngineOutput failed " << ec;
       return make_unexpected(ec);
     }
 
@@ -137,7 +137,7 @@ auto TlsSocket::Accept() -> AcceptResult {
       break;
     }
 
-    ec = HandleOp(op_result);
+    ec = HandleEngineOp(op_result);
     if (ec)
       return make_unexpected(ec);
   }
@@ -163,14 +163,14 @@ error_code TlsSocket::Connect(const endpoint_type& endpoint,
     }
 
     // Flush pending output.
-    RETURN_ON_ERROR(MaybeSendOutput());
+    RETURN_ON_ERROR(MaybeSendEngineOutput());
 
     if (op_result == 1) {
       break;
     }
 
     // Flush the ssl data to the socket and run the loop that ensures handshaking converges.
-    RETURN_ON_ERROR(HandleOp(op_result));
+    RETURN_ON_ERROR(HandleEngineOp(op_result));
   }
 
   const SSL_CIPHER* cipher = SSL_get_current_cipher(engine_->native_handle());
@@ -263,7 +263,7 @@ io::Result<size_t> TlsSocket::RecvMsg(const msghdr& msg, int flags) {
       return read_total;  // Return whatever data we have (0 if true EOF)
     }
 
-    error_code ec = HandleOp(op_val);
+    error_code ec = HandleEngineOp(op_val);
     if (ec) {
       // If we already have data, return it now.  The application will process it and call RecvMsg
       // again, at which point we will hit the error again and return it then.
@@ -290,22 +290,22 @@ io::Result<size_t> TlsSocket::Recv(const io::MutableBytes& mb, int flags) {
 
 io::Result<size_t> TlsSocket::WriteSome(const iovec* ptr, uint32_t len) {
   while (true) {
-    PushResult push_res = PushToEngine(ptr, len);
+    PushResult push_res = PushUserDataToEngine(ptr, len);
     if (push_res.engine_opcode < 0) {
       if (push_res.engine_opcode == Engine::EOF_GRACEFUL) {
         return make_unexpected(make_error_code(std::errc::broken_pipe));
       }
-      auto ec = HandleOp(push_res.engine_opcode);
+      auto ec = HandleEngineOp(push_res.engine_opcode);
       if (ec) {
-        VLOG(1) << "HandleOp failed " << ec.message();
+        VLOG(1) << "HandleEngineOp failed " << ec.message();
         return make_unexpected(ec);
       }
     }
 
     if (push_res.written > 0) {
-      auto ec = MaybeSendOutput();
+      auto ec = MaybeSendEngineOutput();
       if (ec) {
-        VLOG(1) << "MaybeSendOutput failed " << ec.message();
+        VLOG(1) << "MaybeSendEngineOutput failed " << ec.message();
         return make_unexpected(ec);
       }
       return push_res.written;
@@ -313,7 +313,7 @@ io::Result<size_t> TlsSocket::WriteSome(const iovec* ptr, uint32_t len) {
   }
 }
 
-TlsSocket::PushResult TlsSocket::PushToEngine(const iovec* ptr, uint32_t len) {
+TlsSocket::PushResult TlsSocket::PushUserDataToEngine(const iovec* ptr, uint32_t len) {
   PushResult res;
 
   // Chosen to be sufficiently smaller than the usual MTU (1500) and a multiple of 16.
@@ -367,7 +367,7 @@ SSL* TlsSocket::ssl_handle() {
   return engine_ ? engine_->native_handle() : nullptr;
 }
 
-auto TlsSocket::MaybeSendOutput() -> error_code {
+auto TlsSocket::MaybeSendEngineOutput() -> error_code {
   if (engine_->OutputPending() == 0)
     return {};
 
@@ -397,10 +397,10 @@ void TlsSocket::ClearInProgressAndNotify(uint8_t mask) {
   // Clearing a mask that was not set means the caller lost track of state - treat it as a bug.
   DCHECK(state_ & mask);
   state_ &= ~mask;
-  // Why notify_all: more than one fiber can be parked on on block_concurrent_cv_ in different places and on different predicates.
-  // notify_one could wake a fiber whose predicate is still false while leaving another
-  // whose predicate is now true asleep. Every waiter uses wait(lock, pred), so the extra wakeups
-  // are just re-checked and harmless.
+  // Why notify_all: more than one fiber can be parked on block_concurrent_cv_ in different
+  // places and on different predicates. notify_one could wake a fiber whose predicate is still
+  // false while leaving another whose predicate is now true asleep. Every waiter uses wait(lock,
+  // pred), so the extra wakeups are just re-checked and harmless.
   block_concurrent_cv_.notify_all();
 }
 
@@ -409,10 +409,10 @@ auto TlsSocket::HandleUpstreamRead() -> error_code {
     // Normally output is flushed before the read path needs upstream data, or a concurrent
     // write fiber is already in progress (WRITE_IN_PROGRESS). During a TLS 1.3 KeyUpdate the
     // write fiber may exit (e.g. after a connection reset) without draining the ack, leaving
-    // OutputPending > 0 with WRITE_IN_PROGRESS clear. Flush here; MaybeSendOutput will either
+    // OutputPending > 0 with WRITE_IN_PROGRESS clear. Flush here; MaybeSendEngineOutput will either
     // succeed or return the connection error, which is the right outcome either way.
     if ((state_ & WRITE_IN_PROGRESS) == 0) {
-      RETURN_ON_ERROR(MaybeSendOutput());
+      RETURN_ON_ERROR(MaybeSendEngineOutput());
     }
   }
 
@@ -487,7 +487,7 @@ error_code TlsSocket::HandleUpstreamWrite() {
   return ec;
 }
 
-error_code TlsSocket::HandleOp(int op_val) {
+error_code TlsSocket::HandleEngineOp(int op_val) {
   switch (op_val) {
     case Engine::EOF_ABRUPT:
       VLOG(1) << "EOF_ABRUPT received " << next_sock_->native_handle();
@@ -495,14 +495,14 @@ error_code TlsSocket::HandleOp(int op_val) {
     case Engine::EOF_GRACEFUL:
       // Peer said goodbye cleanly.
       // However, EOF_GRACEFUL should be handled by the callers (Accept/Connect/Recv/Write)
-      // explicitly before calling HandleOp.
-      LOG(DFATAL) << "EOF_GRACEFUL received in HandleOp *Should be handled by caller) fd="
+      // explicitly before calling HandleEngineOp.
+      LOG(DFATAL) << "EOF_GRACEFUL received in HandleEngineOp (should be handled by caller) fd="
                   << next_sock_->native_handle();
       return std::error_code{};
     case Engine::NEED_READ_AND_MAYBE_WRITE:
       return HandleUpstreamRead();
     case Engine::NEED_WRITE:
-      return MaybeSendOutput();
+      return MaybeSendEngineOutput();
     default:
       LOG(DFATAL) << "Unsupported " << op_val;
   }
@@ -528,14 +528,15 @@ void TlsSocket::CancelOnErrorCb() {
 void TlsSocket::RegisterOnRecv(OnRecvCb cb) {
   DCHECK(cb);
   // Note: It is vital to store the callback only once (avoid copy!). Both wake paths - the
-  // next_sock_ recv hook (via OnRecv) and a recv-path engine-output drain completion
-  // (StartDrainEngineOutput) - invoke this single copy, so a callback that carries state by value
-  // cannot diverge between two independent copies.
+  // next_sock_ recv hook (via HandleRecvNotification) and a recv-path engine-output drain
+  // completion (StartAsyncWriteForTryRecv) - invoke this single copy, so a callback that carries state
+  // by value cannot diverge between two independent copies.
   on_recv_cb_ = std::move(cb);
-  next_sock_->RegisterOnRecv([this](const RecvNotification& rn) { OnRecv(rn, on_recv_cb_); });
+  next_sock_->RegisterOnRecv(
+      [this](const RecvNotification& rn) { HandleRecvNotification(rn, on_recv_cb_); });
 }
 
-void TlsSocket::OnRecv(const RecvNotification& rn, const OnRecvCb& recv_cb) {
+void TlsSocket::HandleRecvNotification(const RecvNotification& rn, const OnRecvCb& recv_cb) {
   // The recv hook can fire once more after ResetOnRecvHook() has cleared on_recv_cb_, if a
   // notification from next_sock_ was already in flight
   if (!recv_cb) {
@@ -550,7 +551,7 @@ void TlsSocket::OnRecv(const RecvNotification& rn, const OnRecvCb& recv_cb) {
     // Copy the arriving data to the TLS engine's input buffer, commit it, and invoke the receive
     // callback.
     auto input_buf{engine_->PeekInputBuf()};
-    DVSOCK(3) << "OnRecv callback invoked (MutableBytes), #bytes =" << buf->size();
+    DVSOCK(3) << "HandleRecvNotification callback invoked (MutableBytes), #bytes =" << buf->size();
 
     // Note about the next CHECK: We must ensure the arriving data (buf) fits entirely into
     // the TLS engine's currently available input buffer space (input_buf). This check
@@ -583,7 +584,7 @@ void TlsSocket::StartAsyncWrite(io::AsyncProgressCb async_write_cb) {
   async_write_req_->StartUpstreamWrite();
 }
 
-void TlsSocket::StartDrainEngineOutput() {
+void TlsSocket::StartAsyncWriteForTryRecv() {
   // Preconditions (no write in flight, output pending) are checked by StartAsyncWrite.
   // Mark the recv-path engine-output drain as in flight before it starts: while it holds
   // WRITE_IN_PROGRESS, TryRecv must surface EAGAIN (a wake IS coming via on_recv_cb_) rather than
@@ -671,8 +672,8 @@ io::Result<size_t> TlsSocket::TrySend(const iovec* v, uint32_t len) {
     // 3. Push data from user buffer into the engine
     DCHECK_EQ(engine_->OutputPending(), 0u);
     DCHECK_GT(iov_cursor->iov_len, 0u);
-    PushResult push_result{PushToEngine(iov_cursor, curr_iovec_len)};
-    // PushToEngine Result Semantics:
+    PushResult push_result{PushUserDataToEngine(iov_cursor, curr_iovec_len)};
+    // PushUserDataToEngine Result Semantics:
     // 1. written > 0:   Bytes successfully consumed from the user buffer. This happens even if an
     // error/requirement (opcode < 0) immediately follows.
     // 2. opcode < 0:    Engine requires action (NEED_READ/WRITE) or failed (EOF).
@@ -830,7 +831,7 @@ io::Result<size_t> TlsSocket::TryRecv(io::MutableBytes buf) {
             // EAGAIN. That write's completion re-arms the read via the recv callback, so a wake IS
             // coming - the caller may clear its pending-input flag and park. See TryRecv's
             // result-code contract in tls_socket.h.
-            StartDrainEngineOutput();
+            StartAsyncWriteForTryRecv();
             returned_status = make_error_code(errc::resource_unavailable_try_again);
           } else {
             returned_status = send_ec;
@@ -844,7 +845,7 @@ io::Result<size_t> TlsSocket::TryRecv(io::MutableBytes buf) {
         // background write and return EAGAIN (a wake is coming via the recv callback). Log at debug
         // only - this is normal backpressure, not an error.
         if ((*send_result) < output_buf.size()) {
-          StartDrainEngineOutput();
+          StartAsyncWriteForTryRecv();
           returned_status = make_error_code(errc::resource_unavailable_try_again);
           DVSOCK(1) << "TlsSocket::TryRecv: partial upstream send " << (*send_result) << "/"
                     << output_buf.size() << " bytes; started background engine-output drain";
@@ -1146,8 +1147,8 @@ void TlsSocket::AsyncReq::AsyncRoleBasedAction() {
     CompleteAsyncReq(engine_written_);
     return;
   }
-  // We need to call PushToTheEngine again
-  PushResult push_res = owner_->PushToEngine(vec_, len_);
+  // We need to call PushUserDataToEngine again
+  PushResult push_res = owner_->PushUserDataToEngine(vec_, len_);
   Engine::OpResult op_val = push_res.engine_opcode;
   engine_written_ = push_res.written;
   if (op_val < 0) {
@@ -1211,7 +1212,7 @@ void TlsSocket::AsyncWriteSome(const iovec* v, uint32_t len, io::AsyncProgressCb
   CHECK(!async_write_req_);
 
   // Write to the engine
-  PushResult push_res = PushToEngine(v, len);
+  PushResult push_res = PushUserDataToEngine(v, len);
 
   auto req = AsyncReq{this, std::move(cb), v, len, AsyncReq::WRITER};
   req.SetEngineWritten(push_res.written);

--- a/util/tls/tls_socket.h
+++ b/util/tls/tls_socket.h
@@ -13,6 +13,10 @@
 #include "util/tls/tls_engine.h"
 
 namespace util {
+namespace fb2 {
+class AsyncTlsSocketNeedWrite;
+}  // namespace fb2
+
 namespace tls {
 
 class Engine;
@@ -23,6 +27,7 @@ class TlsSocket final : public FiberSocketBase {
   using Buffer = Engine::Buffer;
   using FiberSocketBase::endpoint_type;
 
+  // --- Construction / destruction ---
   TlsSocket(std::unique_ptr<FiberSocketBase> next);
 
   // Takes ownership of next
@@ -30,20 +35,20 @@ class TlsSocket final : public FiberSocketBase {
 
   ~TlsSocket();
 
-  // prefix points to the buffer that optionally holds first bytes from the TLS data stream.
-  void InitSSL(SSL_CTX* context, Buffer prefix = {});
+  // --- FiberSocketBase overrides ---
 
-  error_code Shutdown(int how) final;
+  error_code Shutdown(int how) final override;
 
-  AcceptResult Accept() final;
+  AcceptResult Accept() final override;
 
   // The endpoint should not really pass here, it is to keep
   // the interface with FiberSocketBase.
-  error_code Connect(const endpoint_type& ep, std::function<void(int)> on_pre_connect = {}) final;
+  error_code Connect(const endpoint_type& ep,
+                     std::function<void(int)> on_pre_connect = {}) final override;
 
-  error_code Close() final;
+  error_code Close() final override;
 
-  bool IsOpen() const final {
+  bool IsOpen() const final override {
     return next_sock_->IsOpen();
   }
 
@@ -55,14 +60,12 @@ class TlsSocket final : public FiberSocketBase {
     return next_sock_->timeout();
   }
 
-  io::Result<size_t> RecvMsg(const msghdr& msg, int flags) final;
+  io::Result<size_t> RecvMsg(const msghdr& msg, int flags) final override;
   io::Result<size_t> Recv(const io::MutableBytes& mb, int flags = 0) override;
 
-  ::io::Result<size_t> WriteSome(const iovec* ptr, uint32_t len) final;
-  void AsyncWriteSome(const iovec* v, uint32_t len, io::AsyncProgressCb cb) final;
-  void AsyncReadSome(const iovec* v, uint32_t len, io::AsyncProgressCb cb) final;
-
-  SSL* ssl_handle();
+  ::io::Result<size_t> WriteSome(const iovec* ptr, uint32_t len) final override;
+  void AsyncWriteSome(const iovec* v, uint32_t len, io::AsyncProgressCb cb) final override;
+  void AsyncReadSome(const iovec* v, uint32_t len, io::AsyncProgressCb cb) final override;
 
   endpoint_type LocalEndpoint() const override;
   endpoint_type RemoteEndpoint() const override;
@@ -86,10 +89,10 @@ class TlsSocket final : public FiberSocketBase {
   ABSL_MUST_USE_RESULT error_code ListenUDS(const char* path, mode_t permissions,
                                             unsigned backlog) override;
 
-  virtual void SetProactor(ProactorBase* p) override;
+  void SetProactor(ProactorBase* p) override;
 
-  virtual void RegisterOnRecv(OnRecvCb cb) override;
-  virtual void ResetOnRecvHook() override {
+  void RegisterOnRecv(OnRecvCb cb) override;
+  void ResetOnRecvHook() override {
     on_recv_cb_ = {};
     next_sock_->ResetOnRecvHook();
   }
@@ -118,75 +121,79 @@ class TlsSocket final : public FiberSocketBase {
   io::Result<size_t> TrySend(const iovec* v, uint32_t len) override;
   io::Result<size_t> TryRecv(io::MutableBytes buf) override;
 
-  // * NOT PART OF THE API -- USED FOR TESTING PURPOSES ONLY *
-  // This function is used to simulate a corner case of AsyncReadSome. In particular,
-  // when engine_->Read(...) returns NEED_WRITE. According to chatgpt and google
-  // This scenario reproduces "roughly" by:
-  // 1. client connects to server and server accepts.
-  // 2. handshake completes
-  // 4. client stops reading from the socket -> no acks are sent
-  // 5. server keeps sending data until TCP sent buffers are full (because client has not yet acked)
-  // 6. server calls sll_renegotiate followed by an ssl_handshake
-  // 7. server calls AsyncRead which calls engine->Read() which should return NEED_WRITE
-  //    because the state machine requires a protocol renegotiation and the internal buffers
-  //    are full.
-  // So the idea is that when the server reads, the internal openssl state machine needs to
-  // exchange protocol data but it can not because the TCP buffers are full and consequently
-  // the internall BIO buffers are not yet flushed so the engine->Read() will return NEED_WRITE
-  // such that the protocol renegotiation can kick in. Even though this scenario seems easy to
-  // simulate it does not reproduce NEED_WRITE and for now I use this function to simulate it.
-  void __DebugForceNeedWriteOnAsyncRead(const iovec* v, uint32_t len, io::AsyncProgressCb cb);
+  // --- TlsSocket-specific API (not inherited from FiberSocketBase) ---
 
-  // Used to test AsyncWrite  NEED_WRITE on first PushToEngine. As this scenario is difficult to
-  // time, this function helps simulate it.
-  void __DebugForceNeedWriteOnAsyncWrite(const iovec* v, uint32_t len, io::AsyncProgressCb cb);
+  // prefix points to the buffer that optionally holds first bytes from the TLS data stream.
+  void InitSSL(SSL_CTX* context, Buffer prefix = {});
+
+  SSL* ssl_handle();
 
  private:
+  // Declared first (destroyed last): some blocking/non-blocking/async states below may still
+  // touch the upstream socket while unwinding, so it must outlive them.
+  std::unique_ptr<FiberSocketBase> next_sock_;
+
+  // --- TLS engine bridge: feeds the engine from the upstream socket and/or the user, and
+  // flushes the engine's encrypted output back to the upstream socket ---
+
+  // TLS engine bridge - Common: used by all three paths (blocking, non-blocking, and async) -
+
   // Both opcode and written can be set.
   struct PushResult {
     size_t written = 0;
     int engine_opcode = 0;  // Engine::OpCode
   };
 
-  // Pushes the buffers into input ssl buffer until either everything is written,
-  // or an error occurs or the engine needs to flush its output. Does not interact with the network,
-  // just with the engine. It's up to the caller to send the output buffer to the network.
-  PushResult PushToEngine(const iovec* ptr, uint32_t len);
+  // Pure in-memory engine/crypto operation, does not touch next_sock_. Feeds user-supplied
+  // plaintext into the engine to be encrypted, until either everything is written, or an error
+  // occurs, or the engine needs to flush its output. It's up to the caller to send the output
+  // buffer to the network.
+  PushResult PushUserDataToEngine(const iovec* ptr, uint32_t len);
+
+  // - TLS engine bridge- Blocking path only -
 
   /// Feed encrypted data from the TLS engine into the network socket.
-  error_code MaybeSendOutput();
+  ABSL_MUST_USE_RESULT error_code MaybeSendEngineOutput();
 
   /// Read encrypted data from the network socket and feed it into the TLS engine.
-  error_code HandleUpstreamRead();
+  ABSL_MUST_USE_RESULT error_code HandleUpstreamRead();
 
-  error_code HandleUpstreamWrite();
-  error_code HandleOp(int op);
+  ABSL_MUST_USE_RESULT error_code HandleUpstreamWrite();
+  ABSL_MUST_USE_RESULT error_code HandleEngineOp(int op);
 
-  void OnRecv(const RecvNotification& rn, const OnRecvCb& recv_cb);
+  // - TLS engine bridge - Async path only -
 
-  // Starts a background write that sends the engine's already-buffered output to next_sock_ and
-  // calls `async_write_cb` when it finishes (or errors). Used by TrySend and TryRecv to drain
-  // output they could not send inline. Precondition: no async write is already in flight.
-  void StartAsyncWrite(io::AsyncProgressCb async_write_cb);
+  // Async-notification counterpart of HandleUpstreamRead: when arriving data appears as a
+  // notification instead of a blocking read, this copies it into the engine's input buffer;
+  // retry/error notifications are simply forwarded to the recv callback.
+  void HandleRecvNotification(const RecvNotification& rn, const OnRecvCb& recv_cb);
 
-  // Called from TryRecv when the engine's output it had to send first did not fit in the socket
-  // buffer. Starts a background write (via StartAsyncWrite) to drain that engine output; TryRecv
-  // itself returns EAGAIN. When the write finishes it wakes the reader through on_recv_cb_ (a
-  // read-retry RecvCompletion on success, the error on failure), which re-arms the deferred read.
-  void StartDrainEngineOutput();
-
-  // Clears an in-progress mask (WRITE_IN_PROGRESS or READ_IN_PROGRESS) and wakes any fiber waiting
-  // for it in block_concurrent_cv_, so an async completion can't leave a sync waiter stuck. Masks
-  // nobody waits on are cleared directly.
-  void ClearInProgressAndNotify(uint8_t mask);
-
-  std::unique_ptr<FiberSocketBase> next_sock_;
   std::unique_ptr<Engine> engine_;
   size_t upstream_write_ = 0;
-
-  // Stored recv callback (from RegisterOnRecv) so a recv-path engine-output drain completion can
-  // trigger a read-retry or error notification.
+  // Stored recv callback. Needed so that a read-retry or error can be delivered to the caller
+  // asynchronously, from whichever internal path ends up producing it, without the caller having
+  // to poll or re-register.
   OnRecvCb on_recv_cb_;
+
+  // --- Background engine-output draining: implemented via the async write mechanism ---
+
+  // Starts a background write that sends the engine's already-buffered output to next_sock_ and
+  // calls `async_write_cb` when it finishes (or errors). Precondition: no async write is already
+  // in flight.
+  void StartAsyncWrite(io::AsyncProgressCb async_write_cb);
+
+  // Starts a background write (via StartAsyncWrite) to drain engine output that did not fit
+  // inline in the socket buffer. When the write finishes it wakes the reader through on_recv_cb_
+  // (a read-retry RecvCompletion on success, the error on failure), which re-arms the deferred
+  // read.
+  void StartAsyncWriteForTryRecv();
+
+  // --- state_ bit helpers: shared by the blocking, non-blocking, and async paths ---
+
+  // Clears an in-progress mask (WRITE_IN_PROGRESS or READ_IN_PROGRESS) and wakes any fiber waiting
+  // for it on block_concurrent_cv_, so an async completion can't leave a blocking-path waiter
+  // stuck. Masks nobody waits on are cleared directly.
+  void ClearInProgressAndNotify(uint8_t mask);
 
   enum {
     WRITE_IN_PROGRESS = 1,
@@ -199,6 +206,8 @@ class TlsSocket final : public FiberSocketBase {
   };
   uint8_t state_{0};
 
+  // --- Async I/O primitives: drive a read or write to completion via callbacks instead of
+  // blocking the fiber ---
   class AsyncReq {
    public:
     enum Role : std::uint8_t { READER, WRITER };
@@ -258,6 +267,37 @@ class TlsSocket final : public FiberSocketBase {
   // preempt in function context, we simply subscribe the async request to the one in-flight and
   // once that completes it will also continue the one pending/blocked.
   AsyncReq* blocked_async_req_ = nullptr;
+
+  // --- Testing-only members (not part of the public API) ---
+  friend class fb2::AsyncTlsSocketNeedWrite;
+
+  // This function simulates a corner case of AsyncReadSome: engine_->Read(...) returning
+  // NEED_WRITE. This scenario reproduces roughly as follows:
+  // 1. Client connects to server and server accepts.
+  // 2. Handshake completes.
+  // 3. Client stops reading from the socket -> no acks are sent.
+  // 4. Server keeps sending data until TCP send buffers are full (because the client has not
+  //    yet acked).
+  // 5. Server calls SSL_renegotiate followed by SSL_handshake.
+  // 6. Server calls AsyncRead, which calls engine->Read(), which should return NEED_WRITE
+  //    because the state machine requires a protocol renegotiation and the internal buffers
+  //    are full.
+  // The idea is that when the server reads, the internal OpenSSL state machine needs to
+  // exchange protocol data but cannot, because the TCP buffers are full and consequently the
+  // internal BIO buffers are not yet flushed, so engine->Read() will return NEED_WRITE so that
+  // the protocol renegotiation can kick in. Even though this scenario seems easy to simulate, it
+  // does not reliably reproduce NEED_WRITE, so for now this function simulates it directly.
+  void __DebugForceNeedWriteOnAsyncRead(const iovec* v, uint32_t len, io::AsyncProgressCb cb);
+
+  // Used to test AsyncWrite  NEED_WRITE on first PushUserDataToEngine. As this scenario is
+  // difficult to time, this function helps simulate it.
+  void __DebugForceNeedWriteOnAsyncWrite(const iovec* v, uint32_t len, io::AsyncProgressCb cb);
+
+  // Needed so a fiber that must wait for an in-progress write or read to finish (e.g. to avoid
+  // two concurrent operations touching the socket/engine at once) can park without spinning: it
+  // yields on this CV instead of busy-looping, and gets woken exactly when the state it is
+  // waiting on changes. Declared last so its relative destruction order (destroyed first) is
+  // unaffected by the members above.
   fb2::CondVarAny block_concurrent_cv_;
 };
 

--- a/util/tls/tls_socket_test.cc
+++ b/util/tls/tls_socket_test.cc
@@ -445,12 +445,13 @@ TEST_P(TlsSocketTest, Tls13KeyUpdateNeedWrite) {
   //
   // Sequence after close(fd) → TCP RST:
   //   1. Write fiber's WriteSome fails (ECONNRESET), exits without draining the KeyUpdate ack,
-  //      clears WRITE_IN_PROGRESS, notify_one().
-  //   2. Read fiber wakes from MaybeSendOutput's cv.wait, returns {}.
+  //      clears WRITE_IN_PROGRESS, notify_all().
+  //   2. Read fiber wakes from MaybeSendEngineOutput's cv.wait, returns {}.
   //   3. RecvMsg loops, engine_->Read() returns NEED_READ_AND_MAYBE_WRITE — ack still in output
   //      buffer because the write fiber exited before draining it.
   //   4. HandleUpstreamRead sees OutputPending() > 0 with WRITE_IN_PROGRESS clear, calls
-  //      MaybeSendOutput() which fails with ECONNRESET; error propagates and read fiber exits.
+  //      MaybeSendEngineOutput() which fails with ECONNRESET; error propagates and read fiber
+  //      exits.
   LOG(INFO) << "Closing client connection";
   { auto _ = std::move(ssl_guard); }  // SSL_shutdown + SSL_free (non-blocking, may be EAGAIN)
   LOG(INFO) << "ssl_guard destroyed, closing fd";
@@ -1674,7 +1675,7 @@ struct TrySendScenario {
   std::optional<io::Result<size_t>> sock_flush_ret;
 
   // Phase 2: Engine behavior when processing User Data
-  // This simulates the result of engine_->Write() called via PushToEngine.
+  // This simulates the result of engine_->Write() called via PushUserDataToEngine.
   // Note: To simulate success, use a positive number (bytes consumed).
   Engine::OpResult engine_write_ret = 0;
 


### PR DESCRIPTION
This is the first commit in a series that will refactor TlsSocket. It
performs cleanup and reorganization only - no logic changes, only
renames and comment rewrites - to prepare for the more substantial
refactoring commits that follow.

- Renames (with matching log-string and comment updates):
  * MaybeSendOutput -> MaybeSendEngineOutput
  * HandleOp -> HandleEngineOp
  * PushToEngine -> PushUserDataToEngine
  * OnRecv -> HandleRecvNotification
  * StartDrainEngineOutput -> StartAsyncWriteForTryRecv

- Reorganized tls_socket.h's private section into Common /
  Blocking-path-only / Async-path-only groups, using flat
  blocking/non-blocking/async terminology throughout, relocated the
  PushResult struct under the Common heading, and rewrote member
  and function comments to explain why each piece exists instead of
  listing which callers use it.

- Updated tls_socket_test.cc comments to reference the new function
  names.

- Marked the private engine-bridge helpers (MaybeSendEngineOutput,
  HandleUpstreamRead, HandleUpstreamWrite, HandleEngineOp) with
  ABSL_MUST_USE_RESULT, matching Bind/Listen/ListenUDS.