### PR TITLE
refactor(tls): extract async I/O coordinator

### DIFF
--- a/util/tls/tls_async_io.h
+++ b/util/tls/tls_async_io.h
@@ -1,0 +1,46 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include "util/fiber_socket_base.h"
+
+namespace util {
+namespace tls {
+
+class TlsSocket;
+class TlsAsyncReq;
+class TestDelegator;
+
+// Owns the active TLS read/write requests and coordinates their asynchronous progress.
+class TlsAsyncIo {
+ public:
+  // CTOR/DTOR are defined in tls_socket_async.cc where TlsAsyncReq is complete for unique_ptr cleanup.
+  explicit TlsAsyncIo(TlsSocket* owner);
+  ~TlsAsyncIo();
+
+  // Starts an asynchronous read through the TLS engine.
+  void AsyncReadSome(const iovec* v, uint32_t len, io::AsyncProgressCb cb);
+  // Starts an asynchronous write through the TLS engine.
+  void AsyncWriteSome(const iovec* v, uint32_t len, io::AsyncProgressCb cb);
+  // Drains already-buffered TLS output without accepting new user data.
+  void StartAsyncWrite(io::AsyncProgressCb async_write_cb);
+
+ private:
+  friend class TlsAsyncReq;
+  friend class TestDelegator;
+
+  TlsSocket* owner_;
+  std::unique_ptr<TlsAsyncReq> async_read_req_;
+  std::unique_ptr<TlsAsyncReq> async_write_req_;
+
+  // Aliases one of the owned requests while it waits for an in-flight operation.
+  TlsAsyncReq* blocked_async_req_ = nullptr;
+};
+
+}  // namespace tls
+}  // namespace util

--- a/util/tls/tls_async_req.h
+++ b/util/tls/tls_async_req.h
@@ -1,0 +1,71 @@
+// Copyright 2023, Roman Gershman.  All rights reserved.
+// See LICENSE for licensing terms.
+//
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+
+#include "util/fiber_socket_base.h"
+
+namespace util {
+namespace tls {
+
+class TestDelegator;
+class TlsAsyncIo;
+class TlsSocket;
+
+// Drives one TLS read or write request until it invokes its completion callback.
+class TlsAsyncReq {
+ public:
+  enum Role : std::uint8_t { READER, WRITER };
+  // Captures one caller request and the components that advance it.
+  TlsAsyncReq(TlsSocket* owner, TlsAsyncIo* async_io, io::AsyncProgressCb cb, const iovec* v,
+              uint32_t len, Role role)
+      : owner_(owner), async_io_(async_io), caller_completion_cb_(std::move(cb)), vec_(v),
+        len_(len), role_(role) {
+  }
+
+  // Dispatches the next action requested by the TLS engine.
+  void HandleOpAsync(int op_val);
+  // Starts an upstream write for the engine's pending output.
+  void StartUpstreamWrite();
+  void SetEngineWritten(size_t written) {
+    engine_written_ = written;
+  }
+
+ private:
+  friend class TestDelegator;
+
+  TlsSocket* owner_;
+  TlsAsyncIo* async_io_;
+  io::AsyncProgressCb caller_completion_cb_;
+  const iovec* vec_;
+  uint32_t len_;
+  Role role_;
+  iovec scratch_iovec_ = {};
+  size_t engine_written_ = 0;
+  bool should_read_ = false;
+
+  // Flushes output, then starts the upstream read required by the engine.
+  void MaybeSendOutputAsyncWithRead();
+  // Flushes pending TLS output when the engine requests a write.
+  void MaybeSendOutputAsync();
+  // Starts an upstream read into the engine input buffer.
+  void StartUpstreamRead();
+  // Releases request ownership before invoking the caller callback.
+  void CompleteAsyncReq(io::Result<size_t> result);
+  // Continues or completes the request after an upstream write callback.
+  void AsyncWriteProgressCb(io::Result<size_t> write_result);
+  // Continues or completes the request after an upstream read callback.
+  void AsyncReadProgressCb(io::Result<size_t> result);
+  // Advances the read or write state machine after an engine operation.
+  void AsyncRoleBasedAction();
+  // Resumes the request deferred behind a completed upstream operation.
+  void RunPending();
+};
+
+}  // namespace tls
+}  // namespace util

