### PR TITLE
chore(iouring): flag configurable proactor_busy_poll

### DIFF
--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -55,6 +55,8 @@ using namespace std;
 using absl::StrCat;
 using namespace testing;
 
+ABSL_DECLARE_FLAG(uint32_t, proactor_busy_poll_usec);
+
 namespace util {
 namespace fb2 {
 
@@ -778,6 +780,45 @@ TEST_P(ProactorTest, Sleep) {
         LOG(INFO) << "After Sleep";
       },
       Fiber::Opts{.name = "test_sleep"});
+}
+
+TEST_P(ProactorTest, IdleSleepRespectsBusyPollFlag) {
+  if (GetProactorType() != "uring") {
+    GTEST_SKIP() << "the idle-sleep wakeup tax is specific to the uring proactor's timer path";
+  }
+
+  // On an otherwise idle proactor, SleepFor() for a short duration (in us) enters a blocking
+  // wait syscall and can cost close to ~1ms.
+  // Raising the busy-poll indow past the requested sleep lets the sleeping fiber's expired deadline
+  // be discovered by the cheap non-blocking completion peek instead, avoiding that syscall
+  // entirely.
+  uint32_t saved = absl::GetFlag(FLAGS_proactor_busy_poll_usec);
+  absl::SetFlag(&FLAGS_proactor_busy_poll_usec, 500);
+  auto busy_poll_proactor = CreateProactorThread();
+  absl::SetFlag(&FLAGS_proactor_busy_poll_usec, saved);
+
+  constexpr int kIterations = 2000;
+  constexpr auto kRequestedSleep = 40us;
+
+  chrono::steady_clock::duration actual_total{};
+  busy_poll_proactor->get()->Await([&] {
+    for (int i = 0; i < kIterations; ++i) {
+      auto call_start = chrono::steady_clock::now();
+      ThisFiber::SleepFor(kRequestedSleep);
+      actual_total += chrono::steady_clock::now() - call_start;
+    }
+  });
+
+  double requested_avg_us = chrono::duration<double, std::micro>(kRequestedSleep).count();
+  double actual_avg_us = chrono::duration<double, std::micro>(actual_total).count() / kIterations;
+
+  LOG(INFO) << "[" << GetParam().ToString() << "] idle sleep: requested_avg_us=" << requested_avg_us
+            << " actual_avg_us=" << actual_avg_us
+            << " amplification=" << (actual_avg_us / requested_avg_us) << "x";
+
+  // With the busy-poll window wide enough to cover the requested sleep, we must not pay
+  // anything close to the ~1ms blocking-wait wakeup tax measured with the default 20us window.
+  EXPECT_LT(actual_avg_us, 1000);
 }
 
 TEST_P(ProactorTest, LocalCond) {

--- a/util/fibers/proactor_base.cc
+++ b/util/fibers/proactor_base.cc
@@ -9,6 +9,14 @@
 #include <signal.h>
 
 #include "base/cycle_clock.h"
+#include "base/flags.h"
+
+// For more info: ProactorTest::IdleSleepRespectsBusyPollFlag
+ABSL_FLAG(uint32_t, proactor_busy_poll_usec, 20,
+          "How long a proactor busy-polls for completions before falling back to a "
+          "blocking wait. Raising this trades CPU for wakeup latency: a sleeping "
+          "fiber whose deadline falls inside this window is discovered by the cheap "
+          "non-blocking completion peek instead of paying the full blocking syscall.");
 
 #if __linux__
 #include <sys/eventfd.h>
@@ -116,7 +124,7 @@ ProactorBase::Stats& ProactorBase::Stats::operator+=(const Stats& other) {
 ProactorBase::ProactorBase() : task_queue_(kTaskQueueLen) {
   call_once(module_init, &ModuleInit);
 
-  busy_poll_cycle_limit_ = base::CycleClock::FromUsec(20);
+  busy_poll_cycle_limit_ = base::CycleClock::FromUsec(absl::GetFlag(FLAGS_proactor_busy_poll_usec));
 
 #ifdef __linux__
   wake_fd_ = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
@@ -428,13 +436,13 @@ void ProactorDispatcher::Run(detail::Scheduler* sched) {
   auto& stats = proactor_->stats();
 
   VLOG(1) << "PRO[" << proactor_->GetPoolIndex()
-          << "] total_loop/stalls/cqe_fetches/completions_total: "
-          << stats.num_stalls << "/" << stats.completions_fetches << "/"
-          << stats.num_completions;
+          << "] total_loop/stalls/cqe_fetches/completions_total: " << stats.num_stalls << "/"
+          << stats.completions_fetches << "/" << stats.num_completions;
 
-  VLOG_IF(1, stats.uring_submit_calls > 0) << "PRO[" << proactor_->GetPoolIndex()
-            << "] uring_submit_calls/uring_submit_count: "
-            << stats.uring_submit_calls << "/" << stats.uring_submit_sqes;
+  VLOG_IF(1, stats.uring_submit_calls > 0)
+      << "PRO[" << proactor_->GetPoolIndex()
+      << "] uring_submit_calls/uring_submit_count: " << stats.uring_submit_calls << "/"
+      << stats.uring_submit_sqes;
 }
 
 void ProactorDispatcher::Notify() {


### PR DESCRIPTION
* add a flag to configure iouring proactor busy poll periods (so we don't fall back to expensive syscalls `wait_for_cqe` and spin instead via io_uring_peek_batch_cqe)
* add test

Helps with #643