### PR TITLE
revert: flag configurable proactor_busy_poll (#643)

### DIFF
--- a/util/fibers/fibers_test.cc
+++ b/util/fibers/fibers_test.cc
@@ -55,8 +55,6 @@ using namespace std;
 using absl::StrCat;
 using namespace testing;
 
-ABSL_DECLARE_FLAG(uint32_t, proactor_busy_poll_usec);
-
 namespace util {
 namespace fb2 {
 
@@ -780,45 +778,6 @@ TEST_P(ProactorTest, Sleep) {
         LOG(INFO) << "After Sleep";
       },
       Fiber::Opts{.name = "test_sleep"});
-}
-
-TEST_P(ProactorTest, IdleSleepRespectsBusyPollFlag) {
-  if (GetProactorType() != "uring") {
-    GTEST_SKIP() << "the idle-sleep wakeup tax is specific to the uring proactor's timer path";
-  }
-
-  // On an otherwise idle proactor, SleepFor() for a short duration (in us) enters a blocking
-  // wait syscall and can cost close to ~1ms.
-  // Raising the busy-poll indow past the requested sleep lets the sleeping fiber's expired deadline
-  // be discovered by the cheap non-blocking completion peek instead, avoiding that syscall
-  // entirely.
-  uint32_t saved = absl::GetFlag(FLAGS_proactor_busy_poll_usec);
-  absl::SetFlag(&FLAGS_proactor_busy_poll_usec, 500);
-  auto busy_poll_proactor = CreateProactorThread();
-  absl::SetFlag(&FLAGS_proactor_busy_poll_usec, saved);
-
-  constexpr int kIterations = 2000;
-  constexpr auto kRequestedSleep = 40us;
-
-  chrono::steady_clock::duration actual_total{};
-  busy_poll_proactor->get()->Await([&] {
-    for (int i = 0; i < kIterations; ++i) {
-      auto call_start = chrono::steady_clock::now();
-      ThisFiber::SleepFor(kRequestedSleep);
-      actual_total += chrono::steady_clock::now() - call_start;
-    }
-  });
-
-  double requested_avg_us = chrono::duration<double, std::micro>(kRequestedSleep).count();
-  double actual_avg_us = chrono::duration<double, std::micro>(actual_total).count() / kIterations;
-
-  LOG(INFO) << "[" << GetParam().ToString() << "] idle sleep: requested_avg_us=" << requested_avg_us
-            << " actual_avg_us=" << actual_avg_us
-            << " amplification=" << (actual_avg_us / requested_avg_us) << "x";
-
-  // With the busy-poll window wide enough to cover the requested sleep, we must not pay
-  // anything close to the ~1ms blocking-wait wakeup tax measured with the default 20us window.
-  EXPECT_LT(actual_avg_us, 1000);
 }
 
 TEST_P(ProactorTest, LocalCond) {

--- a/util/fibers/proactor_base.cc
+++ b/util/fibers/proactor_base.cc
@@ -9,14 +9,6 @@
 #include <signal.h>
 
 #include "base/cycle_clock.h"
-#include "base/flags.h"
-
-// For more info: ProactorTest::IdleSleepRespectsBusyPollFlag
-ABSL_FLAG(uint32_t, proactor_busy_poll_usec, 20,
-          "How long a proactor busy-polls for completions before falling back to a "
-          "blocking wait. Raising this trades CPU for wakeup latency: a sleeping "
-          "fiber whose deadline falls inside this window is discovered by the cheap "
-          "non-blocking completion peek instead of paying the full blocking syscall.");
 
 #if __linux__
 #include <sys/eventfd.h>
@@ -124,7 +116,7 @@ ProactorBase::Stats& ProactorBase::Stats::operator+=(const Stats& other) {
 ProactorBase::ProactorBase() : task_queue_(kTaskQueueLen) {
   call_once(module_init, &ModuleInit);
 
-  busy_poll_cycle_limit_ = base::CycleClock::FromUsec(absl::GetFlag(FLAGS_proactor_busy_poll_usec));
+  busy_poll_cycle_limit_ = base::CycleClock::FromUsec(20);
 
 #ifdef __linux__
   wake_fd_ = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);


### PR DESCRIPTION
This reverts commit f43760db482b016e5f4490a2fe7cac7b4185f1ce.

Why ? Because it turns out that the 1ms timeout latency was because my kernel was not configured with high frequency clock and that's why it was capped at 1ms. 😢 😞 