### PR TITLE
fix(tls): demote protocol errors to verbose

### DIFF
--- a/util/tls/tls_engine.cc
+++ b/util/tls/tls_engine.cc
@@ -257,11 +257,11 @@ auto Engine::ToOpResult(int result, const char* location) -> OpResult {
           VLOG(1) << "SSL application data after close_notify " << location;
           break;
         default: {
-          // All other protocol errors are warnings/fatal
+          // All other protocol errors terminate only the affected connection.
+          // They are fatal for the connection, but not to the entire process.
           state_ |= FATAL_ERROR;
-          LOG_EVERY_T(WARNING, 1) << "SSL protocol error " << ERROR_DETAILS(queue_error, location)
-                                  << " bytes_read: " << bytes_read_
-                                  << " bytes_written: " << bytes_written_;
+          VLOG(1) << "SSL protocol error " << ERROR_DETAILS(queue_error, location)
+                  << " bytes_read: " << bytes_read_ << " bytes_written: " << bytes_written_;
         }
       }
       break;


### PR DESCRIPTION
Demote connection-local TLS protocol errors to VLOG(1) to prevent expected client-side failures from polluting production warnings.

Fatal handling remains unchanged: the affected TLS connection still closes with EOF_ABRUPT.