### PR TITLE
chore: rename irq-based naming with tail

### DIFF
--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -31,7 +31,7 @@
 #if defined(__linux__) || defined(__FreeBSD__)
 #include <sched.h>
 
-ABSL_DECLARE_FLAG(std::string, proactor_irq_cpus);
+ABSL_DECLARE_FLAG(std::string, proactor_tail_cpus);
 #endif
 
 #ifdef __linux__
@@ -1522,18 +1522,18 @@ INSTANTIATE_TEST_SUITE_P(Engines, ProactorPoolCpuTest,
                                          ),
                          [](const auto& info) { return string(info.param); });
 
-// Verifies that proactor_irq_cpus pins the listed cpu(s) to the highest thread indices,
+// Verifies that proactor_tail_cpus pins the listed cpu(s) to the highest thread indices,
 // and every other online cpu to the lower indices, in ascending order.
-TEST_P(ProactorPoolCpuTest, IrqCpus) {
+TEST_P(ProactorPoolCpuTest, TailCpus) {
   vector<unsigned> online = OnlineCpuList();
   if (online.size() < 2) {
     GTEST_SKIP() << "Needs at least 2 online cpus";
   }
 
-  // Mark the first online cpu as the irq cpu: it should end up pinned to the *last*
+  // Mark the first online cpu as the tail cpu: it should end up pinned to the *last*
   // thread index, with every other cpu shifted up to fill the lower indices in ascending order.
-  unsigned irq_cpu = online.front();
-  absl::SetFlag(&FLAGS_proactor_irq_cpus, absl::StrCat(irq_cpu));
+  unsigned tail_cpu = online.front();
+  absl::SetFlag(&FLAGS_proactor_tail_cpus, absl::StrCat(tail_cpu));
 
   unique_ptr<Pool> pool = NewPool(online.size());
   pool->Run();
@@ -1544,23 +1544,23 @@ TEST_P(ProactorPoolCpuTest, IrqCpus) {
   for (unsigned i = 0; i + 1 < online.size(); ++i) {
     EXPECT_EQ(int(online[i + 1]), actual_cpu[i]) << "thread " << i;
   }
-  EXPECT_EQ(int(irq_cpu), actual_cpu[online.size() - 1]);
+  EXPECT_EQ(int(tail_cpu), actual_cpu[online.size() - 1]);
 
   pool->Stop();
-  absl::SetFlag(&FLAGS_proactor_irq_cpus, "");  // reset - flags are process-global.
+  absl::SetFlag(&FLAGS_proactor_tail_cpus, "");  // reset - flags are process-global.
 }
 
-// Verifies irq cpu placement when the pool is *smaller* than the online cpu count: the irq cpu
+// Verifies tail cpu placement when the pool is *smaller* than the online cpu count: the tail cpu
 // must still land on the last thread index, not just whatever a naive i % total_online_cpus
 // modulo would happen to pick (the bug this test guards against).
-TEST_P(ProactorPoolCpuTest, IrqCpusSmallPool) {
+TEST_P(ProactorPoolCpuTest, TailCpusSmallPool) {
   vector<unsigned> online = OnlineCpuList();
   if (online.size() < 3) {
     GTEST_SKIP() << "Needs at least 3 online cpus";
   }
 
-  unsigned irq_cpu = online.front();
-  absl::SetFlag(&FLAGS_proactor_irq_cpus, absl::StrCat(irq_cpu));
+  unsigned tail_cpu = online.front();
+  absl::SetFlag(&FLAGS_proactor_tail_cpus, absl::StrCat(tail_cpu));
 
   constexpr unsigned kPoolSize = 2;  // deliberately smaller than online.size().
   unique_ptr<Pool> pool = NewPool(kPoolSize);
@@ -1569,26 +1569,26 @@ TEST_P(ProactorPoolCpuTest, IrqCpusSmallPool) {
   vector<int> actual_cpu(kPoolSize, -1);
   pool->AwaitBrief([&](unsigned index, ProactorBase*) { actual_cpu[index] = sched_getcpu(); });
 
-  // non_irq_count = kPoolSize - 1 = 1: thread 0 gets the first non-irq cpu, thread 1 (the last
-  // index) gets the irq cpu.
+  // non_tail_count = kPoolSize - 1 = 1: thread 0 gets the first non-tail cpu, thread 1 (the last
+  // index) gets the tail cpu.
   EXPECT_EQ(int(online[1]), actual_cpu[0]);
-  EXPECT_EQ(int(irq_cpu), actual_cpu[1]);
+  EXPECT_EQ(int(tail_cpu), actual_cpu[1]);
 
   pool->Stop();
-  absl::SetFlag(&FLAGS_proactor_irq_cpus, "");  // reset - flags are process-global.
+  absl::SetFlag(&FLAGS_proactor_tail_cpus, "");  // reset - flags are process-global.
 }
 
-// Verifies that specifying more irq cpus than the pool has threads is non-fatal: the flag is
+// Verifies that specifying more tail cpus than the pool has threads is non-fatal: the flag is
 // ignored (logged, not CHECK-failed) and pinning falls back to the default ascending spread.
-TEST_P(ProactorPoolCpuTest, IrqCpusMismatchFallsBack) {
+TEST_P(ProactorPoolCpuTest, TailCpusMismatchFallsBack) {
   vector<unsigned> online = OnlineCpuList();
   if (online.size() < 3) {
     GTEST_SKIP() << "Needs at least 3 online cpus";
   }
 
-  absl::SetFlag(&FLAGS_proactor_irq_cpus, absl::StrJoin(online, ","));
+  absl::SetFlag(&FLAGS_proactor_tail_cpus, absl::StrJoin(online, ","));
 
-  unique_ptr<Pool> pool = NewPool(2);  // pool smaller than the irq cpu list.
+  unique_ptr<Pool> pool = NewPool(2);  // pool smaller than the tail cpu list.
   pool->Run();
 
   vector<int> actual_cpu(2, -1);
@@ -1599,7 +1599,7 @@ TEST_P(ProactorPoolCpuTest, IrqCpusMismatchFallsBack) {
   }
 
   pool->Stop();
-  absl::SetFlag(&FLAGS_proactor_irq_cpus, "");  // reset - flags are process-global.
+  absl::SetFlag(&FLAGS_proactor_tail_cpus, "");  // reset - flags are process-global.
 }
 
 #endif  // defined(__linux__) || defined(__FreeBSD__)

--- a/util/fibers/proactor_pool.cc
+++ b/util/fibers/proactor_pool.cc
@@ -28,11 +28,12 @@ using namespace std;
 
 ABSL_FLAG(uint32_t, proactor_threads, 0, "Number of io threads in the pool");
 ABSL_FLAG(string, proactor_affinity_mode, "on", "can be on, off or auto");
-ABSL_FLAG(string, proactor_irq_cpus, "",
-          "Explicit list of cpu ids/ranges handling irqs, e.g. \"1,4,6,7\" or \"0-47\". These "
-          "cpus are pinned to the highest proactor thread indices; every other online cpu is "
-          "pinned to the lower indices. Does not affect pool size. Ignored (with a logged error) "
-          "if it names an offline cpu or more cpus than the pool has threads.");
+ABSL_FLAG(string, proactor_tail_cpus, "",
+          "Explicit list of cpu ids/ranges to pin at the end of the thread list, e.g. "
+          "\"1,4,6,7\" or \"0-47\". These cpus are pinned to the highest proactor thread "
+          "indices; every other online cpu is pinned to the lower indices. Does not affect "
+          "pool size. Ignored (with a logged error) if it names an offline cpu or more cpus "
+          "than the pool has threads.");
 
 namespace util {
 
@@ -127,15 +128,15 @@ vector<unsigned> ParseCpuList(string_view str) {
     size_t dash = part.find('-');
     if (dash == string_view::npos) {
       unsigned v = 0;
-      CHECK(absl::SimpleAtoi(part, &v)) << "Invalid cpu id in proactor_irq_cpus: " << part;
+      CHECK(absl::SimpleAtoi(part, &v)) << "Invalid cpu id in proactor_tail_cpus: " << part;
       res.push_back(v);
     } else {
       unsigned lo = 0, hi = 0;
       CHECK(absl::SimpleAtoi(part.substr(0, dash), &lo))
-          << "Invalid cpu range in proactor_irq_cpus: " << part;
+          << "Invalid cpu range in proactor_tail_cpus: " << part;
       CHECK(absl::SimpleAtoi(part.substr(dash + 1), &hi))
-          << "Invalid cpu range in proactor_irq_cpus: " << part;
-      CHECK_LE(lo, hi) << "Invalid cpu range in proactor_irq_cpus: " << part;
+          << "Invalid cpu range in proactor_tail_cpus: " << part;
+      CHECK_LE(lo, hi) << "Invalid cpu range in proactor_tail_cpus: " << part;
       for (unsigned v = lo; v <= hi; ++v) {
         res.push_back(v);
       }
@@ -283,56 +284,57 @@ void ProactorPool::SetupProactors() {
   CHECK_EQ(rel_cpu_index, num_online_cpus) << "Such beast is not supported";
   cpu_threads_.resize(abs_cpu_index + 1);
 
-  // irq_cpus are pinned to the last irq_cpus.size() thread indices; every other online cpu
+  // tail_cpus are pinned to the last tail_cpus.size() thread indices; every other online cpu
   // (the "complement") is pinned to the remaining, lower indices, cycling in ascending order if
-  // there are more such indices than complement cpus. A mismatch (offline cpu, more irq cpus
-  // than pool threads, or no complement cpu left to fill the non-irq indices) is not fatal: it's
+  // there are more such indices than complement cpus. A mismatch (offline cpu, more tail cpus
+  // than pool threads, or no complement cpu left to fill the non-tail indices) is not fatal: it's
   // logged and the flag is ignored entirely, falling back to the default spread below.
-  vector<unsigned> irq_cpus = ParseCpuList(absl::GetFlag(FLAGS_proactor_irq_cpus));
+  vector<unsigned> tail_cpus = ParseCpuList(absl::GetFlag(FLAGS_proactor_tail_cpus));
   vector<unsigned> complement;
-  bool use_irq_cpus = false;
-  if (!irq_cpus.empty()) {
+  bool use_tail_cpus = false;
+  if (!tail_cpus.empty()) {
     bool valid = true;
-    for (unsigned cpu : irq_cpus) {
+    for (unsigned cpu : tail_cpus) {
       if (cpu >= cpu_threads_.size() || !CPU_ISSET(cpu, &online_cpus)) {
-        LOG(ERROR) << "proactor_irq_cpus: cpu " << cpu
-                   << " is not online/allowed for this process; ignoring proactor_irq_cpus.";
+        LOG(ERROR) << "proactor_tail_cpus: cpu " << cpu
+                   << " is not online/allowed for this process; ignoring proactor_tail_cpus.";
         valid = false;
         break;
       }
     }
-    if (valid && irq_cpus.size() > pool_size_) {
-      LOG(ERROR) << "proactor_irq_cpus: specifies " << irq_cpus.size()
+    if (valid && tail_cpus.size() > pool_size_) {
+      LOG(ERROR) << "proactor_tail_cpus: specifies " << tail_cpus.size()
                  << " cpus, more than the pool size (" << pool_size_
-                 << "); ignoring proactor_irq_cpus.";
+                 << "); ignoring proactor_tail_cpus.";
       valid = false;
     }
-    absl::flat_hash_set<unsigned> irq_set(irq_cpus.begin(), irq_cpus.end());
-    if (valid && irq_set.size() != irq_cpus.size()) {
-      LOG(ERROR) << "proactor_irq_cpus: contains a duplicate cpu id; ignoring proactor_irq_cpus.";
+    absl::flat_hash_set<unsigned> tail_set(tail_cpus.begin(), tail_cpus.end());
+    if (valid && tail_set.size() != tail_cpus.size()) {
+      LOG(ERROR) << "proactor_tail_cpus: contains a duplicate cpu id; ignoring "
+                    "proactor_tail_cpus.";
       valid = false;
     }
     if (valid) {
       for (unsigned cpu = 0; cpu < cpu_threads_.size(); ++cpu) {
-        if (CPU_ISSET(cpu, &online_cpus) && !irq_set.contains(cpu)) {
+        if (CPU_ISSET(cpu, &online_cpus) && !tail_set.contains(cpu)) {
           complement.push_back(cpu);
         }
       }
-      if (pool_size_ > irq_cpus.size() && complement.empty()) {
-        LOG(ERROR) << "proactor_irq_cpus: no cpu left to assign to the non-irq threads; "
-                      "ignoring proactor_irq_cpus.";
+      if (pool_size_ > tail_cpus.size() && complement.empty()) {
+        LOG(ERROR) << "proactor_tail_cpus: no cpu left to assign to the non-tail threads; "
+                      "ignoring proactor_tail_cpus.";
         valid = false;
       }
     }
-    use_irq_cpus = valid;
+    use_tail_cpus = valid;
   }
-  // Number of thread indices [0, non_irq_count) assigned to complement cpus; the remaining
-  // [non_irq_count, pool_size_) indices are assigned to irq_cpus, one each.
-  unsigned non_irq_count = use_irq_cpus ? pool_size_ - irq_cpus.size() : 0;
+  // Number of thread indices [0, non_tail_count) assigned to complement cpus; the remaining
+  // [non_tail_count, pool_size_) indices are assigned to tail_cpus, one each.
+  unsigned non_tail_count = use_tail_cpus ? pool_size_ - tail_cpus.size() : 0;
 
   bool set_affinity = (mode == AffinityMode::ON) ||
                       (mode == AffinityMode::AUTO && pool_size_ > num_online_cpus / 2) ||
-                      use_irq_cpus;
+                      use_tail_cpus;
 
   for (unsigned i = 0; i < pool_size_; ++i) {
     snprintf(buf, sizeof(buf), "Proactor%u", i);
@@ -347,9 +349,9 @@ void ProactorPool::SetupProactors() {
     int cpu_affinity = -1;
     if (set_affinity) {
       unsigned abs_cpu;
-      if (use_irq_cpus) {
+      if (use_tail_cpus) {
         abs_cpu =
-            i < non_irq_count ? complement[i % complement.size()] : irq_cpus[i - non_irq_count];
+            i < non_tail_count ? complement[i % complement.size()] : tail_cpus[i - non_tail_count];
       } else {
         unsigned rel_indx = i % num_online_cpus;
         abs_cpu = rel_to_abs_cpu[rel_indx];
@@ -373,7 +375,7 @@ void ProactorPool::SetupProactors() {
 #endif
   }
 
-  if (use_irq_cpus) {
+  if (use_tail_cpus) {
     string mapping;
     for (unsigned cpu = 0; cpu < cpu_threads_.size(); ++cpu) {
       if (!cpu_threads_[cpu].empty()) {


### PR DESCRIPTION
Rename to address the comment in https://github.com/romange/helio/pull/628#discussion_r3778478739

`proactor_irq_cpus` to `proactor_tail_cpus`
