### PR TITLE
chore: cancel in-flight requests for iouring and epoll socket

### DIFF
--- a/util/fiber_socket_base.h
+++ b/util/fiber_socket_base.h
@@ -199,6 +199,14 @@ class LinuxSocketBase : public FiberSocketBase {
 
   error_code Shutdown(int how) override;
 
+  // Cancels all pending async operations (reads and writes) submitted on this socket's fd,
+  // forcing them to fail immediately instead of waiting to resolve naturally. Unlike
+  // Shutdown()/Close(), this can interrupt an operation that is already in flight - e.g. a
+  // write stalled because the peer isn't draining its receive buffer, which Shutdown()/Close()
+  // cannot force to complete, since io_uring holds its own reference to a submitted operation
+  // until it resolves on its own.
+  virtual error_code CancelInFlightOps() = 0;
+
   // UINT32_MAX to disable timeout.
   void set_timeout(uint32_t msec) final override {
     timeout_ = msec;

--- a/util/fibers/epoll_socket.cc
+++ b/util/fibers/epoll_socket.cc
@@ -193,6 +193,47 @@ auto EpollSocket::Close() -> error_code {
   return ec;
 }
 
+std::error_code EpollSocket::CancelInFlightOps() {
+  // Cleanup pending requests. Unlike UringSocket, there's no kernel-held reference to interrupt
+  // here - write_req_/async_write_req_ (and read_req_/async_read_req_/on_recv_) are a union:
+  // at most one of {synchronous WriteSome() suspended via PendingReq, a queued AsyncWriteSome(),
+  // <read side: also a registered OnRecv hook>} can be outstanding at a time. So cancelling is
+  // just a matter of resolving whichever one is currently set ourselves.
+  //
+  // Unlike Close()'s own cleanup above, this also wakes a fiber suspended in the synchronous
+  // WriteSome()/RecvMsg() path - that's the whole point of this method (see CancelInFlightOps()
+  // on UringSocket, which cancels in-flight kernel ops regardless of whether they were
+  // submitted synchronously or asynchronously). It is intentionally not called from Close().
+  if (async_write_pending_) {
+    DCHECK(async_write_req_);
+    async_write_req_->cb(MakeUnexpected(errc::operation_canceled));
+    delete async_write_req_;
+    async_write_req_ = nullptr;
+    async_write_pending_ = 0;
+  } else if (write_req_ && write_req_->IsSuspended()) {
+    // A fiber is blocked inside the synchronous WriteSome() - wake it with an error instead of
+    // leaving it suspended forever.
+    write_req_->Activate(make_error_code(errc::operation_canceled));
+  }
+
+  if (async_read_pending_) {
+    DCHECK(async_read_req_);
+    async_read_req_->cb(MakeUnexpected(errc::operation_canceled));
+    delete async_read_req_;
+    async_read_req_ = nullptr;
+    async_read_pending_ = 0;
+  } else if (recv_hook_registered_) {
+    delete on_recv_;
+    on_recv_ = nullptr;
+    recv_hook_registered_ = 0;
+  } else if (read_req_ && read_req_->IsSuspended()) {
+    // A fiber is blocked inside the synchronous RecvMsg() - wake it with an error instead of
+    // leaving it suspended forever.
+    read_req_->Activate(make_error_code(errc::operation_canceled));
+  }
+  return {};
+}
+
 void EpollSocket::OnSetProactor() {
   if (fd_ >= 0) {
     CHECK_LT(arm_index_, 0);

--- a/util/fibers/epoll_socket.cc
+++ b/util/fibers/epoll_socket.cc
@@ -204,24 +204,34 @@ std::error_code EpollSocket::CancelInFlightOps() {
   // WriteSome()/RecvMsg() path - that's the whole point of this method (see CancelInFlightOps()
   // on UringSocket, which cancels in-flight kernel ops regardless of whether they were
   // submitted synchronously or asynchronously). It is intentionally not called from Close().
+  LOG(WARNING) << "diag: CancelInFlightOps entry, async_write_pending_=" << int(async_write_pending_)
+               << " write_req_=" << write_req_
+               << " suspended=" << (write_req_ ? write_req_->IsSuspended() : -1);
   if (async_write_pending_) {
     DCHECK(async_write_req_);
-    async_write_req_->cb(MakeUnexpected(errc::operation_canceled));
-    delete async_write_req_;
+    AsyncReq* req = async_write_req_;
+    auto cb = std::move(req->cb);
+    delete req;
     async_write_req_ = nullptr;
     async_write_pending_ = 0;
+    cb(MakeUnexpected(errc::operation_canceled));
   } else if (write_req_ && write_req_->IsSuspended()) {
     // A fiber is blocked inside the synchronous WriteSome() - wake it with an error instead of
     // leaving it suspended forever.
+    LOG(WARNING) << "diag: about to Activate write_req_";
     write_req_->Activate(make_error_code(errc::operation_canceled));
+    LOG(WARNING) << "diag: Activate returned";
   }
 
   if (async_read_pending_) {
     DCHECK(async_read_req_);
-    async_read_req_->cb(MakeUnexpected(errc::operation_canceled));
-    delete async_read_req_;
+    // Same reasoning as the write side above: clear state before invoking cb().
+    AsyncReq* req = async_read_req_;
+    auto cb = std::move(req->cb);
+    delete req;
     async_read_req_ = nullptr;
     async_read_pending_ = 0;
+    cb(MakeUnexpected(errc::operation_canceled));
   } else if (recv_hook_registered_) {
     delete on_recv_;
     on_recv_ = nullptr;

--- a/util/fibers/epoll_socket.h
+++ b/util/fibers/epoll_socket.h
@@ -26,6 +26,8 @@ class EpollSocket : public LinuxSocketBase {
                                           std::function<void(int)> on_pre_connect) final;
   ABSL_MUST_USE_RESULT error_code Close() final;
 
+  error_code CancelInFlightOps() final;
+
   // Really need here expected.
   Result<size_t> WriteSome(const iovec* ptr, uint32_t len) override;
 

--- a/util/fibers/fiber_socket_test.cc
+++ b/util/fibers/fiber_socket_test.cc
@@ -940,5 +940,109 @@ TEST_P(FiberSocketTest, LeakAsyncWrite) {
   proactor_->Await([&] { std::ignore = sock->Close(); });
 }
 
+// Regression test: an AsyncWrite stalled because the peer never drains its receive buffer
+// must not stay pending forever - CancelInFlightOps() should force it to resolve promptly.
+TEST_P(FiberSocketTest, CancelInFlightOpsAsync) {
+  unique_ptr<FiberSocketBase> sock;
+  Done write_done;
+  error_code write_ec;
+  bool write_completed = false;
+
+  proactor_->Await([&] {
+    sock.reset(proactor_->CreateSocket());
+    error_code ec = sock->Connect(listen_ep_);
+    EXPECT_FALSE(ec);
+  });
+  accept_fb_.Join();
+  ASSERT_FALSE(accept_ec_);
+
+  // Shrink the outgoing buffer so a large write genuinely cannot complete synchronously while
+  // nobody drains the peer (conn_socket_ never reads in this test).
+  proactor_->AwaitBrief([&] {
+    int sndbuf = 1024;
+    CHECK_EQ(0, setsockopt(sock->native_handle(), SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf)));
+  });
+
+  constexpr size_t kBufSize = 16 * 1024 * 1024;  // Exceeds any realistic kernel socket buffer.
+  std::unique_ptr<uint8_t[]> buf(new uint8_t[kBufSize]);
+  proactor_->Await([&] {
+    sock->AsyncWrite(io::Bytes(buf.get(), kBufSize), [&](error_code ec) {
+      write_ec = ec;
+      write_completed = true;
+      write_done.Notify();
+    });
+  });
+
+  // The write must still be stuck - nobody is reading conn_socket_.
+  EXPECT_FALSE(write_done.WaitFor(100ms))
+      << "write should not have completed - nobody is draining the peer";
+  EXPECT_FALSE(write_completed);
+
+  // CancelInFlightOps() must force the outstanding write to resolve instead of leaving it
+  // stuck forever.
+  error_code cancel_ec = proactor_->Await(
+      [&] { return static_cast<LinuxSocketBase*>(sock.get())->CancelInFlightOps(); });
+  EXPECT_FALSE(cancel_ec) << cancel_ec.message();
+
+  ASSERT_TRUE(write_done.WaitFor(3s))
+      << "AsyncWrite callback did not fire after CancelInFlightOps()";
+  EXPECT_TRUE(write_ec) << "expected an error after cancellation";
+
+  proactor_->Await([&] { std::ignore = sock->Close(); });
+}
+
+// Same regression, but for the synchronous Write() path: a fiber blocked inside it must also be
+// woken by CancelInFlightOps(), not just pending AsyncWrite()s. Write() loops over WriteSome()
+// until everything is sent, suspending the fiber via PendingReq when the buffer is full - a
+// completely separate code path (on epoll) from the async one, which is what actually needs
+// covering here (WriteSome() alone would return early after a single partial send, never
+// blocking, so it wouldn't exercise the suspend path at all).
+TEST_P(FiberSocketTest, CancelInFlightOpsSync) {
+  unique_ptr<FiberSocketBase> sock;
+
+  proactor_->Await([&] {
+    sock.reset(proactor_->CreateSocket());
+    error_code ec = sock->Connect(listen_ep_);
+    EXPECT_FALSE(ec);
+  });
+  accept_fb_.Join();
+  ASSERT_FALSE(accept_ec_);
+
+  // Shrink the outgoing buffer so a large write genuinely cannot complete synchronously while
+  // nobody drains the peer (conn_socket_ never reads in this test).
+  proactor_->AwaitBrief([&] {
+    int sndbuf = 1024;
+    CHECK_EQ(0, setsockopt(sock->native_handle(), SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf)));
+  });
+
+  constexpr size_t kBufSize = 16 * 1024 * 1024;  // Exceeds any realistic kernel socket buffer.
+  std::unique_ptr<uint8_t[]> buf(new uint8_t[kBufSize]);
+
+  error_code write_ec;
+  bool write_completed = false;
+
+  // Write() suspends the calling fiber until everything is sent, so run it on its own fiber and
+  // observe it from here.
+  Fiber write_fb = proactor_->LaunchFiber("BlockedWrite", [&] {
+    write_ec = sock->Write(io::Bytes(buf.get(), kBufSize));
+    write_completed = true;
+  });
+
+  // The write must still be stuck - nobody is reading conn_socket_.
+  ThisFiber::SleepFor(100ms);
+  EXPECT_FALSE(write_completed) << "write should not have completed - nobody is draining the peer";
+
+  // CancelInFlightOps() must wake the suspended fiber instead of leaving it stuck forever.
+  error_code cancel_ec = proactor_->Await(
+      [&] { return static_cast<LinuxSocketBase*>(sock.get())->CancelInFlightOps(); });
+  EXPECT_FALSE(cancel_ec) << cancel_ec.message();
+
+  write_fb.Join();
+  EXPECT_TRUE(write_completed);
+  EXPECT_TRUE(write_ec) << "expected an error after cancellation";
+
+  proactor_->Await([&] { std::ignore = sock->Close(); });
+}
+
 }  // namespace fb2
 }  // namespace util

--- a/util/fibers/fiber_socket_test.cc
+++ b/util/fibers/fiber_socket_test.cc
@@ -1023,24 +1023,84 @@ TEST_P(FiberSocketTest, CancelInFlightOpsSync) {
 
   // Write() suspends the calling fiber until everything is sent, so run it on its own fiber and
   // observe it from here.
+  LOG(WARNING) << "diag: launching write_fb";
   Fiber write_fb = proactor_->LaunchFiber("BlockedWrite", [&] {
+    LOG(WARNING) << "diag: write_fb started, calling Write()";
     write_ec = sock->Write(io::Bytes(buf.get(), kBufSize));
+    LOG(WARNING) << "diag: write_fb Write() returned ec=" << write_ec.message();
     write_completed = true;
   });
 
   // The write must still be stuck - nobody is reading conn_socket_.
+  LOG(WARNING) << "diag: sleeping 100ms";
   ThisFiber::SleepFor(100ms);
+  LOG(WARNING) << "diag: woke up, write_completed=" << write_completed;
   EXPECT_FALSE(write_completed) << "write should not have completed - nobody is draining the peer";
 
   // CancelInFlightOps() must wake the suspended fiber instead of leaving it stuck forever.
+  LOG(WARNING) << "diag: calling CancelInFlightOps()";
+  error_code cancel_ec = proactor_->Await(
+      [&] { return static_cast<LinuxSocketBase*>(sock.get())->CancelInFlightOps(); });
+  LOG(WARNING) << "diag: CancelInFlightOps() returned ec=" << cancel_ec.message();
+  EXPECT_FALSE(cancel_ec) << cancel_ec.message();
+
+  LOG(WARNING) << "diag: joining write_fb";
+  write_fb.Join();
+  LOG(WARNING) << "diag: write_fb joined";
+  EXPECT_TRUE(write_completed);
+  EXPECT_TRUE(write_ec) << "expected an error after cancellation";
+
+  proactor_->Await([&] { std::ignore = sock->Close(); });
+}
+
+// Regression test: CancelInFlightOps()'s fd-wide cancel used to be able to silently sweep up an
+// unrelated RegisterOnErrorCb() poll registered on the very same socket, leaving UringSocket's
+// error_cb_wrapper_ dangling - which later crashed Close() via LOG(DFATAL). Registering an error
+// callback alongside a stalled write must not trip that; Close() below must not crash.
+TEST_P(FiberSocketTest, CancelInFlightOpsWithErrorCb) {
+  unique_ptr<FiberSocketBase> sock;
+  Done write_done;
+  error_code write_ec;
+
+  proactor_->Await([&] {
+    sock.reset(proactor_->CreateSocket());
+    error_code ec = sock->Connect(listen_ep_);
+    EXPECT_FALSE(ec);
+    sock->RegisterOnErrorCb([](uint32_t) {});
+  });
+  accept_fb_.Join();
+  ASSERT_FALSE(accept_ec_);
+
+  // Shrink the outgoing buffer so a large write genuinely cannot complete synchronously while
+  // nobody drains the peer (conn_socket_ never reads in this test).
+  proactor_->AwaitBrief([&] {
+    int sndbuf = 1024;
+    CHECK_EQ(0, setsockopt(sock->native_handle(), SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf)));
+  });
+
+  constexpr size_t kBufSize = 16 * 1024 * 1024;  // Exceeds any realistic kernel socket buffer.
+  std::unique_ptr<uint8_t[]> buf(new uint8_t[kBufSize]);
+  proactor_->Await([&] {
+    sock->AsyncWrite(io::Bytes(buf.get(), kBufSize), [&](error_code ec) {
+      write_ec = ec;
+      write_done.Notify();
+    });
+  });
+
+  EXPECT_FALSE(write_done.WaitFor(100ms))
+      << "write should not have completed - nobody is draining the peer";
+
   error_code cancel_ec = proactor_->Await(
       [&] { return static_cast<LinuxSocketBase*>(sock.get())->CancelInFlightOps(); });
   EXPECT_FALSE(cancel_ec) << cancel_ec.message();
 
-  write_fb.Join();
-  EXPECT_TRUE(write_completed);
+  ASSERT_TRUE(write_done.WaitFor(3s))
+      << "AsyncWrite callback did not fire after CancelInFlightOps()";
   EXPECT_TRUE(write_ec) << "expected an error after cancellation";
 
+  // Must not crash: previously UringSocket::Close() would LOG(DFATAL) here because
+  // error_cb_wrapper_ was left dangling by the broad cancel above. Deliberately NOT calling
+  // CancelOnErrorCb() here first - CancelInFlightOps() must have already handled it internally.
   proactor_->Await([&] { std::ignore = sock->Close(); });
 }
 

--- a/util/fibers/uring_socket.cc
+++ b/util/fibers/uring_socket.cc
@@ -103,6 +103,35 @@ auto UringSocket::Close() -> error_code {
   return ec;
 }
 
+auto UringSocket::CancelInFlightOps() -> error_code {
+  if (fd_ < 0)
+    return {};
+
+  // IORING_ASYNC_CANCEL_FD/_FD_FIXED: match candidate requests by this fd instead of by a
+  // specific request's user_data (the default) - we want to hit everything pending on this
+  // socket, not one particular operation.
+  // IORING_ASYNC_CANCEL_ALL: cancel every matching request, not just the first one found -
+  // without this, e.g. a pending write and a pending read on the same fd would only have one
+  // of them cancelled.
+  unsigned flags = (is_direct_fd_ ? IORING_ASYNC_CANCEL_FD_FIXED : IORING_ASYNC_CANCEL_FD) |
+                   IORING_ASYNC_CANCEL_ALL;
+
+  // CancelRequests() wraps io_uring_register_sync_cancel(), which is a real synchronous
+  // syscall (IORING_REGISTER_SYNC_CANCEL) - not a submit-then-reap-completion SQE like every
+  // other operation here. It blocks the calling thread in the kernel while it locates and
+  // cancels matching requests (not a userspace busy-loop), but that also means it does NOT
+  // yield to other fibers on this proactor the way normal io_uring ops do - the whole thread
+  // is blocked for its duration. Should be fine in practice since cancellation itself is a fast
+  // kernel-side lookup+abort, not I/O and it's a rather "exceptional" path.
+  int res = GetProactor()->CancelRequests(ShiftedFd(), flags);
+
+  // ENOENT means there was nothing pending to cancel - not an error for our purposes.
+  if (res < 0 && res != -ENOENT) {
+    return error_code(-res, system_category());
+  }
+  return {};
+}
+
 auto UringSocket::Accept() -> AcceptResult {
   CHECK(proactor());
 

--- a/util/fibers/uring_socket.cc
+++ b/util/fibers/uring_socket.cc
@@ -107,22 +107,31 @@ auto UringSocket::CancelInFlightOps() -> error_code {
   if (fd_ < 0)
     return {};
 
+  // The fd-scoped cancel below matches ANY pending request on this fd, not just the write/read
+  // we actually want to unstick - including the error-callback poll from RegisterOnErrorCb()
+  // and the multishot recv from RegisterOnRecv(). Those have their own dedicated teardown paths
+  // that correctly reset this socket's bookkeeping.
+  // Run them first so the broad cancel below doesn't silently swallow one of their completions 
+  // and leave that state stale (e.g. a dangling) error_cb_wrapper_.
+  CancelOnErrorCb();
+  ResetOnRecvHook();
+
   // IORING_ASYNC_CANCEL_FD/_FD_FIXED: match candidate requests by this fd instead of by a
-  // specific request's user_data (the default) - we want to hit everything pending on this
-  // socket, not one particular operation.
+  // specific request's user_data (the default) - we want to hit everything still pending on
+  // this socket (the write/read), not one particular operation.
   // IORING_ASYNC_CANCEL_ALL: cancel every matching request, not just the first one found -
   // without this, e.g. a pending write and a pending read on the same fd would only have one
   // of them cancelled.
   unsigned flags = (is_direct_fd_ ? IORING_ASYNC_CANCEL_FD_FIXED : IORING_ASYNC_CANCEL_FD) |
                    IORING_ASYNC_CANCEL_ALL;
 
-  // CancelRequests() wraps io_uring_register_sync_cancel(), which is a real synchronous
+  // CancelRequests() wraps io_uring_register_sync_cancel(), which is a synchronous
   // syscall (IORING_REGISTER_SYNC_CANCEL) - not a submit-then-reap-completion SQE like every
   // other operation here. It blocks the calling thread in the kernel while it locates and
   // cancels matching requests (not a userspace busy-loop), but that also means it does NOT
-  // yield to other fibers on this proactor the way normal io_uring ops do - the whole thread
-  // is blocked for its duration. Should be fine in practice since cancellation itself is a fast
-  // kernel-side lookup+abort, not I/O and it's a rather "exceptional" path.
+  // yield to other fibers on this proactor. The whole thread is blocked for its duration. 
+  // Should be fine in practice since cancellation itself is a fast kernel-side lookup+abort, 
+  // not I/O and it's a rather "exceptional" path.
   int res = GetProactor()->CancelRequests(ShiftedFd(), flags);
 
   // ENOENT means there was nothing pending to cancel - not an error for our purposes.

--- a/util/fibers/uring_socket.h
+++ b/util/fibers/uring_socket.h
@@ -36,6 +36,8 @@ class UringSocket : public LinuxSocketBase {
                                           std::function<void(int)> on_pre_connect) final;
   ABSL_MUST_USE_RESULT error_code Close() final;
 
+  error_code CancelInFlightOps() final;
+
   io::Result<size_t> WriteSome(const iovec* v, uint32_t len) override;
   void AsyncWriteSome(const iovec* v, uint32_t len, io::AsyncProgressCb cb) override;
   void AsyncReadSome(const iovec* v, uint32_t len, io::AsyncProgressCb cb) override;


### PR DESCRIPTION
* allow cancelling in-flight epoll and iouring read/writes
* add tests to cover all paths