### PR TITLE
feat(fibers): support NUMA-aware CPU pinning via offset and list

### DIFF
--- a/base/pthread_utils.cc
+++ b/base/pthread_utils.cc
@@ -10,6 +10,10 @@
 #define _MAC_OS_ 1
 #endif
 
+#if defined(__FreeBSD__)
+#include <pthread_np.h>
+#endif
+
 namespace base {
 
 static void* start_cpp_function(void* arg) {
@@ -31,12 +35,28 @@ void InitCondVarWithClock(clockid_t clock_id, pthread_cond_t* var) {
   PTHREAD_CHECK(condattr_destroy(&attr));
 }
 
-pthread_t StartThread(const char* name, void* (*start_routine)(void*), void* arg) {
+pthread_t StartThread(const char* name, void* (*start_routine)(void*), void* arg,
+                       int cpu_affinity) {
   CHECK_LT(strlen(name), 16U);
 
   pthread_attr_t attrs;
   PTHREAD_CHECK(attr_init(&attrs));
   PTHREAD_CHECK(attr_setstacksize(&attrs, kThreadStackSize));
+
+#if defined(__linux__) || defined(__FreeBSD__)
+  if (cpu_affinity >= 0) {
+    cpu_set_t cps;
+    CPU_ZERO(&cps);
+    CPU_SET(cpu_affinity, &cps);
+    int rc = pthread_attr_setaffinity_np(&attrs, sizeof(cps), &cps);
+    if (rc != 0) {
+      LOG(WARNING) << "Could not set affinity attr to cpu " << cpu_affinity << ": "
+                   << strerror(rc);
+    }
+  }
+#else
+  (void)cpu_affinity;
+#endif
 
   pthread_t result;
   VLOG(1) << "Starting thread " << name;
@@ -52,8 +72,9 @@ pthread_t StartThread(const char* name, void* (*start_routine)(void*), void* arg
   return result;
 }
 
-pthread_t StartThread(const char* name, std::function<void()> f) {
-  return StartThread(name, start_cpp_function, new std::function<void()>(std::move(f)));
+pthread_t StartThread(const char* name, std::function<void()> f, int cpu_affinity) {
+  return StartThread(name, start_cpp_function, new std::function<void()>(std::move(f)),
+                     cpu_affinity);
 }
 
 }  // namespace base

--- a/base/pthread_utils.cc
+++ b/base/pthread_utils.cc
@@ -36,25 +36,24 @@ void InitCondVarWithClock(clockid_t clock_id, pthread_cond_t* var) {
 }
 
 pthread_t StartThread(const char* name, void* (*start_routine)(void*), void* arg,
-                       int cpu_affinity) {
+                      int cpu_affinity) {
   CHECK_LT(strlen(name), 16U);
 
   pthread_attr_t attrs;
   PTHREAD_CHECK(attr_init(&attrs));
   PTHREAD_CHECK(attr_setstacksize(&attrs, kThreadStackSize));
 
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(__GLIBC__) || defined(__FreeBSD__)
+  // musl (e.g. Alpine) lacks pthread_attr_setaffinity_np, so it falls back below instead.
   if (cpu_affinity >= 0) {
     cpu_set_t cps;
     CPU_ZERO(&cps);
     CPU_SET(cpu_affinity, &cps);
     int rc = pthread_attr_setaffinity_np(&attrs, sizeof(cps), &cps);
-    if (rc != 0) {
-      LOG(WARNING) << "Could not set affinity attr to cpu " << cpu_affinity << ": "
-                   << strerror(rc);
-    }
+    CHECK_EQ(0, rc) << "Could not set affinity attr to cpu " << cpu_affinity << ": "
+                    << strerror(rc);
   }
-#else
+#elif !defined(__linux__)
   (void)cpu_affinity;
 #endif
 
@@ -62,6 +61,18 @@ pthread_t StartThread(const char* name, void* (*start_routine)(void*), void* arg
   VLOG(1) << "Starting thread " << name;
 
   PTHREAD_CHECK(create(&result, &attrs, start_routine, arg));
+
+#if defined(__linux__) && !defined(__GLIBC__)
+  // Fallback for musl: no pre-creation affinity API, so pin after creation instead.
+  if (cpu_affinity >= 0) {
+    cpu_set_t cps;
+    CPU_ZERO(&cps);
+    CPU_SET(cpu_affinity, &cps);
+    int rc = pthread_setaffinity_np(result, sizeof(cps), &cps);
+    CHECK_EQ(0, rc) << "Could not set affinity to cpu " << cpu_affinity << ": " << strerror(rc);
+  }
+#endif
+
 #ifndef _MAC_OS_
   int my_err = pthread_setname_np(result, name);
   if (my_err != 0) {

--- a/base/pthread_utils.cc
+++ b/base/pthread_utils.cc
@@ -16,6 +16,15 @@
 
 namespace base {
 
+#if defined(__linux__) || defined(__FreeBSD__)
+static cpu_set_t SingleCpuSet(int cpu) {
+  cpu_set_t cps;
+  CPU_ZERO(&cps);
+  CPU_SET(cpu, &cps);
+  return cps;
+}
+#endif
+
 static void* start_cpp_function(void* arg) {
   std::function<void()>* fp = (std::function<void()>*)arg;
   CHECK(*fp);
@@ -46,9 +55,7 @@ pthread_t StartThread(const char* name, void* (*start_routine)(void*), void* arg
 #if defined(__GLIBC__) || defined(__FreeBSD__)
   // musl (e.g. Alpine) lacks pthread_attr_setaffinity_np, so it falls back below instead.
   if (cpu_affinity >= 0) {
-    cpu_set_t cps;
-    CPU_ZERO(&cps);
-    CPU_SET(cpu_affinity, &cps);
+    cpu_set_t cps = SingleCpuSet(cpu_affinity);
     int rc = pthread_attr_setaffinity_np(&attrs, sizeof(cps), &cps);
     CHECK_EQ(0, rc) << "Could not set affinity attr to cpu " << cpu_affinity << ": "
                     << strerror(rc);
@@ -65,9 +72,7 @@ pthread_t StartThread(const char* name, void* (*start_routine)(void*), void* arg
 #if defined(__linux__) && !defined(__GLIBC__)
   // Fallback for musl: no pre-creation affinity API, so pin after creation instead.
   if (cpu_affinity >= 0) {
-    cpu_set_t cps;
-    CPU_ZERO(&cps);
-    CPU_SET(cpu_affinity, &cps);
+    cpu_set_t cps = SingleCpuSet(cpu_affinity);
     int rc = pthread_setaffinity_np(result, sizeof(cps), &cps);
     CHECK_EQ(0, rc) << "Could not set affinity to cpu " << cpu_affinity << ": " << strerror(rc);
   }

--- a/base/pthread_utils.h
+++ b/base/pthread_utils.h
@@ -22,27 +22,12 @@ constexpr size_t kThreadStackSize = 1 << 18;
 
 void InitCondVarWithClock(clockid_t clock_id, pthread_cond_t* var);
 
-// cpu_affinity: if >= 0, the thread is created already pinned to that cpu id
-// (via pthread_attr_setaffinity_np(3)), avoiding the race of pinning a thread
-// after it has already started running.
-//
-// Rationale: pthread_setaffinity_np(3) on an already-running thread only
-// forces the kernel to migrate its *execution* to an allowed cpu
-// (sched_setaffinity(2): "If the thread ... is not currently running on one
-// of the CPUs specified in mask, then it is migrated to one of those CPUs").
-// It does NOT relocate memory the thread already faulted in. Linux's default
-// NUMA memory policy is "local allocation" a.k.a. first-touch (see numa(7),
-// "MEMORY POLICY" / "local allocation"): a page is placed on the node of the
-// CPU that faults it in, at fault time. So anything the thread touches
-// before the affinity call lands (e.g. thread-local heap arenas, or in our
-// proactor case the io_uring SQ/CQ ring pages allocated in
-// UringProactor::Init) can get first-touched on whatever node the thread
-// happened to start on, and stays there for the life of the process unless
-// AutoNUMA balancing (see Documentation/admin-guide/sysctl/kernel.rst,
-// numa_balancing) opportunistically migrates it later. Setting affinity in
-// the pthread_attr_t before pthread_create(3) avoids the window entirely.
+// See numa(7) ("MEMORY POLICY" / local allocation aka first-touch).
+// cpu_affinity: if >= 0, pins the thread to that cpu id before it starts running, avoiding a
+// first-touch NUMA placement race on whatever the thread allocates early on. Falls back to
+// pinning after creation on libcs without pthread_attr_setaffinity_np(3), e.g. musl.
 pthread_t StartThread(const char* name, void* (*start_routine)(void*), void* arg,
-                       int cpu_affinity = -1);
+                      int cpu_affinity = -1);
 pthread_t StartThread(const char* name, std::function<void()> f, int cpu_affinity = -1);
 
 }  // namespace base

--- a/base/pthread_utils.h
+++ b/base/pthread_utils.h
@@ -22,7 +22,27 @@ constexpr size_t kThreadStackSize = 1 << 18;
 
 void InitCondVarWithClock(clockid_t clock_id, pthread_cond_t* var);
 
-pthread_t StartThread(const char* name, void* (*start_routine)(void*), void* arg);
-pthread_t StartThread(const char* name, std::function<void()> f);
+// cpu_affinity: if >= 0, the thread is created already pinned to that cpu id
+// (via pthread_attr_setaffinity_np(3)), avoiding the race of pinning a thread
+// after it has already started running.
+//
+// Rationale: pthread_setaffinity_np(3) on an already-running thread only
+// forces the kernel to migrate its *execution* to an allowed cpu
+// (sched_setaffinity(2): "If the thread ... is not currently running on one
+// of the CPUs specified in mask, then it is migrated to one of those CPUs").
+// It does NOT relocate memory the thread already faulted in. Linux's default
+// NUMA memory policy is "local allocation" a.k.a. first-touch (see numa(7),
+// "MEMORY POLICY" / "local allocation"): a page is placed on the node of the
+// CPU that faults it in, at fault time. So anything the thread touches
+// before the affinity call lands (e.g. thread-local heap arenas, or in our
+// proactor case the io_uring SQ/CQ ring pages allocated in
+// UringProactor::Init) can get first-touched on whatever node the thread
+// happened to start on, and stays there for the life of the process unless
+// AutoNUMA balancing (see Documentation/admin-guide/sysctl/kernel.rst,
+// numa_balancing) opportunistically migrates it later. Setting affinity in
+// the pthread_attr_t before pthread_create(3) avoids the window entirely.
+pthread_t StartThread(const char* name, void* (*start_routine)(void*), void* arg,
+                       int cpu_affinity = -1);
+pthread_t StartThread(const char* name, std::function<void()> f, int cpu_affinity = -1);
 
 }  // namespace base

--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -5,6 +5,7 @@
 #include "util/fibers/fibers.h"
 
 #include <absl/strings/str_cat.h>
+#include <absl/strings/str_join.h>
 #include <gmock/gmock.h>
 
 #include <atomic>
@@ -30,8 +31,7 @@
 #if defined(__linux__) || defined(__FreeBSD__)
 #include <sched.h>
 
-ABSL_DECLARE_FLAG(std::string, proactor_cpu_list);
-ABSL_DECLARE_FLAG(uint32_t, proactor_cpu_offset);
+ABSL_DECLARE_FLAG(std::string, proactor_irq_cpus);
 #endif
 
 #ifdef __linux__
@@ -1466,42 +1466,18 @@ static vector<unsigned> OnlineCpuList() {
   return online;
 }
 
-// Verifies that proactor_cpu_list pins proactor thread i to list[i], in the exact
-// (possibly non-ascending) order given - not just "some" cpu.
-TEST_F(FiberTest, ProactorPoolCpuList) {
+// Verifies that proactor_irq_cpus pins the listed cpu(s) to the highest thread indices,
+// and every other online cpu to the lower indices, in ascending order.
+TEST_F(FiberTest, ProactorPoolIrqCpus) {
   vector<unsigned> online = OnlineCpuList();
   if (online.size() < 2) {
     GTEST_SKIP() << "Needs at least 2 online cpus";
   }
 
-  // Deliberately reversed (last, first) to prove we are not just relying on ascending order.
-  unsigned cpu_a = online.back();
-  unsigned cpu_b = online.front();
-  absl::SetFlag(&FLAGS_proactor_cpu_list, absl::StrCat(cpu_a, ",", cpu_b));
-
-  unique_ptr<Pool> pool(Pool::Epoll());  // pool size defaults to the cpu list length (2).
-  pool->Run();
-  ASSERT_EQ(2u, pool->size());
-
-  vector<int> actual_cpu(2, -1);
-  pool->AwaitBrief([&](unsigned index, ProactorBase*) { actual_cpu[index] = sched_getcpu(); });
-
-  EXPECT_EQ(int(cpu_a), actual_cpu[0]);
-  EXPECT_EQ(int(cpu_b), actual_cpu[1]);
-
-  pool->Stop();
-  absl::SetFlag(&FLAGS_proactor_cpu_list, "");  // reset - flags are process-global.
-}
-
-// Verifies that proactor_cpu_offset rotates the default ascending cpu assignment,
-// including wraparound.
-TEST_F(FiberTest, ProactorPoolCpuOffset) {
-  vector<unsigned> online = OnlineCpuList();
-  if (online.size() < 2) {
-    GTEST_SKIP() << "Needs at least 2 online cpus";
-  }
-
-  absl::SetFlag(&FLAGS_proactor_cpu_offset, 1u);
+  // Mark the first online cpu as the irq cpu: it should end up pinned to the *last*
+  // thread index, with every other cpu shifted up to fill the lower indices in ascending order.
+  unsigned irq_cpu = online.front();
+  absl::SetFlag(&FLAGS_proactor_irq_cpus, absl::StrCat(irq_cpu));
 
   unique_ptr<Pool> pool(Pool::Epoll(online.size()));
   pool->Run();
@@ -1509,13 +1485,37 @@ TEST_F(FiberTest, ProactorPoolCpuOffset) {
   vector<int> actual_cpu(online.size(), -1);
   pool->AwaitBrief([&](unsigned index, ProactorBase*) { actual_cpu[index] = sched_getcpu(); });
 
-  for (unsigned i = 0; i < online.size(); ++i) {
-    unsigned expected = online[(i + 1) % online.size()];
-    EXPECT_EQ(int(expected), actual_cpu[i]) << "thread " << i;
+  for (unsigned i = 0; i + 1 < online.size(); ++i) {
+    EXPECT_EQ(int(online[i + 1]), actual_cpu[i]) << "thread " << i;
+  }
+  EXPECT_EQ(int(irq_cpu), actual_cpu[online.size() - 1]);
+
+  pool->Stop();
+  absl::SetFlag(&FLAGS_proactor_irq_cpus, "");  // reset - flags are process-global.
+}
+
+// Verifies that specifying more irq cpus than the pool has threads is non-fatal: the flag is
+// ignored (logged, not CHECK-failed) and pinning falls back to the default ascending spread.
+TEST_F(FiberTest, ProactorPoolIrqCpusMismatchFallsBack) {
+  vector<unsigned> online = OnlineCpuList();
+  if (online.size() < 3) {
+    GTEST_SKIP() << "Needs at least 3 online cpus";
+  }
+
+  absl::SetFlag(&FLAGS_proactor_irq_cpus, absl::StrJoin(online, ","));
+
+  unique_ptr<Pool> pool(Pool::Epoll(2));  // pool smaller than the irq cpu list.
+  pool->Run();
+
+  vector<int> actual_cpu(2, -1);
+  pool->AwaitBrief([&](unsigned index, ProactorBase*) { actual_cpu[index] = sched_getcpu(); });
+
+  for (unsigned i = 0; i < 2; ++i) {
+    EXPECT_EQ(int(online[i % online.size()]), actual_cpu[i]) << "thread " << i;
   }
 
   pool->Stop();
-  absl::SetFlag(&FLAGS_proactor_cpu_offset, 0u);  // reset - flags are process-global.
+  absl::SetFlag(&FLAGS_proactor_irq_cpus, "");  // reset - flags are process-global.
 }
 
 #endif  // defined(__linux__) || defined(__FreeBSD__)

--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -1466,9 +1466,37 @@ static vector<unsigned> OnlineCpuList() {
   return online;
 }
 
+// Parameterized over backend kind ("epoll" / "uring"), mirroring the ProactorTest pattern above
+// but for tests that need a full Pool rather than a single ProactorThread.
+class ProactorPoolCpuTest : public testing::TestWithParam<string_view> {
+ protected:
+  static unique_ptr<Pool> NewPool(size_t pool_size) {
+    string_view backend = GetParam();
+    if (backend == "epoll") {
+      return unique_ptr<Pool>(Pool::Epoll(pool_size));
+    }
+#ifdef __linux__
+    if (backend == "uring") {
+      return unique_ptr<Pool>(Pool::IOUring(kRingDepth, pool_size));
+    }
+#endif
+    LOG(FATAL) << "Unknown backend: " << backend;
+    return nullptr;
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(Engines, ProactorPoolCpuTest,
+                         testing::Values("epoll"
+#ifdef __linux__
+                                         ,
+                                         "uring"
+#endif
+                                         ),
+                         [](const auto& info) { return string(info.param); });
+
 // Verifies that proactor_irq_cpus pins the listed cpu(s) to the highest thread indices,
 // and every other online cpu to the lower indices, in ascending order.
-TEST_F(FiberTest, ProactorPoolIrqCpus) {
+TEST_P(ProactorPoolCpuTest, IrqCpus) {
   vector<unsigned> online = OnlineCpuList();
   if (online.size() < 2) {
     GTEST_SKIP() << "Needs at least 2 online cpus";
@@ -1479,7 +1507,7 @@ TEST_F(FiberTest, ProactorPoolIrqCpus) {
   unsigned irq_cpu = online.front();
   absl::SetFlag(&FLAGS_proactor_irq_cpus, absl::StrCat(irq_cpu));
 
-  unique_ptr<Pool> pool(Pool::Epoll(online.size()));
+  unique_ptr<Pool> pool = NewPool(online.size());
   pool->Run();
 
   vector<int> actual_cpu(online.size(), -1);
@@ -1494,9 +1522,37 @@ TEST_F(FiberTest, ProactorPoolIrqCpus) {
   absl::SetFlag(&FLAGS_proactor_irq_cpus, "");  // reset - flags are process-global.
 }
 
+// Verifies irq cpu placement when the pool is *smaller* than the online cpu count: the irq cpu
+// must still land on the last thread index, not just whatever a naive i % total_online_cpus
+// modulo would happen to pick (the bug this test guards against).
+TEST_P(ProactorPoolCpuTest, IrqCpusSmallPool) {
+  vector<unsigned> online = OnlineCpuList();
+  if (online.size() < 3) {
+    GTEST_SKIP() << "Needs at least 3 online cpus";
+  }
+
+  unsigned irq_cpu = online.front();
+  absl::SetFlag(&FLAGS_proactor_irq_cpus, absl::StrCat(irq_cpu));
+
+  constexpr unsigned kPoolSize = 2;  // deliberately smaller than online.size().
+  unique_ptr<Pool> pool = NewPool(kPoolSize);
+  pool->Run();
+
+  vector<int> actual_cpu(kPoolSize, -1);
+  pool->AwaitBrief([&](unsigned index, ProactorBase*) { actual_cpu[index] = sched_getcpu(); });
+
+  // non_irq_count = kPoolSize - 1 = 1: thread 0 gets the first non-irq cpu, thread 1 (the last
+  // index) gets the irq cpu.
+  EXPECT_EQ(int(online[1]), actual_cpu[0]);
+  EXPECT_EQ(int(irq_cpu), actual_cpu[1]);
+
+  pool->Stop();
+  absl::SetFlag(&FLAGS_proactor_irq_cpus, "");  // reset - flags are process-global.
+}
+
 // Verifies that specifying more irq cpus than the pool has threads is non-fatal: the flag is
 // ignored (logged, not CHECK-failed) and pinning falls back to the default ascending spread.
-TEST_F(FiberTest, ProactorPoolIrqCpusMismatchFallsBack) {
+TEST_P(ProactorPoolCpuTest, IrqCpusMismatchFallsBack) {
   vector<unsigned> online = OnlineCpuList();
   if (online.size() < 3) {
     GTEST_SKIP() << "Needs at least 3 online cpus";
@@ -1504,7 +1560,7 @@ TEST_F(FiberTest, ProactorPoolIrqCpusMismatchFallsBack) {
 
   absl::SetFlag(&FLAGS_proactor_irq_cpus, absl::StrJoin(online, ","));
 
-  unique_ptr<Pool> pool(Pool::Epoll(2));  // pool smaller than the irq cpu list.
+  unique_ptr<Pool> pool = NewPool(2);  // pool smaller than the irq cpu list.
   pool->Run();
 
   vector<int> actual_cpu(2, -1);

--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -13,6 +13,7 @@
 #include <mutex>
 #include <thread>
 
+#include "base/flags.h"
 #include "base/gtest.h"
 #include "base/logging.h"
 #include "base/mpmc_bounded_queue.h"
@@ -25,6 +26,13 @@
 #include "util/fibers/pool.h"
 #include "util/fibers/simple_channel.h"
 #include "util/fibers/synchronization.h"
+
+#if defined(__linux__) || defined(__FreeBSD__)
+#include <sched.h>
+
+ABSL_DECLARE_FLAG(std::string, proactor_cpu_list);
+ABSL_DECLARE_FLAG(uint32_t, proactor_cpu_offset);
+#endif
 
 #ifdef __linux__
 #include <sys/epoll.h>
@@ -1442,6 +1450,75 @@ TEST_F(FiberTest, PersistentWaiterStarvationDCheck) {
       "causes starvation");
 }
 #endif
+
+#if defined(__linux__) || defined(__FreeBSD__)
+
+// Returns the list of cpus this process is allowed to run on.
+static vector<unsigned> OnlineCpuList() {
+  cpu_set_t allowed;
+  CPU_ZERO(&allowed);
+  CHECK_EQ(0, sched_getaffinity(0, sizeof(allowed), &allowed));
+  vector<unsigned> online;
+  for (unsigned c = 0; c < CPU_SETSIZE; ++c) {
+    if (CPU_ISSET(c, &allowed))
+      online.push_back(c);
+  }
+  return online;
+}
+
+// Verifies that proactor_cpu_list pins proactor thread i to list[i], in the exact
+// (possibly non-ascending) order given - not just "some" cpu.
+TEST_F(FiberTest, ProactorPoolCpuList) {
+  vector<unsigned> online = OnlineCpuList();
+  if (online.size() < 2) {
+    GTEST_SKIP() << "Needs at least 2 online cpus";
+  }
+
+  // Deliberately reversed (last, first) to prove we are not just relying on ascending order.
+  unsigned cpu_a = online.back();
+  unsigned cpu_b = online.front();
+  absl::SetFlag(&FLAGS_proactor_cpu_list, absl::StrCat(cpu_a, ",", cpu_b));
+
+  unique_ptr<Pool> pool(Pool::Epoll());  // pool size defaults to the cpu list length (2).
+  pool->Run();
+  ASSERT_EQ(2u, pool->size());
+
+  vector<int> actual_cpu(2, -1);
+  pool->AwaitBrief([&](unsigned index, ProactorBase*) { actual_cpu[index] = sched_getcpu(); });
+
+  EXPECT_EQ(int(cpu_a), actual_cpu[0]);
+  EXPECT_EQ(int(cpu_b), actual_cpu[1]);
+
+  pool->Stop();
+  absl::SetFlag(&FLAGS_proactor_cpu_list, "");  // reset - flags are process-global.
+}
+
+// Verifies that proactor_cpu_offset rotates the default ascending cpu assignment,
+// including wraparound.
+TEST_F(FiberTest, ProactorPoolCpuOffset) {
+  vector<unsigned> online = OnlineCpuList();
+  if (online.size() < 2) {
+    GTEST_SKIP() << "Needs at least 2 online cpus";
+  }
+
+  absl::SetFlag(&FLAGS_proactor_cpu_offset, 1u);
+
+  unique_ptr<Pool> pool(Pool::Epoll(online.size()));
+  pool->Run();
+
+  vector<int> actual_cpu(online.size(), -1);
+  pool->AwaitBrief([&](unsigned index, ProactorBase*) { actual_cpu[index] = sched_getcpu(); });
+
+  for (unsigned i = 0; i < online.size(); ++i) {
+    unsigned expected = online[(i + 1) % online.size()];
+    EXPECT_EQ(int(expected), actual_cpu[i]) << "thread " << i;
+  }
+
+  pool->Stop();
+  absl::SetFlag(&FLAGS_proactor_cpu_offset, 0u);  // reset - flags are process-global.
+}
+
+#endif  // defined(__linux__) || defined(__FreeBSD__)
 
 }  // namespace fb2
 }  // namespace util

--- a/util/fibers/proactor_pool.cc
+++ b/util/fibers/proactor_pool.cc
@@ -4,6 +4,11 @@
 
 #include "util/proactor_pool.h"
 
+#include <absl/strings/numbers.h>
+#include <absl/strings/str_cat.h>
+#include <absl/strings/str_join.h>
+#include <absl/strings/str_split.h>
+
 #include <vector>
 
 #include "base/flags.h"
@@ -22,6 +27,15 @@ using namespace std;
 
 ABSL_FLAG(uint32_t, proactor_threads, 0, "Number of io threads in the pool");
 ABSL_FLAG(string, proactor_affinity_mode, "on", "can be on, off or auto");
+ABSL_FLAG(string, proactor_cpu_list, "",
+          "Explicit list of cpu ids to pin proactor threads to, e.g. \"1,4,6,7\" or "
+          "\"48-95,0-47\". Proactor thread i is pinned to entry (i % list_size). Takes priority "
+          "over proactor_cpu_offset. If set and proactor_threads is 0, the pool size defaults to "
+          "the list length.");
+ABSL_FLAG(uint32_t, proactor_cpu_offset, 0,
+          "Rotates the default sequential cpu assignment: proactor thread i is pinned to the "
+          "((i + offset) % num_online_cpus)-th online cpu (in ascending order) instead of the "
+          "(i % num_online_cpus)-th. Ignored if proactor_cpu_list is set.");
 
 namespace util {
 
@@ -107,13 +121,44 @@ static unsigned NumOnlineCpus() {
   return CPU_COUNT(&cpus);
 }
 
+// Parses a comma-separated list of cpu ids and/or inclusive ranges, e.g.
+// "1,4,6,7" or "48-95,0-47". Order is preserved (ranges expand in the order given),
+// duplicates are allowed as-is.
+vector<unsigned> ParseCpuList(string_view str) {
+  vector<unsigned> res;
+  for (string_view part : absl::StrSplit(str, ',', absl::SkipEmpty())) {
+    size_t dash = part.find('-');
+    if (dash == string_view::npos) {
+      unsigned v = 0;
+      CHECK(absl::SimpleAtoi(part, &v)) << "Invalid cpu id in proactor_cpu_list: " << part;
+      res.push_back(v);
+    } else {
+      unsigned lo = 0, hi = 0;
+      CHECK(absl::SimpleAtoi(part.substr(0, dash), &lo))
+          << "Invalid cpu range in proactor_cpu_list: " << part;
+      CHECK(absl::SimpleAtoi(part.substr(dash + 1), &hi))
+          << "Invalid cpu range in proactor_cpu_list: " << part;
+      CHECK_LE(lo, hi) << "Invalid cpu range in proactor_cpu_list: " << part;
+      for (unsigned v = lo; v <= hi; ++v) {
+        res.push_back(v);
+      }
+    }
+  }
+  return res;
+}
+
 }  // namespace
 
 ProactorPool::ProactorPool(std::size_t pool_size) {
   if (pool_size == 0) {
     auto num_pthreads = absl::GetFlag(FLAGS_proactor_threads);
-    // thread::hardware_concurrency() returns number of online cpus but ignores taskset.
-    pool_size = num_pthreads > 0 ? num_pthreads : NumOnlineCpus();
+    if (num_pthreads > 0) {
+      pool_size = num_pthreads;
+    } else {
+      // thread::hardware_concurrency() returns number of online cpus but ignores taskset.
+      vector<unsigned> cpu_list = ParseCpuList(absl::GetFlag(FLAGS_proactor_cpu_list));
+      pool_size = cpu_list.empty() ? NumOnlineCpus() : cpu_list.size();
+    }
     VLOG(1) << "Setting pool size to " << pool_size;
   }
 
@@ -246,11 +291,19 @@ void ProactorPool::SetupProactors() {
   CHECK_EQ(rel_cpu_index, num_online_cpus) << "Such beast is not supported";
   cpu_threads_.resize(abs_cpu_index + 1);
 
-  cpu_set_t cps;
-  CPU_ZERO(&cps);
+  vector<unsigned> cpu_list = ParseCpuList(absl::GetFlag(FLAGS_proactor_cpu_list));
+  for (unsigned cpu : cpu_list) {
+    CHECK_LT(cpu, cpu_threads_.size())
+        << "proactor_cpu_list: cpu id out of range: " << cpu;
+    CHECK(CPU_ISSET(cpu, &online_cpus))
+        << "proactor_cpu_list: cpu " << cpu << " is not online/allowed for this process";
+  }
+  uint32_t cpu_offset = absl::GetFlag(FLAGS_proactor_cpu_offset);
 
+  bool explicit_pin = !cpu_list.empty() || cpu_offset != 0;
   bool set_affinity = (mode == AffinityMode::ON) ||
-                      (mode == AffinityMode::AUTO && pool_size_ > num_online_cpus / 2);
+                      (mode == AffinityMode::AUTO && pool_size_ > num_online_cpus / 2) ||
+                      explicit_pin;
 
   for (unsigned i = 0; i < pool_size_; ++i) {
     snprintf(buf, sizeof(buf), "Proactor%u", i);
@@ -261,29 +314,43 @@ void ProactorPool::SetupProactors() {
       proactor_[i]->Run();
     };
 
-    pthread_t tid = base::StartThread(buf, std::move(cb));
 #if defined(__linux__) || defined(__FreeBSD__)
+    int cpu_affinity = -1;
     if (set_affinity) {
-      // Spread proactor threads across online CPUs.
-      int rel_indx = i % num_online_cpus;
-      unsigned abs_cpu = rel_to_abs_cpu[rel_indx];
-      CHECK_LT(abs_cpu, cpu_threads_.size());
-      CPU_SET(abs_cpu, &cps);
-
-      int rc = pthread_setaffinity_np(tid, sizeof(cpu_set_t), &cps);
-      if (rc == 0) {
-        VLOG(1) << "Setting affinity of thread " << i << " on cpu " << abs_cpu;
-        cpu_threads_[abs_cpu].push_back(i);
+      unsigned abs_cpu;
+      if (!cpu_list.empty()) {
+        abs_cpu = cpu_list[i % cpu_list.size()];
       } else {
-        LOG(WARNING) << "Error calling pthread_setaffinity_np: " << strerror(rc) << "\n";
+        unsigned rel_indx = (i + cpu_offset) % num_online_cpus;
+        abs_cpu = rel_to_abs_cpu[rel_indx];
       }
+      CHECK_LT(abs_cpu, cpu_threads_.size());
+      cpu_affinity = static_cast<int>(abs_cpu);
+    }
 
-      CPU_CLR(abs_cpu, &cps);
+    // Pin the thread's affinity before it starts running (via pthread_attr_setaffinity_np),
+    // rather than after via pthread_setaffinity_np: setting it after only migrates the
+    // thread's *execution*, not memory it may have already first-touched (see
+    // base::StartThread's doc comment for the full rationale).
+    base::StartThread(buf, std::move(cb), cpu_affinity);
+    if (cpu_affinity >= 0) {
+      VLOG(1) << "Pinned thread " << i << " to cpu " << cpu_affinity;
+      cpu_threads_[cpu_affinity].push_back(i);
     }
 #else
-    (void)tid;
+    base::StartThread(buf, std::move(cb));
     (void)set_affinity;
 #endif
+  }
+
+  if (!cpu_list.empty() || cpu_offset != 0) {
+    string mapping;
+    for (unsigned cpu = 0; cpu < cpu_threads_.size(); ++cpu) {
+      if (!cpu_threads_[cpu].empty()) {
+        absl::StrAppend(&mapping, " cpu", cpu, "={", absl::StrJoin(cpu_threads_[cpu], ","), "}");
+      }
+    }
+    LOG(INFO) << "Proactor thread->cpu mapping:" << mapping;
   }
 
   state_ = RUN;

--- a/util/fibers/proactor_pool.cc
+++ b/util/fibers/proactor_pool.cc
@@ -4,6 +4,7 @@
 
 #include "util/proactor_pool.h"
 
+#include <absl/container/flat_hash_set.h>
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_join.h>
@@ -27,15 +28,11 @@ using namespace std;
 
 ABSL_FLAG(uint32_t, proactor_threads, 0, "Number of io threads in the pool");
 ABSL_FLAG(string, proactor_affinity_mode, "on", "can be on, off or auto");
-ABSL_FLAG(string, proactor_cpu_list, "",
-          "Explicit list of cpu ids to pin proactor threads to, e.g. \"1,4,6,7\" or "
-          "\"48-95,0-47\". Proactor thread i is pinned to entry (i % list_size). Takes priority "
-          "over proactor_cpu_offset. If set and proactor_threads is 0, the pool size defaults to "
-          "the list length.");
-ABSL_FLAG(uint32_t, proactor_cpu_offset, 0,
-          "Rotates the default sequential cpu assignment: proactor thread i is pinned to the "
-          "((i + offset) % num_online_cpus)-th online cpu (in ascending order) instead of the "
-          "(i % num_online_cpus)-th. Ignored if proactor_cpu_list is set.");
+ABSL_FLAG(string, proactor_irq_cpus, "",
+          "Explicit list of cpu ids/ranges handling irqs, e.g. \"1,4,6,7\" or \"0-47\". These "
+          "cpus are pinned to the highest proactor thread indices; every other online cpu is "
+          "pinned to the lower indices. Does not affect pool size. Ignored (with a logged error) "
+          "if it names an offline cpu or more cpus than the pool has threads.");
 
 namespace util {
 
@@ -152,13 +149,8 @@ vector<unsigned> ParseCpuList(string_view str) {
 ProactorPool::ProactorPool(std::size_t pool_size) {
   if (pool_size == 0) {
     auto num_pthreads = absl::GetFlag(FLAGS_proactor_threads);
-    if (num_pthreads > 0) {
-      pool_size = num_pthreads;
-    } else {
-      // thread::hardware_concurrency() returns number of online cpus but ignores taskset.
-      vector<unsigned> cpu_list = ParseCpuList(absl::GetFlag(FLAGS_proactor_cpu_list));
-      pool_size = cpu_list.empty() ? NumOnlineCpus() : cpu_list.size();
-    }
+    // thread::hardware_concurrency() returns number of online cpus but ignores taskset.
+    pool_size = num_pthreads > 0 ? num_pthreads : NumOnlineCpus();
     VLOG(1) << "Setting pool size to " << pool_size;
   }
 
@@ -291,19 +283,42 @@ void ProactorPool::SetupProactors() {
   CHECK_EQ(rel_cpu_index, num_online_cpus) << "Such beast is not supported";
   cpu_threads_.resize(abs_cpu_index + 1);
 
-  vector<unsigned> cpu_list = ParseCpuList(absl::GetFlag(FLAGS_proactor_cpu_list));
-  for (unsigned cpu : cpu_list) {
-    CHECK_LT(cpu, cpu_threads_.size())
-        << "proactor_cpu_list: cpu id out of range: " << cpu;
-    CHECK(CPU_ISSET(cpu, &online_cpus))
-        << "proactor_cpu_list: cpu " << cpu << " is not online/allowed for this process";
+  // irq_cpus are pinned to the highest thread indices; every other online cpu (the
+  // "complement") is pinned to the lower indices, in ascending order. A mismatch (offline cpu,
+  // or more irq cpus than pool threads) is not fatal: it's logged and the flag is ignored
+  // entirely, falling back to the default spread below.
+  vector<unsigned> irq_cpus = ParseCpuList(absl::GetFlag(FLAGS_proactor_irq_cpus));
+  vector<unsigned> effective_list;
+  if (!irq_cpus.empty()) {
+    bool valid = true;
+    for (unsigned cpu : irq_cpus) {
+      if (cpu >= cpu_threads_.size() || !CPU_ISSET(cpu, &online_cpus)) {
+        LOG(ERROR) << "proactor_irq_cpus: cpu " << cpu
+                   << " is not online/allowed for this process; ignoring proactor_irq_cpus.";
+        valid = false;
+        break;
+      }
+    }
+    if (valid && irq_cpus.size() > pool_size_) {
+      LOG(ERROR) << "proactor_irq_cpus: specifies " << irq_cpus.size()
+                 << " cpus, more than the pool size (" << pool_size_
+                 << "); ignoring proactor_irq_cpus.";
+      valid = false;
+    }
+    if (valid) {
+      absl::flat_hash_set<unsigned> irq_set(irq_cpus.begin(), irq_cpus.end());
+      for (unsigned cpu = 0; cpu < cpu_threads_.size(); ++cpu) {
+        if (CPU_ISSET(cpu, &online_cpus) && !irq_set.contains(cpu)) {
+          effective_list.push_back(cpu);
+        }
+      }
+      effective_list.insert(effective_list.end(), irq_cpus.begin(), irq_cpus.end());
+    }
   }
-  uint32_t cpu_offset = absl::GetFlag(FLAGS_proactor_cpu_offset);
 
-  bool explicit_pin = !cpu_list.empty() || cpu_offset != 0;
   bool set_affinity = (mode == AffinityMode::ON) ||
                       (mode == AffinityMode::AUTO && pool_size_ > num_online_cpus / 2) ||
-                      explicit_pin;
+                      !effective_list.empty();
 
   for (unsigned i = 0; i < pool_size_; ++i) {
     snprintf(buf, sizeof(buf), "Proactor%u", i);
@@ -318,10 +333,10 @@ void ProactorPool::SetupProactors() {
     int cpu_affinity = -1;
     if (set_affinity) {
       unsigned abs_cpu;
-      if (!cpu_list.empty()) {
-        abs_cpu = cpu_list[i % cpu_list.size()];
+      if (!effective_list.empty()) {
+        abs_cpu = effective_list[i % effective_list.size()];
       } else {
-        unsigned rel_indx = (i + cpu_offset) % num_online_cpus;
+        unsigned rel_indx = i % num_online_cpus;
         abs_cpu = rel_to_abs_cpu[rel_indx];
       }
       CHECK_LT(abs_cpu, cpu_threads_.size());
@@ -343,7 +358,7 @@ void ProactorPool::SetupProactors() {
 #endif
   }
 
-  if (!cpu_list.empty() || cpu_offset != 0) {
+  if (!effective_list.empty()) {
     string mapping;
     for (unsigned cpu = 0; cpu < cpu_threads_.size(); ++cpu) {
       if (!cpu_threads_[cpu].empty()) {

--- a/util/fibers/proactor_pool.cc
+++ b/util/fibers/proactor_pool.cc
@@ -127,15 +127,15 @@ vector<unsigned> ParseCpuList(string_view str) {
     size_t dash = part.find('-');
     if (dash == string_view::npos) {
       unsigned v = 0;
-      CHECK(absl::SimpleAtoi(part, &v)) << "Invalid cpu id in proactor_cpu_list: " << part;
+      CHECK(absl::SimpleAtoi(part, &v)) << "Invalid cpu id in proactor_irq_cpus: " << part;
       res.push_back(v);
     } else {
       unsigned lo = 0, hi = 0;
       CHECK(absl::SimpleAtoi(part.substr(0, dash), &lo))
-          << "Invalid cpu range in proactor_cpu_list: " << part;
+          << "Invalid cpu range in proactor_irq_cpus: " << part;
       CHECK(absl::SimpleAtoi(part.substr(dash + 1), &hi))
-          << "Invalid cpu range in proactor_cpu_list: " << part;
-      CHECK_LE(lo, hi) << "Invalid cpu range in proactor_cpu_list: " << part;
+          << "Invalid cpu range in proactor_irq_cpus: " << part;
+      CHECK_LE(lo, hi) << "Invalid cpu range in proactor_irq_cpus: " << part;
       for (unsigned v = lo; v <= hi; ++v) {
         res.push_back(v);
       }
@@ -283,12 +283,14 @@ void ProactorPool::SetupProactors() {
   CHECK_EQ(rel_cpu_index, num_online_cpus) << "Such beast is not supported";
   cpu_threads_.resize(abs_cpu_index + 1);
 
-  // irq_cpus are pinned to the highest thread indices; every other online cpu (the
-  // "complement") is pinned to the lower indices, in ascending order. A mismatch (offline cpu,
-  // or more irq cpus than pool threads) is not fatal: it's logged and the flag is ignored
-  // entirely, falling back to the default spread below.
+  // irq_cpus are pinned to the last irq_cpus.size() thread indices; every other online cpu
+  // (the "complement") is pinned to the remaining, lower indices, cycling in ascending order if
+  // there are more such indices than complement cpus. A mismatch (offline cpu, more irq cpus
+  // than pool threads, or no complement cpu left to fill the non-irq indices) is not fatal: it's
+  // logged and the flag is ignored entirely, falling back to the default spread below.
   vector<unsigned> irq_cpus = ParseCpuList(absl::GetFlag(FLAGS_proactor_irq_cpus));
-  vector<unsigned> effective_list;
+  vector<unsigned> complement;
+  bool use_irq_cpus = false;
   if (!irq_cpus.empty()) {
     bool valid = true;
     for (unsigned cpu : irq_cpus) {
@@ -305,20 +307,32 @@ void ProactorPool::SetupProactors() {
                  << "); ignoring proactor_irq_cpus.";
       valid = false;
     }
+    absl::flat_hash_set<unsigned> irq_set(irq_cpus.begin(), irq_cpus.end());
+    if (valid && irq_set.size() != irq_cpus.size()) {
+      LOG(ERROR) << "proactor_irq_cpus: contains a duplicate cpu id; ignoring proactor_irq_cpus.";
+      valid = false;
+    }
     if (valid) {
-      absl::flat_hash_set<unsigned> irq_set(irq_cpus.begin(), irq_cpus.end());
       for (unsigned cpu = 0; cpu < cpu_threads_.size(); ++cpu) {
         if (CPU_ISSET(cpu, &online_cpus) && !irq_set.contains(cpu)) {
-          effective_list.push_back(cpu);
+          complement.push_back(cpu);
         }
       }
-      effective_list.insert(effective_list.end(), irq_cpus.begin(), irq_cpus.end());
+      if (pool_size_ > irq_cpus.size() && complement.empty()) {
+        LOG(ERROR) << "proactor_irq_cpus: no cpu left to assign to the non-irq threads; "
+                      "ignoring proactor_irq_cpus.";
+        valid = false;
+      }
     }
+    use_irq_cpus = valid;
   }
+  // Number of thread indices [0, non_irq_count) assigned to complement cpus; the remaining
+  // [non_irq_count, pool_size_) indices are assigned to irq_cpus, one each.
+  unsigned non_irq_count = use_irq_cpus ? pool_size_ - irq_cpus.size() : 0;
 
   bool set_affinity = (mode == AffinityMode::ON) ||
                       (mode == AffinityMode::AUTO && pool_size_ > num_online_cpus / 2) ||
-                      !effective_list.empty();
+                      use_irq_cpus;
 
   for (unsigned i = 0; i < pool_size_; ++i) {
     snprintf(buf, sizeof(buf), "Proactor%u", i);
@@ -333,8 +347,9 @@ void ProactorPool::SetupProactors() {
     int cpu_affinity = -1;
     if (set_affinity) {
       unsigned abs_cpu;
-      if (!effective_list.empty()) {
-        abs_cpu = effective_list[i % effective_list.size()];
+      if (use_irq_cpus) {
+        abs_cpu =
+            i < non_irq_count ? complement[i % complement.size()] : irq_cpus[i - non_irq_count];
       } else {
         unsigned rel_indx = i % num_online_cpus;
         abs_cpu = rel_to_abs_cpu[rel_indx];
@@ -358,7 +373,7 @@ void ProactorPool::SetupProactors() {
 #endif
   }
 
-  if (!effective_list.empty()) {
+  if (use_irq_cpus) {
     string mapping;
     for (unsigned cpu = 0; cpu < cpu_threads_.size(); ++cpu) {
       if (!cpu_threads_[cpu].empty()) {


### PR DESCRIPTION
* proactor_irq_cpus flag that accept cpu ranges that should be assigned/pinned at the end of the thread list
* add tests (maybe an overkill) but why not