### PR TITLE
feat(io_buf): add capacity shrinking

### DIFF
--- a/base/io_buf.cc
+++ b/base/io_buf.cc
@@ -39,10 +39,26 @@ void IoBuf::Reserve(size_t sz) {
     return;
 
   sz = absl::bit_ceil(sz);
-  uint8_t* nb = new (std::align_val_t{alignment_}) uint8_t[sz];
+  Reallocate(sz);
+}
+
+bool IoBuf::ShrinkTo(size_t target_capacity) {
+  if (target_capacity >= capacity_)
+    return false;
+
+  target_capacity = absl::bit_ceil(target_capacity);
+  if ((target_capacity >= capacity_) || (target_capacity < InputLen()))
+    return false;
+
+  Reallocate(target_capacity);
+  return true;
+}
+
+void IoBuf::Reallocate(size_t new_capacity) {
+  uint8_t* new_buf = new (std::align_val_t{alignment_}) uint8_t[new_capacity];
   if (buf_) {
     if (size_ > offs_) {
-      memcpy(nb, buf_ + offs_, size_ - offs_);
+      memcpy(new_buf, buf_ + offs_, size_ - offs_);
       size_ -= offs_;
       offs_ = 0;
     } else {
@@ -50,9 +66,9 @@ void IoBuf::Reserve(size_t sz) {
     }
     ::operator delete[](buf_, std::align_val_t{alignment_});
   }
-
-  buf_ = nb;
-  capacity_ = sz;
+  buf_ = new_buf;
+  capacity_ = new_capacity;
+  ++generation_;
 }
 
 void IoBuf::Swap(IoBuf& other) {
@@ -61,6 +77,7 @@ void IoBuf::Swap(IoBuf& other) {
   std::swap(size_, other.size_);
   std::swap(alignment_, other.alignment_);
   std::swap(capacity_, other.capacity_);
+  std::swap(generation_, other.generation_);
 }
 
 };  // namespace base

--- a/base/io_buf.h
+++ b/base/io_buf.h
@@ -7,6 +7,7 @@
 #include <absl/types/span.h>
 
 #include <cassert>
+#include <cstdint>
 #include <cstring>
 
 namespace base {
@@ -14,6 +15,15 @@ namespace base {
 // Generic buffer for reads and writes.
 // Write directly to AppendBuffer() and mark bytes as written with CommitWrite.
 // Read from InputBuffer() and mark bytes as read with ConsumeInput.
+//
+// Here's how IoBuf looks in memory:
+//
+// buf_:    [  consumed  |  unread input  |  append room  ]
+//          ^            ^                ^               ^
+//          0           offs_            size_         capacity_
+//
+// InputBuffer(): immutable view [offs_, size_): bytes ready to parse.
+// AppendBuffer(): mutable view [size_, capacity_): room for new reads or writes.
 class IoBuf {
  public:
   using Bytes = absl::Span<uint8_t>;
@@ -80,14 +90,23 @@ class IoBuf {
   // Ensures append buffer is large enough.
   void WriteAndCommit(const void* source, size_t num_copy);
 
-  // Ensure required append buffer size.
+  // Ensure required append buffer size without reallocating when the current append region fits.
   void EnsureCapacity(size_t sz) {
-    Reserve(size_ + sz);
+    if (sz > AppendLen()) {
+      Reserve(size_ + sz);
+    }
   }
 
-  // Reserve by whole buffer size.
-  // Use EnsureCapacity instead for resizing only by desired append buffer size.
+  // Ensures the whole buffer has at least full_size capacity. An equal-size request (full_size is
+  // equal to the current capacity) reallocates the raw buffer and compacts unread input. Use
+  // EnsureCapacity for append space instead.
   void Reserve(size_t full_size);
+
+  // Reduces capacity while preserving unread input. The new capacity is the smallest power of two
+  // that is at least target_capacity; a zero target selects one byte. Returns false if the target
+  // is at least the current capacity, the resulting capacity cannot hold InputLen(), or the target
+  // rounds to the current capacity.
+  [[nodiscard]] bool ShrinkTo(size_t target_capacity);
 
   // ============== GENERIC ===========
 
@@ -119,12 +138,20 @@ class IoBuf {
     return capacity_;
   }
 
+  // Returns a counter identifying the current raw buffer memory. It changes only when Reserve or
+  // ShrinkTo replaces that memory.
+  uint64_t generation() const {
+    return generation_;
+  }
+
   struct MemoryUsage {
     size_t consumed = 0;
     size_t input_length = 0;
     size_t append_length = 0;
 
-    size_t GetTotalSize() const { return consumed + input_length + append_length; }
+    size_t GetTotalSize() const {
+      return consumed + input_length + append_length;
+    }
 
     MemoryUsage& operator+=(const MemoryUsage& o) {
       consumed += o.consumed;
@@ -136,20 +163,26 @@ class IoBuf {
 
   MemoryUsage GetMemoryUsage() const {
     return {
-      .consumed = offs_,
-      .input_length = InputLen(),
-      .append_length = AppendLen(),
+        .consumed = offs_,
+        .input_length = InputLen(),
+        .append_length = AppendLen(),
     };
   }
 
  private:
+  void Reallocate(size_t new_capacity);
   void Swap(IoBuf& other);
 
   uint8_t* buf_ = nullptr;
+  // Offset to unread input within buf_.
   size_t offs_ = 0;
+  // Number of bytes written into buf_, including consumed input before offs_.
   size_t size_ = 0;
   size_t alignment_ = 8;
+  // Total size of buf_.
   size_t capacity_ = 0;
+  // Tracks raw buffer memory replacements.
+  uint64_t generation_ = 0;
 };
 
 }  // namespace base

--- a/base/io_buf.h
+++ b/base/io_buf.h
@@ -139,7 +139,8 @@ class IoBuf {
   }
 
   // Returns a counter identifying the current raw buffer memory. It changes only when Reserve or
-  // ShrinkTo replaces that memory.
+  // ShrinkTo replaces that memory, not when Compact() changes the layout within it. Do not use it
+  // as a span-validity check.
   uint64_t generation() const {
     return generation_;
   }

--- a/base/io_buf_test.cc
+++ b/base/io_buf_test.cc
@@ -5,6 +5,7 @@
 #include "base/io_buf.h"
 
 #include <cstring>
+#include <utility>
 
 #include <gtest/gtest.h>
 
@@ -39,6 +40,7 @@ TEST(IoBuf, AutoCompactSmallRemainder) {
   ASSERT_EQ(buf.InputLen(), kCompactThreshold);
   ASSERT_EQ(buf.Capacity(), kCap);
   ASSERT_EQ(buf.AppendLen(), kCap - kCompactThreshold);  // NOT at full capacity
+  const uint64_t generation = buf.generation();
 
   constexpr size_t kRemainder = 100;
   static_assert(kCompactThreshold > kRemainder,
@@ -49,6 +51,7 @@ TEST(IoBuf, AutoCompactSmallRemainder) {
   buf.ConsumeInput(kCompactThreshold - kRemainder);
   EXPECT_EQ(buf.InputLen(), kRemainder);
   EXPECT_EQ(buf.AppendLen(), kCap - kRemainder);  // offs_ reset to 0, space reclaimed
+  EXPECT_EQ(buf.generation(), generation);
   for (uint8_t b : buf.InputBuffer()) {
     EXPECT_EQ(b, 0xAA);
   }
@@ -77,11 +80,169 @@ TEST(IoBuf, CompactReclaimsSpaceOnFullBuffer) {
   ASSERT_EQ(buf.AppendLen(), 0u);  // deadlock-prone state
 
   // Caller must explicitly compact to reclaim consumed space.
+  const uint64_t generation = buf.generation();
   buf.Compact();
   EXPECT_EQ(buf.InputLen(), kRemainder);
   EXPECT_EQ(buf.AppendLen(), kConsumed);
+  EXPECT_EQ(buf.generation(), generation);
   for (uint8_t b : buf.InputBuffer()) {
     EXPECT_EQ(b, 0xBB);
+  }
+}
+
+// Verifies shrinking preserves unread input and replaces the raw buffer memory.
+TEST(IoBuf, ShrinkPreservesUnreadInput) {
+  IoBuf buf(1024);
+  FillAppend(&buf, 0xCC);
+  buf.ConsumeInput(600);
+
+  const uint64_t generation = buf.generation();
+  ASSERT_TRUE(buf.ShrinkTo(512));
+  EXPECT_EQ(buf.Capacity(), 512u);
+  EXPECT_EQ(buf.InputLen(), 424u);
+  EXPECT_GT(buf.generation(), generation);
+  for (uint8_t byte : buf.InputBuffer()) {
+    EXPECT_EQ(byte, 0xCC);
+  }
+}
+
+// Verifies shrinking validates the rounded capacity rather than the requested target.
+TEST(IoBuf, ShrinkRoundsUpToFitUnreadInput) {
+  IoBuf buf(1024);
+  FillAppend(&buf, 0xCC);
+  buf.ConsumeInput(700);
+
+  ASSERT_TRUE(buf.ShrinkTo(257));
+  EXPECT_EQ(buf.Capacity(), 512u);
+  EXPECT_EQ(buf.InputLen(), 324u);
+  for (uint8_t byte : buf.InputBuffer()) {
+    EXPECT_EQ(byte, 0xCC);
+  }
+}
+
+// Verifies shrinking an empty buffer updates capacity and raw buffer memory.
+TEST(IoBuf, ShrinkEmptyBuffer) {
+  IoBuf buf(1024);
+
+  const uint64_t generation = buf.generation();
+  ASSERT_TRUE(buf.ShrinkTo(512));
+  EXPECT_EQ(buf.Capacity(), 512u);
+  EXPECT_EQ(buf.InputLen(), 0u);
+  EXPECT_EQ(buf.AppendLen(), 512u);
+  EXPECT_GT(buf.generation(), generation);
+}
+
+// Verifies a zero shrink target selects the minimum one-byte capacity.
+TEST(IoBuf, ShrinkZeroTargetUsesMinimumCapacity) {
+  IoBuf buf(1024);
+
+  ASSERT_TRUE(buf.ShrinkTo(0));
+  EXPECT_EQ(buf.Capacity(), 1u);
+  EXPECT_EQ(buf.InputLen(), 0u);
+  EXPECT_EQ(buf.AppendLen(), 1u);
+}
+
+// Verifies an equal-capacity reserve compacts unread input.
+TEST(IoBuf, ReserveEqualCapacityCompactsUnreadInput) {
+  IoBuf buf(1024);
+  FillAppend(&buf, 0xCC);
+  buf.ConsumeInput(400);
+
+  const uint64_t generation = buf.generation();
+  buf.Reserve(1024);
+
+  EXPECT_EQ(buf.Capacity(), 1024u);
+  EXPECT_EQ(buf.InputLen(), 624u);
+  EXPECT_EQ(buf.AppendLen(), 400u);
+  EXPECT_GT(buf.generation(), generation);
+  for (uint8_t byte : buf.InputBuffer()) {
+    EXPECT_EQ(byte, 0xCC);
+  }
+}
+
+// Verifies growing the buffer preserves unread input and replaces raw buffer memory.
+TEST(IoBuf, ReserveGrowingPreservesUnreadInput) {
+  IoBuf buf(512);
+  FillAppend(&buf, 0xCC);
+  buf.ConsumeInput(100);
+
+  const uint64_t generation = buf.generation();
+  buf.Reserve(1024);
+
+  EXPECT_EQ(buf.Capacity(), 1024u);
+  EXPECT_EQ(buf.InputLen(), 412u);
+  EXPECT_EQ(buf.AppendLen(), 612u);
+  EXPECT_GT(buf.generation(), generation);
+  for (uint8_t byte : buf.InputBuffer()) {
+    EXPECT_EQ(byte, 0xCC);
+  }
+}
+
+// Verifies a smaller reserve request does not replace raw buffer memory.
+TEST(IoBuf, ReserveSmallerCapacityDoesNothing) {
+  IoBuf buf(1024);
+  FillAppend(&buf, 0xCC);
+  buf.ConsumeInput(400);
+
+  const uint64_t generation = buf.generation();
+  buf.Reserve(512);
+
+  EXPECT_EQ(buf.Capacity(), 1024u);
+  EXPECT_EQ(buf.InputLen(), 624u);
+  EXPECT_EQ(buf.AppendLen(), 0u);
+  EXPECT_EQ(buf.generation(), generation);
+}
+
+// Verifies EnsureCapacity does not replace raw buffer memory when append space fits.
+TEST(IoBuf, EnsureCapacityDoesNothingWhenAppendSpaceFits) {
+  IoBuf buf(1024);
+  auto appendbuf = buf.AppendBuffer();
+  memset(appendbuf.data(), 0xCC, 600);
+  buf.CommitWrite(600);
+  buf.ConsumeInput(100);
+
+  const uint64_t generation = buf.generation();
+  buf.EnsureCapacity(buf.AppendLen());
+
+  EXPECT_EQ(buf.Capacity(), 1024u);
+  EXPECT_EQ(buf.InputLen(), 500u);
+  EXPECT_EQ(buf.AppendLen(), 424u);
+  EXPECT_EQ(buf.generation(), generation);
+}
+
+// Verifies shrinking rejects targets that cannot reduce capacity or hold unread input.
+TEST(IoBuf, ShrinkRejectsNonReducingOrTooSmallTarget) {
+  IoBuf buf(1024);
+  FillAppend(&buf, 0xDD);
+  const uint64_t generation = buf.generation();
+
+  EXPECT_FALSE(buf.ShrinkTo(1024));
+  EXPECT_FALSE(buf.ShrinkTo(512));
+  EXPECT_EQ(buf.Capacity(), 1024u);
+  EXPECT_EQ(buf.InputLen(), 1024u);
+  EXPECT_EQ(buf.generation(), generation);
+
+  IoBuf empty_buf(1024);
+  const uint64_t empty_generation = empty_buf.generation();
+  EXPECT_FALSE(empty_buf.ShrinkTo(768));
+  EXPECT_EQ(empty_buf.Capacity(), 1024u);
+  EXPECT_EQ(empty_buf.generation(), empty_generation);
+}
+
+// Verifies moving a buffer preserves the generation associated with its raw memory.
+TEST(IoBuf, MovePreservesGeneration) {
+  IoBuf source(512);
+  FillAppend(&source, 0xEE);
+  source.Reserve(1024);
+
+  const uint64_t generation = source.generation();
+  IoBuf destination(std::move(source));
+
+  EXPECT_EQ(destination.Capacity(), 1024u);
+  EXPECT_EQ(destination.InputLen(), 512u);
+  EXPECT_EQ(destination.generation(), generation);
+  for (uint8_t byte : destination.InputBuffer()) {
+    EXPECT_EQ(byte, 0xEE);
   }
 }
 


### PR DESCRIPTION
- Add ShrinkTo to reclaim unused capacity while preserving unread input
    and round the resulting allocation to a power of two.
- Fix EnsureCapacity so exact-fit append requests retain the existing raw
    buffer, avoiding reallocation, compaction, and span invalidation.
- Track raw-buffer replacements with generation() so callers detect
    invalidated spans.
- Add regression coverage for shrinking, rounded targets, and exact-fit
    capacity behavior.