--- a/util/tls/tls_async_req.h
+++ b/util/tls/tls_async_req.h
@@ -27,6 +27,10 @@ class TlsAsyncReq {
       : owner_(owner), async_io_(async_io), caller_completion_cb_(std::move(cb)), vec_(v),
         len_(len), role_(role) {
   }
+  TlsAsyncReq(const TlsAsyncReq&) = delete;
+  TlsAsyncReq& operator=(const TlsAsyncReq&) = delete;
+  TlsAsyncReq(TlsAsyncReq&&) = delete;
+  TlsAsyncReq& operator=(TlsAsyncReq&&) = delete;
 
   // Dispatches the next action requested by the TLS engine.
   void HandleOpAsync(int op_val);
@@ -55,7 +59,7 @@ class TlsAsyncReq {
   void MaybeSendOutputAsync();
   // Starts an upstream read into the engine input buffer.
   void StartUpstreamRead();
-  // Releases request ownership before invoking the caller callback.
+  // Releases request ownership and destroys this after invoking the caller callback.
   void CompleteAsyncReq(io::Result<size_t> result);
   // Continues or completes the request after an upstream write callback.
   void AsyncWriteProgressCb(io::Result<size_t> write_result);

--- a/util/tls/tls_socket.cc
+++ b/util/tls/tls_socket.cc
@@ -605,14 +605,6 @@ io::Result<size_t> TlsSocket::TrySend(io::Bytes buf) {
   return TrySend(vec, 1);
 }
 
-void TlsSocket::AsyncReadSome(const iovec* v, uint32_t len, io::AsyncProgressCb cb) {
-  async_io_.AsyncReadSome(v, len, std::move(cb));
-}
-
-void TlsSocket::AsyncWriteSome(const iovec* v, uint32_t len, io::AsyncProgressCb cb) {
-  async_io_.AsyncWriteSome(v, len, std::move(cb));
-}
-
 io::Result<size_t> TlsSocket::TrySend(const iovec* v, uint32_t len) {
   auto& socket_flags = flags_;
   size_t iovec_total_bytes = GetIovecTotalBytes(v, len);
@@ -765,6 +757,14 @@ io::Result<size_t> TlsSocket::TrySend(const iovec* v, uint32_t len) {
     return 0;  // No error, Clean EOF case
   }
   return make_unexpected(returned_status);
+}
+
+void TlsSocket::AsyncReadSome(const iovec* v, uint32_t len, io::AsyncProgressCb cb) {
+  async_io_.AsyncReadSome(v, len, std::move(cb));
+}
+
+void TlsSocket::AsyncWriteSome(const iovec* v, uint32_t len, io::AsyncProgressCb cb) {
+  async_io_.AsyncWriteSome(v, len, std::move(cb));
 }
 
 io::Result<size_t> TlsSocket::TryRecv(io::MutableBytes buf) {

--- a/util/tls/tls_socket.cc
+++ b/util/tls/tls_socket.cc
@@ -575,16 +575,7 @@ void TlsSocket::HandleRecvNotification(const RecvNotification& rn, const OnRecvC
 }
 
 void TlsSocket::StartAsyncWrite(io::AsyncProgressCb async_write_cb) {
-  // Hard CHECK: overwriting a live async_write_req_ would free an AsyncReq still referenced by
-  // in-flight AsyncWriteSome callbacks (use-after-free). Callers guarantee no write is in flight
-  // (TrySend/TryRecv bail out early on WRITE_IN_PROGRESS), so this never fires in correct runs.
-  CHECK(!async_write_req_);
-  DCHECK_GT(engine_->OutputPending(), 0u);
-  // (vec, len) = (nullptr, 0): no new user bytes, we only send what the engine already buffered.
-  // AsyncRoleBasedAction treats a WRITER with vec_ == nullptr as output-only and ends when drained.
-  async_write_req_ =
-      std::make_unique<AsyncReq>(this, std::move(async_write_cb), nullptr, 0, AsyncReq::WRITER);
-  async_write_req_->StartUpstreamWrite();
+  async_io_.StartAsyncWrite(std::move(async_write_cb));
 }
 
 void TlsSocket::StartAsyncWriteForTryRecv() {
@@ -612,6 +603,14 @@ io::Result<size_t> TlsSocket::TrySend(io::Bytes buf) {
   vec[0].iov_base = const_cast<uint8_t*>(buf.data());
   vec[0].iov_len = buf.size();
   return TrySend(vec, 1);
+}
+
+void TlsSocket::AsyncReadSome(const iovec* v, uint32_t len, io::AsyncProgressCb cb) {
+  async_io_.AsyncReadSome(v, len, std::move(cb));
+}
+
+void TlsSocket::AsyncWriteSome(const iovec* v, uint32_t len, io::AsyncProgressCb cb) {
+  async_io_.AsyncWriteSome(v, len, std::move(cb));
 }
 
 io::Result<size_t> TlsSocket::TrySend(const iovec* v, uint32_t len) {

--- a/util/tls/tls_socket.h
+++ b/util/tls/tls_socket.h
@@ -10,13 +10,10 @@
 
 #include "util/fiber_socket_base.h"
 #include "util/fibers/synchronization.h"
+#include "util/tls/tls_async_io.h"
 #include "util/tls/tls_engine.h"
 
 namespace util {
-namespace fb2 {
-class AsyncTlsSocketNeedWrite;
-}  // namespace fb2
-
 namespace tls {
 
 class Engine;
@@ -291,92 +288,11 @@ class TlsSocket final : public FiberSocketBase {
     fb2::CondVarAny cv_;
   };
 
-  // --- Async I/O primitives: drive a read or write to completion via callbacks instead of
-  // blocking the fiber ---
-  class AsyncReq {
-   public:
-    enum Role : std::uint8_t { READER, WRITER };
+  // TlsAsyncIo owns async request state and drives the async state machine.
+  friend class TlsAsyncIo;
+  friend class TlsAsyncReq;
 
-    AsyncReq(TlsSocket* owner, io::AsyncProgressCb cb, const iovec* v, uint32_t len, Role role)
-        : owner_(owner), caller_completion_cb_(std::move(cb)), vec_(v), len_(len), role_(role) {
-    }
-
-    void HandleOpAsync(int op_val);
-    void StartUpstreamWrite();
-    void SetEngineWritten(size_t written) {
-      engine_written_ = written;
-    }
-
-   private:
-    TlsSocket* owner_;
-    // Callback passed from the user.
-    io::AsyncProgressCb caller_completion_cb_;
-
-    const iovec* vec_;
-    uint32_t len_;
-
-    Role role_;
-
-    iovec scratch_iovec_ = {};
-
-    size_t engine_written_ = 0;
-    bool should_read_ = false;
-
-    // Asynchronous helpers
-    void MaybeSendOutputAsyncWithRead();
-    void MaybeSendOutputAsync();
-
-    void StartUpstreamRead();
-
-    void CompleteAsyncReq(io::Result<size_t> result);
-
-    void AsyncWriteProgressCb(io::Result<size_t> write_result);
-    void AsyncReadProgressCb(io::Result<size_t> result);
-
-    // Both reader and writer can at any point dispatch a RW operation.
-    // So, AsyncWriteProgress* must decide how to complete based on its role and this
-    // function extracts the common execution paths.
-    void AsyncRoleBasedAction();
-
-    // Helper function to handle WRITE_IN_PROGRESS and READ_IN_PROGRESS without preemption.
-    // When an operation can't continue because there is already one in progress, it early returns
-    // and copies itself to blocked_async_req_. When the in progress operation completes,
-    // it resumes the one pending.
-    void RunPending();
-  };
-
-  std::unique_ptr<AsyncReq> async_read_req_;
-  std::unique_ptr<AsyncReq> async_write_req_;
-
-  // Pending request that is blocked on WRITE_IN_PROGRESS or READ_IN_PROGRESS. Since we can't
-  // preempt in function context, we simply subscribe the async request to the one in-flight and
-  // once that completes it will also continue the one pending/blocked.
-  AsyncReq* blocked_async_req_ = nullptr;
-
-  // --- Testing-only members (not part of the public API) ---
-  friend class fb2::AsyncTlsSocketNeedWrite;
-
-  // This function simulates a corner case of AsyncReadSome: engine_->Read(...) returning
-  // NEED_WRITE. This scenario reproduces roughly as follows:
-  // 1. Client connects to server and server accepts.
-  // 2. Handshake completes.
-  // 3. Client stops reading from the socket -> no acks are sent.
-  // 4. Server keeps sending data until TCP send buffers are full (because the client has not
-  //    yet acked).
-  // 5. Server calls SSL_renegotiate followed by SSL_handshake.
-  // 6. Server calls AsyncRead, which calls engine->Read(), which should return NEED_WRITE
-  //    because the state machine requires a protocol renegotiation and the internal buffers
-  //    are full.
-  // The idea is that when the server reads, the internal OpenSSL state machine needs to
-  // exchange protocol data but cannot, because the TCP buffers are full and consequently the
-  // internal BIO buffers are not yet flushed, so engine->Read() will return NEED_WRITE so that
-  // the protocol renegotiation can kick in. Even though this scenario seems easy to simulate, it
-  // does not reliably reproduce NEED_WRITE, so for now this function simulates it directly.
-  void __DebugForceNeedWriteOnAsyncRead(const iovec* v, uint32_t len, io::AsyncProgressCb cb);
-
-  // Used to test AsyncWrite  NEED_WRITE on first PushUserDataToEngine. As this scenario is
-  // difficult to time, this function helps simulate it.
-  void __DebugForceNeedWriteOnAsyncWrite(const iovec* v, uint32_t len, io::AsyncProgressCb cb);
+  TlsAsyncIo async_io_{this};
 
   // - Owns the shared state bits and CV used by the blocking, non-blocking, and async paths. A
   // fiber that conflicts with an in-progress read, write, or shutdown waits on this CV instead of

--- a/util/tls/tls_socket_async.cc
+++ b/util/tls/tls_socket_async.cc
@@ -6,6 +6,8 @@
 #include <utility>
 
 #include "base/logging.h"
+#include "util/tls/tls_async_io.h"
+#include "util/tls/tls_async_req.h"
 #include "util/tls/tls_engine.h"
 #include "util/tls/tls_socket.h"
 
@@ -15,7 +17,25 @@ namespace tls {
 using namespace std;
 using nonstd::make_unexpected;
 
-void TlsSocket::AsyncReq::MaybeSendOutputAsyncWithRead() {
+TlsAsyncIo::TlsAsyncIo(TlsSocket* owner) : owner_(owner) {
+}
+
+TlsAsyncIo::~TlsAsyncIo() = default;
+
+void TlsAsyncIo::StartAsyncWrite(io::AsyncProgressCb async_write_cb) {
+  // Hard CHECK: overwriting a live request would free a TlsAsyncReq still referenced by in-flight
+  // AsyncWriteSome callbacks (use-after-free). Callers guarantee no write is in flight
+  // (TrySend/TryRecv bail out early on WRITE_IN_PROGRESS), so this never fires in correct runs.
+  CHECK(!async_write_req_);
+  DCHECK_GT(owner_->engine_->OutputPending(), 0u);
+  // (vec, len) = (nullptr, 0): no new user bytes, only the engine's buffered output is sent.
+  // AsyncRoleBasedAction treats a WRITER with vec_ == nullptr as output-only and ends when drained.
+  async_write_req_ = std::make_unique<TlsAsyncReq>(owner_, this, std::move(async_write_cb), nullptr,
+                                                   0, TlsAsyncReq::WRITER);
+  async_write_req_->StartUpstreamWrite();
+}
+
+void TlsAsyncReq::MaybeSendOutputAsyncWithRead() {
   if (owner_->engine_->OutputPending() != 0) {
     // Once the networking socket completes the write, it will start the read path
     // We use this bool to signal this.
@@ -27,8 +47,8 @@ void TlsSocket::AsyncReq::MaybeSendOutputAsyncWithRead() {
   StartUpstreamRead();
 }
 
-void TlsSocket::AsyncReq::AsyncReadProgressCb(io::Result<size_t> read_result) {
-  owner_->flags_.clear_io_in_progress_and_notify(READ_IN_PROGRESS);
+void TlsAsyncReq::AsyncReadProgressCb(io::Result<size_t> read_result) {
+  owner_->flags_.clear_io_in_progress_and_notify(TlsSocket::READ_IN_PROGRESS);
   RunPending();
   if (!read_result) {
     // Erroneous path. Apply the completion callback and exit.
@@ -46,13 +66,13 @@ void TlsSocket::AsyncReq::AsyncReadProgressCb(io::Result<size_t> read_result) {
   AsyncRoleBasedAction();
 }
 
-void TlsSocket::AsyncReq::StartUpstreamRead() {
+void TlsAsyncReq::StartUpstreamRead() {
   auto& socket_flags = owner_->flags_;
   // Even if we early return below we still should not try to read. When we
   // wake up we will poll the SSL engine which will dictate the next action/step.
   should_read_ = false;
   if (socket_flags.read_in_progress()) {
-    auto* prev = std::exchange(owner_->blocked_async_req_, this);
+    auto* prev = std::exchange(async_io_->blocked_async_req_, this);
     CHECK(prev == nullptr);
     return;
   }
@@ -68,17 +88,17 @@ void TlsSocket::AsyncReq::StartUpstreamRead() {
                                     [this](auto res) { this->AsyncReadProgressCb(res); });
 }
 
-void TlsSocket::AsyncReq::CompleteAsyncReq(io::Result<size_t> result) {
-  std::unique_ptr<AsyncReq> current;
+void TlsAsyncReq::CompleteAsyncReq(io::Result<size_t> result) {
+  std::unique_ptr<TlsAsyncReq> current;
   if (role_ == Role::READER) {
-    current = std::move(owner_->async_read_req_);
+    current = std::move(async_io_->async_read_req_);
   } else {
-    current = std::move(owner_->async_write_req_);
+    current = std::move(async_io_->async_write_req_);
   }
   current->caller_completion_cb_(result);
 }
 
-void TlsSocket::AsyncReq::HandleOpAsync(int op_val) {
+void TlsAsyncReq::HandleOpAsync(int op_val) {
   if (op_val > 0) {
     CompleteAsyncReq(op_val);
     return;
@@ -103,11 +123,12 @@ void TlsSocket::AsyncReq::HandleOpAsync(int op_val) {
   }
 }
 
-void TlsSocket::AsyncReadSome(const iovec* v, uint32_t len, io::AsyncProgressCb cb) {
+void TlsAsyncIo::AsyncReadSome(const iovec* v, uint32_t len, io::AsyncProgressCb cb) {
   // Engine read
   CHECK(!async_read_req_);
 
-  Engine::OpResult op_val = engine_->Read(reinterpret_cast<uint8_t*>(v->iov_base), v->iov_len);
+  Engine::OpResult op_val =
+      owner_->engine_->Read(reinterpret_cast<uint8_t*>(v->iov_base), v->iov_len);
   DVLOG(2) << "Engine::Read tried to read " << v->iov_len << " bytes, got " << op_val;
   // We read some data from the engine. Satisfy the request and return.
   if (op_val > 0) {
@@ -115,25 +136,25 @@ void TlsSocket::AsyncReadSome(const iovec* v, uint32_t len, io::AsyncProgressCb 
   }
 
   if (op_val == Engine::EOF_ABRUPT) {
-    VLOG(1) << "EOF_ABRUPT received " << next_sock_->native_handle();
+    VLOG(1) << "EOF_ABRUPT received " << owner_->next_sock_->native_handle();
     return cb(make_unexpected(make_error_code(errc::connection_reset)));
   }
   if (op_val == Engine::EOF_GRACEFUL) {
-    VLOG(1) << "EOF_GRACEFUL received " << next_sock_->native_handle();
+    VLOG(1) << "EOF_GRACEFUL received " << owner_->next_sock_->native_handle();
     return cb(0);  // return 0 to indicate EOF
   }
 
   // We could not read from the engine. Dispatch async op.
   DCHECK_GT(len, 0u);
-  auto req = AsyncReq{this, std::move(cb), v, len, AsyncReq::READER};
-  async_read_req_ = std::make_unique<AsyncReq>(std::move(req));
+  auto req = TlsAsyncReq{owner_, this, std::move(cb), v, len, TlsAsyncReq::READER};
+  async_read_req_ = std::make_unique<TlsAsyncReq>(std::move(req));
   async_read_req_->HandleOpAsync(op_val);
 }
 
-void TlsSocket::AsyncReq::AsyncWriteProgressCb(io::Result<size_t> write_result) {
+void TlsAsyncReq::AsyncWriteProgressCb(io::Result<size_t> write_result) {
   auto& socket_flags = owner_->flags_;
   if (!write_result) {
-    socket_flags.clear_io_in_progress_and_notify(WRITE_IN_PROGRESS);
+    socket_flags.clear_io_in_progress_and_notify(TlsSocket::WRITE_IN_PROGRESS);
 
     // broken_pipe - happens when the other side closes the connection. do not log this.
     if (write_result.error() != errc::broken_pipe) {
@@ -153,7 +174,7 @@ void TlsSocket::AsyncReq::AsyncWriteProgressCb(io::Result<size_t> write_result) 
   owner_->upstream_write_ += *write_result;
   owner_->engine_->ConsumeOutputBuf(*write_result);
   // We might have more data pending. Peek again.
-  Buffer buffer = owner_->engine_->PeekOutputBuf();
+  TlsSocket::Buffer buffer = owner_->engine_->PeekOutputBuf();
 
   // We are not done. Re-arm the async write until we drive it to completion or error.
   // We would also like to avoid fragmented socket writes so we make sure we drain it here
@@ -171,7 +192,7 @@ void TlsSocket::AsyncReq::AsyncWriteProgressCb(io::Result<size_t> write_result) 
                 << " bytes. Async short write detected";
   }
 
-  socket_flags.clear_io_in_progress_and_notify(WRITE_IN_PROGRESS);
+  socket_flags.clear_io_in_progress_and_notify(TlsSocket::WRITE_IN_PROGRESS);
   RunPending();
 
   // We are done with the write, check if we also need to read because we are
@@ -184,7 +205,7 @@ void TlsSocket::AsyncReq::AsyncWriteProgressCb(io::Result<size_t> write_result) 
   AsyncRoleBasedAction();
 }
 
-void TlsSocket::AsyncReq::AsyncRoleBasedAction() {
+void TlsAsyncReq::AsyncRoleBasedAction() {
   if (role_ == READER) {
     auto op_val = owner_->engine_->Read(reinterpret_cast<uint8_t*>(vec_->iov_base), vec_->iov_len);
     DVLOG(2) << "Engine::Read tried to read " << vec_->iov_len << " bytes, got " << op_val;
@@ -208,7 +229,7 @@ void TlsSocket::AsyncReq::AsyncRoleBasedAction() {
     return;
   }
   // We need to call PushUserDataToEngine again
-  PushResult push_res = owner_->PushUserDataToEngine(vec_, len_);
+  TlsSocket::PushResult push_res = owner_->PushUserDataToEngine(vec_, len_);
   Engine::OpResult op_val = push_res.engine_opcode;
   engine_written_ = push_res.written;
   if (op_val < 0) {
@@ -219,11 +240,11 @@ void TlsSocket::AsyncReq::AsyncRoleBasedAction() {
   StartUpstreamWrite();
 }
 
-void TlsSocket::AsyncReq::StartUpstreamWrite() {
+void TlsAsyncReq::StartUpstreamWrite() {
   auto& socket_flags = owner_->flags_;
   if (socket_flags.write_in_progress()) {
-    CHECK(owner_->blocked_async_req_ == nullptr);
-    owner_->blocked_async_req_ = this;
+    CHECK(async_io_->blocked_async_req_ == nullptr);
+    async_io_->blocked_async_req_ = this;
     return;
   }
 
@@ -243,14 +264,14 @@ void TlsSocket::AsyncReq::StartUpstreamWrite() {
       &scratch, 1, [this](auto write_result) { AsyncWriteProgressCb(write_result); });
 }
 
-void TlsSocket::AsyncReq::MaybeSendOutputAsync() {
+void TlsAsyncReq::MaybeSendOutputAsync() {
   if (owner_->engine_->OutputPending() == 0) {
     return;
   }
 
   if (owner_->flags_.write_in_progress()) {
-    CHECK(owner_->blocked_async_req_ == nullptr);
-    owner_->blocked_async_req_ = this;
+    CHECK(async_io_->blocked_async_req_ == nullptr);
+    async_io_->blocked_async_req_ = this;
     return;
   }
 
@@ -269,16 +290,16 @@ void TlsSocket::AsyncReq::MaybeSendOutputAsync() {
    Only if TrySend does not flush everything, we need to enter the async state machine. All this is
    similar to how posix write path works.
 */
-void TlsSocket::AsyncWriteSome(const iovec* v, uint32_t len, io::AsyncProgressCb cb) {
+void TlsAsyncIo::AsyncWriteSome(const iovec* v, uint32_t len, io::AsyncProgressCb cb) {
   CHECK(!async_write_req_);
 
   // Write to the engine
-  PushResult push_res = PushUserDataToEngine(v, len);
+  TlsSocket::PushResult push_res = owner_->PushUserDataToEngine(v, len);
 
-  auto req = AsyncReq{this, std::move(cb), v, len, AsyncReq::WRITER};
+  auto req = TlsAsyncReq{owner_, this, std::move(cb), v, len, TlsAsyncReq::WRITER};
   req.SetEngineWritten(push_res.written);
 
-  async_write_req_ = std::make_unique<AsyncReq>(std::move(req));
+  async_write_req_ = std::make_unique<TlsAsyncReq>(std::move(req));
   const int op_val = push_res.engine_opcode;
 
   // Handle engine state.
@@ -293,12 +314,12 @@ void TlsSocket::AsyncWriteSome(const iovec* v, uint32_t len, io::AsyncProgressCb
   }
 }
 
-void TlsSocket::AsyncReq::RunPending() {
-  if (!owner_->blocked_async_req_) {
+void TlsAsyncReq::RunPending() {
+  if (!async_io_->blocked_async_req_) {
     return;
   }
 
-  auto* blocked = std::exchange(owner_->blocked_async_req_, nullptr);
+  auto* blocked = std::exchange(async_io_->blocked_async_req_, nullptr);
 
   if (blocked->should_read_) {
     blocked->StartUpstreamRead();
@@ -306,34 +327,12 @@ void TlsSocket::AsyncReq::RunPending() {
   }
 
   if (blocked->role_ == Role::WRITER) {
-    auto current = std::move(owner_->async_write_req_);
+    auto current = std::move(async_io_->async_write_req_);
     owner_->AsyncWriteSome(current->vec_, current->len_, std::move(current->caller_completion_cb_));
     return;
   }
-  auto current = std::move(owner_->async_read_req_);
+  auto current = std::move(async_io_->async_read_req_);
   owner_->AsyncReadSome(current->vec_, current->len_, std::move(current->caller_completion_cb_));
-}
-
-void TlsSocket::__DebugForceNeedWriteOnAsyncRead(const iovec* v, uint32_t len,
-                                                 io::AsyncProgressCb cb) {
-  // Engine read
-  CHECK(!async_read_req_);
-  auto req = AsyncReq{this, std::move(cb), v, len, AsyncReq::READER};
-  async_read_req_ = std::make_unique<AsyncReq>(std::move(req));
-  async_read_req_->HandleOpAsync(Engine::NEED_WRITE);
-}
-
-void TlsSocket::__DebugForceNeedWriteOnAsyncWrite(const iovec* v, uint32_t len,
-                                                  io::AsyncProgressCb cb) {
-  CHECK(!async_write_req_);
-  auto req = AsyncReq{this, std::move(cb), v, len, AsyncReq::WRITER};
-  async_write_req_ = std::make_unique<AsyncReq>(std::move(req));
-
-  // Simulate NEED_READ_AND_MAYBE_WRITE. By the end of the async write we should have
-  // sent 2x v->iov_len.
-  // The reason for this is that we "mock" the state machine with v->iov_len data
-  // which we treat as protocol data.
-  async_write_req_->HandleOpAsync(Engine::NEED_READ_AND_MAYBE_WRITE);
 }
 
 }  // namespace tls

--- a/util/tls/tls_socket_async.cc
+++ b/util/tls/tls_socket_async.cc
@@ -95,6 +95,7 @@ void TlsAsyncReq::CompleteAsyncReq(io::Result<size_t> result) {
   } else {
     current = std::move(async_io_->async_write_req_);
   }
+  CHECK(current.get() == this);
   current->caller_completion_cb_(result);
 }
 
@@ -146,8 +147,8 @@ void TlsAsyncIo::AsyncReadSome(const iovec* v, uint32_t len, io::AsyncProgressCb
 
   // We could not read from the engine. Dispatch async op.
   DCHECK_GT(len, 0u);
-  auto req = TlsAsyncReq{owner_, this, std::move(cb), v, len, TlsAsyncReq::READER};
-  async_read_req_ = std::make_unique<TlsAsyncReq>(std::move(req));
+  async_read_req_ =
+      std::make_unique<TlsAsyncReq>(owner_, this, std::move(cb), v, len, TlsAsyncReq::READER);
   async_read_req_->HandleOpAsync(op_val);
 }
 
@@ -296,10 +297,9 @@ void TlsAsyncIo::AsyncWriteSome(const iovec* v, uint32_t len, io::AsyncProgressC
   // Write to the engine
   TlsSocket::PushResult push_res = owner_->PushUserDataToEngine(v, len);
 
-  auto req = TlsAsyncReq{owner_, this, std::move(cb), v, len, TlsAsyncReq::WRITER};
-  req.SetEngineWritten(push_res.written);
-
-  async_write_req_ = std::make_unique<TlsAsyncReq>(std::move(req));
+  async_write_req_ =
+      std::make_unique<TlsAsyncReq>(owner_, this, std::move(cb), v, len, TlsAsyncReq::WRITER);
+  async_write_req_->SetEngineWritten(push_res.written);
   const int op_val = push_res.engine_opcode;
 
   // Handle engine state.

--- a/util/tls/tls_socket_test.cc
+++ b/util/tls/tls_socket_test.cc
@@ -1006,7 +1006,8 @@ TEST_P(AsyncTlsSocketNeedWrite, AsyncReadNeedWrite) {
       }
 
       VLOG(1) << "Step 2";
-      // Write it again to simulate NEED_READ_AND_MAYBE_WRITE in ForceNeedWriteOnAsyncWrite.
+      // Write it again to simulate NEED_READ_AND_MAYBE_WRITE in
+      // ForceNeedReadAndMaybeWriteOnAsyncWrite.
       tls_sock->AsyncWrite(&v, 1, [&](auto result) mutable {
         EXPECT_FALSE(result);
         done.Notify();

--- a/util/tls/tls_socket_test.cc
+++ b/util/tls/tls_socket_test.cc
@@ -19,6 +19,7 @@
 #include "util/fibers/fibers.h"
 #include "util/fibers/synchronization.h"
 #include "util/tls/iovec_utils.h"
+#include "util/tls/tls_async_req.h"
 #include "util/tls/tls_socket.h"
 #include "util/tls/tls_test_infra.h"
 
@@ -958,13 +959,15 @@ class AsyncTlsSocketNeedWrite : public AsyncTlsSocketTest {
     // Without handling NEED_WRITE in AsyncReq::CompleteAsyncReq we would deadlock here
     uint8_t res[256];
     iovec v{.iov_base = &res, .iov_len = 256};
-    tls_socket_->__DebugForceNeedWriteOnAsyncRead(&v, 1, [&](auto res) { done.Notify(); });
+    tls::TestDelegator::ForceNeedWriteOnAsyncRead(tls_socket_.get(), &v, 1,
+                                                  [&](auto res) { done.Notify(); });
 
     done.Wait();
     VLOG(1) << "Read completed";
     done.Reset();
 
-    tls_socket_->__DebugForceNeedWriteOnAsyncWrite(&v, 1, [&](auto res) { done.Notify(); });
+    tls::TestDelegator::ForceNeedWriteOnAsyncWrite(tls_socket_.get(), &v, 1,
+                                                   [&](auto res) { done.Notify(); });
     done.Wait();
     VLOG(1) << "Write completed";
   }
@@ -1003,7 +1006,7 @@ TEST_P(AsyncTlsSocketNeedWrite, AsyncReadNeedWrite) {
       }
 
       VLOG(1) << "Step 2";
-      // Write it again to simulate NEED_READ_AND_MAYBE_WRITE in __DebugForceNeedWriteOnAsyncWrite
+      // Write it again to simulate NEED_READ_AND_MAYBE_WRITE in ForceNeedWriteOnAsyncWrite.
       tls_sock->AsyncWrite(&v, 1, [&](auto result) mutable {
         EXPECT_FALSE(result);
         done.Notify();
@@ -1203,6 +1206,22 @@ TEST_P(AsyncTlsSocketRenegotiate, Renegotiate) {
 }  // namespace util
 
 namespace util::tls {
+
+void TestDelegator::ForceNeedWriteOnAsyncRead(TlsSocket* sock, const iovec* v, uint32_t len,
+                                              io::AsyncProgressCb cb) {
+  CHECK(!sock->async_io_.async_read_req_);
+  auto req = TlsAsyncReq{sock, &sock->async_io_, std::move(cb), v, len, TlsAsyncReq::READER};
+  sock->async_io_.async_read_req_ = std::make_unique<TlsAsyncReq>(std::move(req));
+  sock->async_io_.async_read_req_->HandleOpAsync(Engine::NEED_WRITE);
+}
+
+void TestDelegator::ForceNeedWriteOnAsyncWrite(TlsSocket* sock, const iovec* v, uint32_t len,
+                                               io::AsyncProgressCb cb) {
+  CHECK(!sock->async_io_.async_write_req_);
+  auto req = TlsAsyncReq{sock, &sock->async_io_, std::move(cb), v, len, TlsAsyncReq::WRITER};
+  sock->async_io_.async_write_req_ = std::make_unique<TlsAsyncReq>(std::move(req));
+  sock->async_io_.async_write_req_->HandleOpAsync(Engine::NEED_READ_AND_MAYBE_WRITE);
+}
 
 // Mock Fixture
 class MockTlsSocketTest : public testing::TestWithParam<std::string> {

--- a/util/tls/tls_socket_test.cc
+++ b/util/tls/tls_socket_test.cc
@@ -956,7 +956,7 @@ TEST_P(AsyncTlsSocketTest, AsyncRW) {
 class AsyncTlsSocketNeedWrite : public AsyncTlsSocketTest {
   virtual void HandleRequest() {
     Done done;
-    // Without handling NEED_WRITE in AsyncReq::CompleteAsyncReq we would deadlock here
+    // Without handling NEED_WRITE in TlsAsyncReq::CompleteAsyncReq we would deadlock here.
     uint8_t res[256];
     iovec v{.iov_base = &res, .iov_len = 256};
     tls::TestDelegator::ForceNeedWriteOnAsyncRead(tls_socket_.get(), &v, 1,
@@ -966,8 +966,8 @@ class AsyncTlsSocketNeedWrite : public AsyncTlsSocketTest {
     VLOG(1) << "Read completed";
     done.Reset();
 
-    tls::TestDelegator::ForceNeedWriteOnAsyncWrite(tls_socket_.get(), &v, 1,
-                                                   [&](auto res) { done.Notify(); });
+    tls::TestDelegator::ForceNeedReadAndMaybeWriteOnAsyncWrite(tls_socket_.get(), &v, 1,
+                                                               [&](auto res) { done.Notify(); });
     done.Wait();
     VLOG(1) << "Write completed";
   }
@@ -1210,16 +1210,16 @@ namespace util::tls {
 void TestDelegator::ForceNeedWriteOnAsyncRead(TlsSocket* sock, const iovec* v, uint32_t len,
                                               io::AsyncProgressCb cb) {
   CHECK(!sock->async_io_.async_read_req_);
-  auto req = TlsAsyncReq{sock, &sock->async_io_, std::move(cb), v, len, TlsAsyncReq::READER};
-  sock->async_io_.async_read_req_ = std::make_unique<TlsAsyncReq>(std::move(req));
+  sock->async_io_.async_read_req_ = std::make_unique<TlsAsyncReq>(
+      sock, &sock->async_io_, std::move(cb), v, len, TlsAsyncReq::READER);
   sock->async_io_.async_read_req_->HandleOpAsync(Engine::NEED_WRITE);
 }
 
-void TestDelegator::ForceNeedWriteOnAsyncWrite(TlsSocket* sock, const iovec* v, uint32_t len,
-                                               io::AsyncProgressCb cb) {
+void TestDelegator::ForceNeedReadAndMaybeWriteOnAsyncWrite(TlsSocket* sock, const iovec* v,
+                                                           uint32_t len, io::AsyncProgressCb cb) {
   CHECK(!sock->async_io_.async_write_req_);
-  auto req = TlsAsyncReq{sock, &sock->async_io_, std::move(cb), v, len, TlsAsyncReq::WRITER};
-  sock->async_io_.async_write_req_ = std::make_unique<TlsAsyncReq>(std::move(req));
+  sock->async_io_.async_write_req_ = std::make_unique<TlsAsyncReq>(
+      sock, &sock->async_io_, std::move(cb), v, len, TlsAsyncReq::WRITER);
   sock->async_io_.async_write_req_->HandleOpAsync(Engine::NEED_READ_AND_MAYBE_WRITE);
 }
 

--- a/util/tls/tls_test_infra.h
+++ b/util/tls/tls_test_infra.h
@@ -26,10 +26,11 @@ class TestDelegator {
   static void SetState(TlsSocket* sock, uint8_t state) {
     sock->flags_.overwrite(state);
   }
+  // Defined in tls_socket_test.cc because they construct TlsAsyncReq test requests.
   static void ForceNeedWriteOnAsyncRead(TlsSocket* sock, const iovec* v, uint32_t len,
                                         io::AsyncProgressCb cb);
-  static void ForceNeedWriteOnAsyncWrite(TlsSocket* sock, const iovec* v, uint32_t len,
-                                         io::AsyncProgressCb cb);
+  static void ForceNeedReadAndMaybeWriteOnAsyncWrite(TlsSocket* sock, const iovec* v, uint32_t len,
+                                                     io::AsyncProgressCb cb);
 
   static constexpr uint8_t GetWriteInProgress() {
     return TlsSocket::WRITE_IN_PROGRESS;

--- a/util/tls/tls_test_infra.h
+++ b/util/tls/tls_test_infra.h
@@ -26,6 +26,10 @@ class TestDelegator {
   static void SetState(TlsSocket* sock, uint8_t state) {
     sock->flags_.overwrite(state);
   }
+  static void ForceNeedWriteOnAsyncRead(TlsSocket* sock, const iovec* v, uint32_t len,
+                                        io::AsyncProgressCb cb);
+  static void ForceNeedWriteOnAsyncWrite(TlsSocket* sock, const iovec* v, uint32_t len,
+                                         io::AsyncProgressCb cb);
 
   static constexpr uint8_t GetWriteInProgress() {
     return TlsSocket::WRITE_IN_PROGRESS;


### PR DESCRIPTION
Continue with TLS socket refactoring:
- Move request ownership and state-machine coordination from TlsSocket into TlsAsyncIo and TlsAsyncReq.
- Delegate socket async entry points to the extracted coordinator while preserving callback ownership and blocked-request handling.
- Move test-only helpers out of TlsSocket and implement them through TestDelegator in test code.