### PR TITLE
fix(ci): keep Azurite alive by detaching it from the step's stdout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,10 @@ jobs:
         curl -fsSL https://dl.min.io/server/minio/release/linux-amd64/minio -o /tmp/minio
         chmod +x /tmp/minio
         mkdir -p /tmp/minio-data/ci-test-bucket
-        MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin /tmp/minio server /tmp/minio-data &
+        # Redirect the output to a file: the runner closes this step's stdout pipe once the
+        # step finishes, and a background server that keeps logging into it gets EPIPE.
+        MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin \
+          nohup /tmp/minio server /tmp/minio-data > /tmp/minio.log 2>&1 &
         for i in $(seq 1 20); do
           curl -sf http://localhost:9000/minio/health/live && break || sleep 1
         done
@@ -164,7 +167,10 @@ jobs:
         curl -fsSL https://nodejs.org/dist/v22.16.0/node-v22.16.0-linux-x64.tar.xz | tar -xJ -C /tmp
         export PATH=/tmp/node-v22.16.0-linux-x64/bin:$PATH
         npm install -g azurite
-        azurite-blob --blobHost 0.0.0.0 --skipApiVersionCheck &
+        # Azurite must not inherit this step's stdout: the runner closes that pipe when the
+        # step ends, and the next access-log line azurite writes fails with EPIPE, which is
+        # an uncaught exception in node and kills the emulator in the middle of the tests.
+        nohup azurite-blob --blobHost 0.0.0.0 --skipApiVersionCheck > /tmp/azurite.log 2>&1 &
         ready=0
         for i in $(seq 1 20); do
           if curl -sf http://localhost:10000/ 2>/dev/null || \
@@ -204,6 +210,14 @@ jobs:
           export LSAN_OPTIONS=suppressions=$(pwd)/asan_suppressions.txt
           cd tests
           python3 -m pytest -q -s
+    - name: Emulator logs on failure
+      if: failure() && matrix.config.name == 'ubuntu24-gcc' && matrix.os.arch == 'amd64'
+      run: |
+        echo "----- azurite -----"
+        tail -n 100 /tmp/azurite.log || true
+        echo "----- minio -----"
+        tail -n 100 /tmp/minio.log || true
+
     - name: Upload logs on failure
       if: failure()
       uses: actions/upload-artifact@v4

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -81,6 +81,14 @@ def azurite():
     proc.wait(timeout=5)
 
 
+@pytest.fixture(autouse=True)
+def azurite_alive(azurite):
+    """Fail loudly if Azurite died mid-session instead of drowning in connection errors."""
+    if not _azurite_running():
+        pytest.fail(f"Azurite is not listening on port {AZURITE_PORT} - the emulator died")
+    yield
+
+
 @pytest.fixture(scope="module")
 def gcs_demo(azurite) -> Path:
     binary = _find_gcs_demo()


### PR DESCRIPTION
## Problem

Every scheduled `ci-tests` run since 2026-08-25 09:31 UTC (and sporadically since mid-August) fails in one place: `ubuntu24-gcc on (amd64)` → **Python tests (echo_server)**. The other red jobs in each run are fail-fast cancellations.

Azurite dies partway through `test_azure.py`, and everything after that point fails with:

```
W https_client_pool.cc:91] ClientPool: Could not connect to 127.0.0.1:10000 - system:111
F gcs_demo.cc:158] Check failed: !ec
```

The test it dies on drifts run to run (2–7 failures), which is why it read as flaky. Not a helio regression — no commits landed between the last green streak and the onset, and the same signature goes back to 08-15.

## Root cause

Azurite was started as `azurite-blob ... &`, inheriting the step's stdout pipe. The runner closes the read end of that pipe when the step completes, and the next access-log line Azurite writes fails with `EPIPE` — a fatal uncaught exception in node.

Reproduced locally with the same Node 22.16.0 / Azurite 3.37.0 setup and the real `gcs_demo`, backgrounding Azurite onto a FIFO whose reader then exits:

```
Error: write EPIPE
    at afterWriteDispatched (node:internal/stream_base_commons:159:15)
    ...
    at logRequest (.../node_modules/morgan/index.js:156:14)
  errno: -32, code: 'EPIPE', syscall: 'write'
```

Corroborating evidence in the job logs: Azurite's access-log lines appear during its own step and stop the instant that step ends — in passing runs too. Only the moment the pipe teardown actually bites varies, which is what turned a rare flake into a near-permanent failure. Minio is started the same way and survives only because Go ignores stdout write errors.

## Changes

- Start Azurite (and Minio, same anti-pattern) with `nohup ... > /tmp/<name>.log 2>&1 &` so neither writes into the step's pipe.
- New `Emulator logs on failure` step tailing both logs, so a future emulator death is diagnosable rather than invisible.
- `tests/test_azure.py`: autouse liveness fixture reporting `Azurite is not listening on port 10000 - the emulator died` instead of dozens of SIGABRT stack traces once the emulator is gone.

## Verification

Local, Node 22.16.0 + Azurite 3.37.0, real `gcs_demo` from `build-dbg`:

- Old startup style → Azurite dies right after the pipe reader exits (EPIPE trace above). Reproduced.
- Fixed startup style → Azurite survives the step end, full suite green: `11 passed in 7.36s`.
- Azurite killed mid-run → remaining tests report `Failed: Azurite is not listening...` instead of connection-refused noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
