### PR TITLE
fix(aws): drop "Bearer " prefix from container-credentials auth header

### DIFF
--- a/util/cloud/aws/aws_creds_provider.cc
+++ b/util/cloud/aws/aws_creds_provider.cc
@@ -252,6 +252,17 @@ string StsEndpoint(string_view region) {
   return "sts.amazonaws.com";
 }
 
+vector<pair<string, string>> ContainerCredsHeaders(string_view auth_token) {
+  vector<pair<string, string>> headers;
+  if (!auth_token.empty()) {
+    // ECS/EKS Pod Identity container-credentials endpoints expect the raw token as the
+    // header value, with no "Bearer " scheme prefix (unlike normal OAuth bearer auth).
+    // See https://github.com/romange/helio/issues/627.
+    headers.push_back({"Authorization", string(auth_token)});
+  }
+  return headers;
+}
+
 AwsCredsProvider::AwsCredsProvider(string region, string endpoint_override)
     : region_(std::move(region)), endpoint_override_(std::move(endpoint_override)) {
 }
@@ -454,11 +465,7 @@ error_code AwsCredsProvider::TryContainerCreds() {
     }
   }
 
-  // Determine if http or https.
-  vector<pair<string, string>> headers;
-  if (!auth_token.empty()) {
-    headers.push_back({"Authorization", absl::StrCat("Bearer ", auth_token)});
-  }
+  vector<pair<string, string>> headers = ContainerCredsHeaders(auth_token);
 
   auto [host, port, path, is_https] = ParseHttpUrl(uri);
   auto resp = FetchUrl(host, port, path, h2::verb::get, headers, "", connect_ms_,

--- a/util/cloud/aws/aws_creds_provider.h
+++ b/util/cloud/aws/aws_creds_provider.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include <atomic>
+#include <utility>
+#include <vector>
 
 #include "base/RWSpinLock.h"
 #include "util/cloud/utils.h"
@@ -37,6 +39,12 @@ std::string_view PartitionDnsSuffix(std::string_view region);
 // endpoint, so it uses the regional "sts.{region}.amazonaws.com.cn"; every other
 // partition uses the global "sts.amazonaws.com".
 std::string StsEndpoint(std::string_view region);
+
+// Builds the request headers for the ECS/EKS Pod Identity container-credentials
+// endpoint. Empty when `auth_token` is empty; otherwise a single "Authorization"
+// header whose value is the raw token, with no "Bearer " scheme prefix (unlike
+// normal OAuth bearer auth) — see https://github.com/romange/helio/issues/627.
+std::vector<std::pair<std::string, std::string>> ContainerCredsHeaders(std::string_view auth_token);
 
 // Implements CredentialsProvider for AWS.
 //

--- a/util/cloud/aws/aws_creds_provider_test.cc
+++ b/util/cloud/aws/aws_creds_provider_test.cc
@@ -58,5 +58,20 @@ TEST_F(AwsCredsProviderTest, ServiceEndpointOverride) {
   EXPECT_EQ(provider.ServiceEndpoint(), "my-minio.example:9000");
 }
 
+// Regression test for https://github.com/romange/helio/issues/627: the
+// container-credentials auth token must be sent as-is, with no "Bearer "
+// scheme prefix, or the EKS Pod Identity Agent (and ECS task metadata) reject
+// the request with HTTP 400.
+TEST_F(AwsCredsProviderTest, ContainerCredsHeadersNoBearerPrefix) {
+  auto headers = ContainerCredsHeaders("eks-pod-identity-token");
+  ASSERT_EQ(headers.size(), 1u);
+  EXPECT_EQ(headers[0].first, "Authorization");
+  EXPECT_EQ(headers[0].second, "eks-pod-identity-token");
+}
+
+TEST_F(AwsCredsProviderTest, ContainerCredsHeadersEmptyTokenOmitsHeader) {
+  EXPECT_TRUE(ContainerCredsHeaders("").empty());
+}
+
 }  // namespace cloud::aws
 }  // namespace util


### PR DESCRIPTION
## Summary
- `TryContainerCreds()` sent `Authorization: Bearer <token>` to the ECS/EKS Pod Identity container-credentials endpoint, but that protocol expects the raw token with no scheme prefix. The EKS Pod Identity Agent rejects the malformed header with HTTP 400, so credential retrieval fails whenever a workload relies on Pod Identity instead of IRSA.
- Extracted the header-building logic into `ContainerCredsHeaders()` so the fix has direct unit coverage without needing a real network round-trip.
- IRSA is unaffected — `TryWebIdentity()` is a separate code path that sends its token as a `WebIdentityToken` POST body param, never as an `Authorization` header.

Fixes #627

## Test plan
- [x] Added `ContainerCredsHeadersNoBearerPrefix` / `ContainerCredsHeadersEmptyTokenOmitsHeader` unit tests; verified they fail against the pre-fix code and pass with the fix.
- [x] Built a full `linux/amd64` Dragonfly release image with this fix applied on top of the exact helio commit that `v1.40.0` vendors, and deployed it to a real EKS cluster with a Pod Identity association (no IRSA). Confirmed in logs:
  ```
  aws_creds_provider.cc:484] aws: loaded credentials; provider=container-credentials
  ```
  followed by a successful S3 snapshot load and full sync/takeover.